### PR TITLE
Remove `hank` from `alias` `ci`

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -25,7 +25,7 @@
 ]}.
 
 {alias, [
-    {ci, [lint, hank, xref, dialyzer, ex_doc, ct, cover]}
+    {ci, [lint, xref, dialyzer, ex_doc, ct, cover]}
 ]}.
 
 {profiles, [


### PR DESCRIPTION
# Description

Check #81. It's crashing for some reason.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
