### PR TITLE
Use a predictable name, for the CI ruleset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ name: CI
 
 jobs:
   linux:
-    name: OTP ${{ matrix.otp_version }}
+    name: CI
     runs-on: ${{ matrix.os }}
 
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,9 @@ jobs:
       - name: Compile
         run: rebar3 compile
       - name: Run tests
-        run: rebar3 do ct, eunit
+        run: |
+          rebar3 ct
+          rebar3 eunit
 #  FIXME: Resolve dialyzer warnings and errors.
 # - name: Run dialyzer
 # run: rebar3 dialyzer


### PR DESCRIPTION

# Description

Otherwise when the matrix element changes the ruleset also has to be updated. It's an Ok practice to have a matrix for a given number of elements, and then a specific element version (e.g. OTP 27) on which we absolutely can't fail.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
