### PR TITLE
Add `eunit` to `ci` alias, for future runs

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -28,7 +28,7 @@
 ]}.
 
 {alias, [
-    {ci, [lint, xref, dialyzer, ex_doc, ct, cover]}
+    {ci, [lint, xref, dialyzer, ex_doc, eunit, ct, cover]}
 ]}.
 
 {profiles, [


### PR DESCRIPTION
# Description

We're soon gonna call `rebar3 ci` in CI, so...

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
