### PR TITLE
Tweak the main CI file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,10 +53,6 @@ jobs:
                 -hash-${{hashFiles('rebar.lock')}}"
         if: ${{matrix.os-base != 'macos'}}
 
-      - name: Check file format
-        run: |
-          rebar3 fmt --check
-
       - name: Continuous Integration
         run: |
           rebar3 as test ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,31 +3,60 @@ name: CI
 
 "on":
   push:
-    branches: [main]
+    branches:
+      - main
   pull_request:
-    branches: [main]
+    branches:
+      - "*"
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{github.workflow}}-${{github.ref}}
+  cancel-in-progress: true
 
 jobs:
-  linux:
+  ci:
     name: CI
-    runs-on: ${{ matrix.os }}
 
     strategy:
-      matrix:
-        otp_version: [27]
-        os: [ubuntu-latest]
+      fail-fast: false
 
-    container:
-      image: erlang:${{ matrix.otp_version }}
+    runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
-      - name: Compile
-        run: rebar3 compile
-      - name: Run tests
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+
+      - uses: erlef/setup-beam@a6e26b22319003294c58386b6f25edbc7336819a # v1.18.0
+        with:
+          version-type: strict
+          version-file: .tool-versions
+
+      - name: Restore _build
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        with:
+          path: _build
+          key: "_build-cache-for\
+                -os-${{runner.os}}\
+                -otp-${{steps.setup-beam.outputs.otp-version}}\
+                -rebar3-${{steps.setup-beam.outputs.rebar3-version}}\
+                -hash-${{hashFiles('rebar.lock')}}"
+        if: ${{matrix.os-base != 'macos'}}
+
+      - name: Restore rebar3's cache
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        with:
+          path: ~/.cache/rebar3
+          key: "rebar3-cache-for\
+                -os-${{runner.os}}\
+                -otp-${{steps.setup-beam.outputs.otp-version}}\
+                -rebar3-${{steps.setup-beam.outputs.rebar3-version}}\
+                -hash-${{hashFiles('rebar.lock')}}"
+        if: ${{matrix.os-base != 'macos'}}
+
+      - name: Check file format
         run: |
-          rebar3 ct
-          rebar3 eunit
-#  FIXME: Resolve dialyzer warnings and errors.
-# - name: Run dialyzer
-# run: rebar3 dialyzer
+          rebar3 fmt --check
+
+      - name: Continuous Integration
+        run: |
+          rebar3 as test ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
       - uses: erlef/setup-beam@a6e26b22319003294c58386b6f25edbc7336819a # v1.18.0
+        id: setup-beam
         with:
           version-type: strict
           version-file: .tool-versions
@@ -40,7 +41,6 @@ jobs:
                 -otp-${{steps.setup-beam.outputs.otp-version}}\
                 -rebar3-${{steps.setup-beam.outputs.rebar3-version}}\
                 -hash-${{hashFiles('rebar.lock')}}"
-        if: ${{matrix.os-base != 'macos'}}
 
       - name: Restore rebar3's cache
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
@@ -51,7 +51,6 @@ jobs:
                 -otp-${{steps.setup-beam.outputs.otp-version}}\
                 -rebar3-${{steps.setup-beam.outputs.rebar3-version}}\
                 -hash-${{hashFiles('rebar.lock')}}"
-        if: ${{matrix.os-base != 'macos'}}
 
       - name: Continuous Integration
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,6 @@ jobs:
   ci:
     name: CI
 
-    strategy:
-      fail-fast: false
-
     runs-on: ubuntu-24.04
 
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,10 @@ name: Lint
       - "*"
   workflow_dispatch: {}
 
+concurrency:
+  group: ${{github.workflow}}-${{github.ref}}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/rebar-lock.yml
+++ b/.github/workflows/rebar-lock.yml
@@ -10,6 +10,10 @@ name: Update dependencies
       - "*"
   workflow_dispatch: {}
 
+concurrency:
+  group: ${{github.workflow}}-${{github.ref}}
+  cancel-in-progress: true
+
 jobs:
   update:
     name: Update rebar.lock

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+erlang 27.0
+rebar 3.23.0

--- a/rebar.config
+++ b/rebar.config
@@ -34,7 +34,6 @@
 {profiles, [
     {test, [
         {cover_enabled, true},
-        {cover_excl_mods, [rebar3_checkshell]},
         {cover_opts, [verbose]},
         {erl_opts, [
             debug_info,

--- a/rebar.config
+++ b/rebar.config
@@ -37,8 +37,6 @@
         {cover_opts, [verbose]},
         {erl_opts, [
             debug_info,
-            report,
-            verbose,
             nowarn_missing_spec,
             warnings_as_errors
         ]},

--- a/rebar.config
+++ b/rebar.config
@@ -15,6 +15,8 @@
 {dialyzer, [
     {plt_apps, all_deps},
     {plt_extra_apps, [
+        eunit,
+        inets,
         syntax_tools
     ]},
     {warnings, [

--- a/rebar.config
+++ b/rebar.config
@@ -28,7 +28,14 @@
 ]}.
 
 {alias, [
-    {ci, [lint, xref, dialyzer, ex_doc, eunit, ct, cover]}
+    {ci, [
+        lint,
+        {do, "default as test dialyzer"},
+        eunit,
+        ct,
+        cover,
+        ex_doc
+    ]}
 ]}.
 
 {profiles, [
@@ -40,8 +47,7 @@
             nowarn_missing_spec,
             warnings_as_errors
         ]},
-        {extra_src_dirs, [{"test", [{recursive, true}]}]},
-        {xref_extra_paths, ["test"]}
+        {extra_src_dirs, [{"test", [{recursive, true}]}]}
     ]}
 ]}.
 


### PR DESCRIPTION
# Description

Closes #34.

1. adds concurrency cancel-in-progress
2. uses `setup-beam`, coupled with `.tool-versions`
3. uses alias `ci` from `rebar.config`, instead of separate commands
4. adds cache (especially useful for Dialyzer)

⚠️ to be merged after #91.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
