### PR TITLE
Fix folder `include` (breaks interface)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ example project.
 
 %% Libs.
 %% `live_view.hrl` contains the ?ARIZONA_LIVEVIEW macro.
--include("arizona.hrl").
+-include_lib("arizona/include/arizona.hrl").
 
 %% --------------------------------------------------------------------
 %% arizona_live_view callbacks.

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ example project.
 -export([button/1]).
 
 %% Libs.
-%% `live_view.hrl` contains the ?LV macro.
--include_lib("arizona/include/live_view.hrl").
+%% `live_view.hrl` contains the ?ARIZONA_LIVEVIEW macro.
+-include("arizona.hrl").
 
 %% --------------------------------------------------------------------
 %% arizona_live_view callbacks.
@@ -76,7 +76,7 @@ render(Macros0) ->
     Macros = Macros0#{
         title => maps:get(title, Macros0, ~"Arizona")
     },
-    ?LV(~"""
+    ?ARIZONA_LIVEVIEW(~"""
     <!DOCTYPE html>
     <html lang="en">
     <head>
@@ -127,7 +127,7 @@ handle_event(<<"decr">>, #{}, #{assigns := Assigns} = Socket) ->
 %% --------------------------------------------------------------------
 
 counter(Macros) ->
-    ?LV(~s"""
+    ?ARIZONA_LIVEVIEW(~s"""
     <div :stateful>
         <div>Count: {_@count}</div>
         <.button event={_@event} text={_@btn_text} />
@@ -135,7 +135,7 @@ counter(Macros) ->
     """).
 
 button(Macros) ->
-    ?LV(~s"""
+    ?ARIZONA_LIVEVIEW(~s"""
     {% NOTE: On this example, :onclick is and expression to be }
     {%       dynamic. It could be just, e.g., :onclick="incr". }
     <button type="button" :onclick={arizona_js:send(_@event)}>

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ example project.
 -export([button/1]).
 
 %% Libs.
-%% `live_view.hrl` contains the ?ARIZONA_LIVEVIEW macro.
+%% `arizona.hrl` contains the ?ARIZONA_LIVEVIEW macro.
 -include_lib("arizona/include/arizona.hrl").
 
 %% --------------------------------------------------------------------

--- a/include/arizona.hrl
+++ b/include/arizona.hrl
@@ -1,5 +1,4 @@
--define(LV(Str), (begin
+-define(ARIZONA_LIVEVIEW(Str), (begin
     {ok, Tree} = arizona_live_view:parse_str(Str, Macros),
     Tree
 end)).
-

--- a/include/arizona_assert.hrl
+++ b/include/arizona_assert.hrl
@@ -1,0 +1,9 @@
+-include_lib("stdlib/include/assert.hrl").
+
+-define(ARIZONA_ASSERT_BODY(Pattern, Resp), (
+    ?assertNotEqual(nomatch, string:find(element(3, Resp), Pattern))
+)).
+
+-define(ARIZONA_ASSERT_STATUS(Status, Resp), (
+    ?assertEqual(Status, element(2, element(1, Resp)))
+)).

--- a/include/live_view_test.hrl
+++ b/include/live_view_test.hrl
@@ -1,7 +1,0 @@
--define(assertHttpBody(Pattern, Resp), (
-    ?assertNotEqual(nomatch, string:find(element(3, Resp), Pattern))
-)).
--define(assertHttpStatus(Status, Resp), (
-    ?assertEqual(Status, element(2, element(1, Resp)))
-)).
-

--- a/src/arizona_live_view.erl
+++ b/src/arizona_live_view.erl
@@ -96,7 +96,7 @@ persist(Mod, Fun, Macros) ->
 
 -ifdef(TEST).
 -compile([export_all, nowarn_export_all]).
--include("live_view.hrl").
+-include("arizona.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
 parse_str_test() ->
@@ -109,7 +109,7 @@ parse_str_test() ->
 % Start parse_str support.
 
 render(Macros) ->
-    ?LV("""
+    ?ARIZONA_LIVEVIEW("""
     <main :stateful>
         <h1>{_@title}</h1>
         <.arizona_live_view:counter/>
@@ -117,7 +117,7 @@ render(Macros) ->
     """).
 
 counter(Macros) ->
-    ?LV("""
+    ?ARIZONA_LIVEVIEW("""
     <div :stateful>
         <div>{_@count}</div>
         <button type="button">Increment</button>

--- a/test/arizona_live_view_SUITE.erl
+++ b/test/arizona_live_view_SUITE.erl
@@ -32,10 +32,8 @@
 -export([hello_world/1]).
 
 %% Libs
--include_lib("common_test/include/ct.hrl").
--include_lib("stdlib/include/assert.hrl").
--include("live_view.hrl").
--include("live_view_test.hrl").
+-include("arizona.hrl").
+-include("arizona_assert.hrl").
 
 %% --------------------------------------------------------------------
 %% arizona_live_view callbacks.
@@ -66,7 +64,7 @@ mount(Socket) ->
     {ok, Socket}.
 
 render(Macros) ->
-    ?LV(~s"""
+    ?ARIZONA_LIVEVIEW(~s"""
     <html>
     <head>
     </head>
@@ -82,8 +80,8 @@ render(Macros) ->
 
 hello_world(Config) when is_list(Config) ->
     {ok, Resp0} = httpc:request("http://localhost:8080/notfound"),
-    ?assertHttpStatus(404, Resp0),
+    ?ARIZONA_ASSERT_STATUS(404, Resp0),
     {ok, Resp1} = httpc:request("http://localhost:8080/helloworld"),
-    ?assertHttpStatus(200, Resp1),
-    ?assertHttpBody("Hello, World!", Resp1).
+    ?ARIZONA_ASSERT_STATUS(200, Resp1),
+    ?ARIZONA_ASSERT_BODY("Hello, World!", Resp1).
 


### PR DESCRIPTION
# Description

1. rename files (known prefix)
2. rename macros (known prefix)

Closes #4.

## Further considerations

* `LV` has no semantic value, `LIVEVIEW` does
* tempting as it may be to use macros, I'm not sure of they're real value here
  * e.g. `?assertNotEqual(nomatch, string:find(element(3, Resp), Pattern))` could easily be replaced with a function call in an `arizona_test` module, for example

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
