### PR TITLE
Introduce `arizona.erl` and move (opaque) types inside it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
 
       - name: Continuous Integration
         run: |
+          rebar3 xref
           rebar3 as test ci
 
       - name: Check if build left artifacts

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ example project.
 % connects to the server via WebSocket.
 mount(#{assigns := Assigns} = Socket) ->
     Count = maps:get(count, Assigns, 0),
-    {ok, arizona_socket:assign(count, Count, Socket)}.
+    {ok, arizona_socket:put_assign(count, Count, Socket)}.
 
 % render/1 is called by the route to compile the template.
 % Macros substitutes variables.
@@ -117,10 +117,10 @@ render(Macros0) ->
 % Handle client events.
 handle_event(<<"incr">>, #{}, #{assigns := Assigns} = Socket) ->
     Count = maps:get(count, Assigns) + 1,
-    {noreply, arizona_socket:assign(count, Count, Socket)};
+    {noreply, arizona_socket:put_assign(count, Count, Socket)};
 handle_event(<<"decr">>, #{}, #{assigns := Assigns} = Socket) ->
     Count = maps:get(count, Assigns) - 1,
-    {noreply, arizona_socket:assign(count, Count, Socket)}.
+    {noreply, arizona_socket:put_assign(count, Count, Socket)}.
 
 %% --------------------------------------------------------------------
 %% Component functions.

--- a/include/arizona.hrl
+++ b/include/arizona.hrl
@@ -1,4 +1,3 @@
--define(ARIZONA_LIVEVIEW(Str), (begin
-    {ok, Tree} = arizona_live_view:parse_str(Str, Macros),
-    Tree
-end)).
+-define(ARIZONA_LIVEVIEW(Macros, Str), (
+    arizona_live_view:parse_str(Str, Macros)
+)).

--- a/src/arizona.erl
+++ b/src/arizona.erl
@@ -1,0 +1,16 @@
+-module(arizona).
+
+-opaque socket() :: map().
+-export_type([socket/0]).
+
+-opaque macros() :: map().
+-export_type([macros/0]).
+
+-opaque tree() :: list().
+-export_type([tree/0]).
+
+-type event_name() :: binary().
+-export_type([event_name/0]).
+
+-opaque payload() :: map().
+-export_type([payload/0]).

--- a/src/arizona.erl
+++ b/src/arizona.erl
@@ -1,16 +1,4 @@
 -module(arizona).
 
--opaque socket() :: map().
--export_type([socket/0]).
-
--opaque macros() :: map().
--export_type([macros/0]).
-
--opaque tree() :: list().
--export_type([tree/0]).
-
--type event_name() :: binary().
--export_type([event_name/0]).
-
 -opaque payload() :: map().
 -export_type([payload/0]).

--- a/src/arizona_live_view.erl
+++ b/src/arizona_live_view.erl
@@ -32,13 +32,6 @@ Live view.
 -export([mount/2]).
 -export([handle_event/4]).
 
-%% TODO: Real types.
--type socket()  :: map().
--type macros()  :: map().
--type tree()    :: list().
--type event()   :: binary().
--type payload() :: map().
-
 %% Macros
 -define(PERSIST_KEY, ?MODULE).
 
@@ -46,14 +39,14 @@ Live view.
 %% Callbacks.
 %% --------------------------------------------------------------------
 
--callback mount(socket()) ->
-    {ok, socket()}.
+-callback mount(arizona:socket()) ->
+    {ok, arizona:socket()}.
 
--callback render(macros()) ->
-    tree().
+-callback render(arizona:macros()) ->
+    arizona:tree().
 
--callback handle_event(event(), payload(), socket()) ->
-    {noreply, socket()}.
+-callback handle_event(arizona:event_name(), arizona:payload(), arizona:socket()) ->
+    {noreply, arizona:socket()}.
 
 -optional_callbacks([handle_event/3]).
 

--- a/src/arizona_socket.erl
+++ b/src/arizona_socket.erl
@@ -24,12 +24,19 @@ Components state.
 
 %% API functions.
 -export([new/3]).
--export([assign/2]).
--ignore_xref([assign/2]).
--export([assign/3]).
--ignore_xref([assign/3]).
+-export([put_assign/2]).
+-ignore_xref([put_assign/2]).
+-export([put_assign/3]).
+-ignore_xref([put_assign/3]).
+-export([get_assign/2]).
+-ignore_xref([get_assign/2]).
+-export([get_assign/3]).
+-ignore_xref([get_assign/3]).
 -export([push_event/3]).
 -export([prune/1]).
+
+-opaque t() :: map().
+-export_type([t/0]).
 
 %% --------------------------------------------------------------------
 %% API functions.
@@ -44,10 +51,15 @@ new(Id, View, Assigns) ->
         changes => #{}
     }.
 
-assign(Map, Socket) ->
-    maps:fold(fun assign/3, Socket, Map).
+put_assign(Map, Socket) ->
+    maps:fold(fun put_assign/3, Socket, Map).
 
-assign(Key, Value, #{assigns := Assigns, changes := Changes} = Socket) ->
+-spec put_assign(Key, Value, Socket) -> Socket
+    when Key :: atom(),
+         Value :: term(),
+         Socket :: t().
+put_assign(Key, Value, Socket) ->
+    #{assigns := Assigns, changes := Changes} = Socket,
     case Assigns of
         #{Key := Value} ->
             Socket;
@@ -57,6 +69,23 @@ assign(Key, Value, #{assigns := Assigns, changes := Changes} = Socket) ->
                 changes => Changes#{Key => Value}
             }
     end.
+
+-spec get_assign(Key, Socket) -> Got
+    when Key :: atom(),
+         Socket :: t(),
+         Got :: term().
+get_assign(Key, Socket) ->
+    #{assigns := Assigns} = Socket,
+    maps:get(Key, Assigns).
+
+-spec get_assign(Key, Socket, Default) -> Got
+    when Key :: atom(),
+         Socket :: t(),
+         Default :: term(),
+         Got :: term().
+get_assign(Key, Socket, Default) ->
+    #{assigns := Assigns} = Socket,
+    maps:get(Key, Assigns, Default).
 
 push_event(Name, Payload, #{events := Events} = Socket) ->
     Socket#{events => [[Name, Payload] | Events]}.

--- a/test/arizona_live_view_SUITE.erl
+++ b/test/arizona_live_view_SUITE.erl
@@ -64,7 +64,7 @@ mount(Socket) ->
     {ok, Socket}.
 
 render(Macros) ->
-    ?ARIZONA_LIVEVIEW(~s"""
+    ?ARIZONA_LIVEVIEW(Macros, ~s"""
     <html>
     <head>
     </head>


### PR DESCRIPTION
# Description

We'll later add setters, getters and more interface definition to module `arizona`. This is just a minor first step to understand how consumption would happen next to `arizona_example`.

The TODO was turned into an issue on GitHub.

## Further considerations

When trying to use the new types in `arizona_example` I had to overcome a few obstacles. I'll look at the changed files and try to "review" on some of the decisions, if warranted.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
