### PR TITLE
Fix GHA workflow `rebar-lock`, by also running for major version updates

### DIFF
--- a/.github/workflows/rebar-lock.yml
+++ b/.github/workflows/rebar-lock.yml
@@ -18,7 +18,7 @@ jobs:
   update:
     name: Update rebar.lock
 
-    if: "${{ github.ref == 'refs/heads/renovate/rebar.config-deps' }}"
+    if: endsWith(github.ref, 'rebar.config-deps')
 
     runs-on: ubuntu-24.04
 


### PR DESCRIPTION
# Description

When there's a major version bump, Renovate prefixes branch names with `major`. We circumvent that by looking only at the suffix: `rebar.config-deps`, which should be enough for our current needs.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
