### PR TITLE
Change tokens and tree struct to support loops and conditionals

### DIFF
--- a/src/arizona_template_scanner.erl
+++ b/src/arizona_template_scanner.erl
@@ -272,6 +272,14 @@ new_anno_test() ->
         }, ?ANNO)
     ].
 
+new_line_test() ->
+    #{line := Ln, column := Col} = new_line(new_anno(#{file => ?FILE, column => 2})),
+    ?assertEqual({2, 1}, {Ln, Col}).
+
+incr_anno_col_test() ->
+    #{column := Col} = incr_anno_col(1, new_anno(#{file => ?FILE})),
+    ?assertEqual(2, Col).
+
 incr_anno_pos_test() ->
     #{position := Pos} = incr_anno_pos(1, new_anno(#{file => ?FILE})),
     ?assertEqual(1, Pos).

--- a/src/arizona_template_scanner.erl
+++ b/src/arizona_template_scanner.erl
@@ -1,0 +1,125 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright 2024 Arizona Framework <contact@arizonaframe.work>
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+-module(arizona_template_scanner).
+-moduledoc false.
+
+%% API functions.
+-export([scan/2, new_anno/1]).
+
+%% Types
+-export_type([anno/0, anno_options/0]).
+
+% Module and function could be undefined in favor of files scanning.
+-opaque anno() :: #{
+    module => module() | undefined,
+    function => atom() | undefined,
+    file => binary(),
+    line => non_neg_integer(),
+    column => non_neg_integer(),
+    first_column => non_neg_integer(),
+    position => non_neg_integer()
+}.
+
+-type anno_options() :: #{
+    module := module(),
+    function := atom(),
+    file := string() | binary(),
+    line := non_neg_integer(),
+    column := non_neg_integer(),
+    first_column := non_neg_integer(),
+    position := non_neg_integer()
+}.
+
+%% --------------------------------------------------------------------
+%% API funtions.
+%% --------------------------------------------------------------------
+
+scan(Bin, Anno) when is_binary(Bin), is_map(Anno) ->
+    scan(Bin, _Len = 0, Anno).
+
+new_anno(Opts) when is_map(Opts) ->
+    Anno = maps:merge(default_anno(), Opts),
+    maps:map(fun normalize_anno_value/2, Anno).
+
+%% --------------------------------------------------------------------
+%% Internal funtions.
+%% --------------------------------------------------------------------
+
+scan(_Bin, _Len, _Anno) ->
+    error(not_implemented_yet).
+
+default_anno() ->
+    #{
+        module => undefined,
+        function => undefined,
+        file => undefined,
+        line => 1,
+        column => 1,
+        first_column => 1,
+        position => 0
+    }.
+
+normalize_anno_value(module, Mod) when is_atom(Mod) ->
+    Mod;
+normalize_anno_value(function, Fun) when is_atom(Fun) ->
+    Fun;
+normalize_anno_value(file, File) when is_binary(File) ->
+    File;
+normalize_anno_value(file, File) when is_list(File) ->
+    iolist_to_binary(File);
+normalize_anno_value(line, Ln) when is_integer(Ln), Ln >= 0 ->
+    Ln;
+normalize_anno_value(column, Col) when is_integer(Col), Col >= 0 ->
+    Col;
+normalize_anno_value(first_column, Col) when is_integer(Col), Col >= 0 ->
+    Col;
+normalize_anno_value(position, Pos) when is_integer(Pos), Pos >= 0 ->
+    Pos.
+
+%% --------------------------------------------------------------------
+%% EUnit tests.
+%% --------------------------------------------------------------------
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+new_anno_test() ->
+    [
+        ?assertError(function_clause, new_anno(#{})),
+        ?assertError(function_clause, new_anno(#{module => -1})),
+        ?assertError(function_clause, new_anno(#{function => -1})),
+        ?assertError(function_clause, new_anno(#{file => -1})),
+        ?assertError(function_clause, new_anno(#{line => -1})),
+        ?assertError(function_clause, new_anno(#{column => -1})),
+        ?assertError(function_clause, new_anno(#{first_column => -1})),
+        ?assertError(function_clause, new_anno(#{position => -10})),
+        ?assertEqual(#{
+            module => undefined,
+            function => undefined,
+            file => iolist_to_binary(?FILE),
+            line => 1,
+            column => 1,
+            first_column => 1,
+            position => 0
+        }, new_anno(#{file => ?FILE}))
+    ].
+
+-endif.
+

--- a/src/arizona_template_scanner.erl
+++ b/src/arizona_template_scanner.erl
@@ -21,10 +21,17 @@
 -moduledoc false.
 
 %% API functions.
--export([scan/2, new_anno/1]).
+-export([scan/2]).
+-export([new_anno/1]).
 
 %% Types
--export_type([anno/0, token_anno/0, anno_options/0]).
+-export_type([anno/0]).
+-export_type([anno_options/0]).
+-export_type([token_anno/0]).
+-export_type([source/0]).
+-export_type([location/0]).
+-export_type([line/0]).
+-export_type([column/0]).
 
 % Module and function could be undefined in favor of files scanning.
 % This anno struct helps error_info of erlang:error/3 to display
@@ -38,7 +45,6 @@
     first_column => non_neg_integer(),
     position => non_neg_integer()
 }.
-
 -type anno_options() :: #{
     module := module(),
     function := atom(),
@@ -48,7 +54,6 @@
     first_column := non_neg_integer(),
     position := non_neg_integer()
 }.
-
 -type token_anno() :: {source(), location()}.
 -type source() :: {file, binary()} | {module(), atom()}.
 -type location() :: {line(), column()}.

--- a/src/arizona_template_scanner.erl
+++ b/src/arizona_template_scanner.erl
@@ -114,11 +114,17 @@ scan_expr(Rest0, Bin, ExprAnno) ->
                 {ok, Category} ->
                     [{Category, token_anno(ExprAnno), Expr} | scan(Rest, Bin, 0, Anno)];
                 error ->
-                    error({badexpr, Expr}, [Rest0, Bin, ExprAnno], [{error_info, Anno}])
+                    error({badexpr, Expr}, [Rest0, Bin, ExprAnno], [{error_info, error_info(Anno)}])
             end;
         {error, {Reason, Anno}} ->
-            error(Reason, [Rest0, Bin, ExprAnno], [{error_info, Anno}])
+            error(Reason, [Rest0, Bin, ExprAnno], [{error_info, error_info(Anno)}])
     end.
+
+error_info(Anno = #{module := Mod, function := Fun}) when Mod =/= undefined,
+                                                          Fun =/= undefined ->
+    maps:with([module, function, line, column], Anno);
+error_info(Anno) ->
+    maps:with([file, line, column], Anno).
 
 expr_category(Expr) ->
     try

--- a/src/arizona_template_scanner.erl
+++ b/src/arizona_template_scanner.erl
@@ -78,6 +78,12 @@ new_anno(Opts) when is_map(Opts) ->
 scan(<<${, Rest/binary>>, Bin, Len, Anno) ->
     maybe_prepend_text_token(Bin, Len, Anno,
         scan_expr(Rest, Bin, incr_anno_pos(Len + 1, Anno)));
+scan(<<$<, $/, Rest/binary>>, Bin, Len, Anno) ->
+    maybe_prepend_text_token(Bin, Len, Anno,
+        scan_closing_tag(Rest, Bin, incr_anno_pos(Len + 2, Anno)));
+scan(<<$<, Rest/binary>>, Bin, Len, Anno) ->
+    maybe_prepend_text_token(Bin, Len, Anno,
+        scan_tag(Rest, Bin, incr_anno_pos(Len + 1, Anno)));
 scan(<<$\r, $\n, Rest/binary>>, Bin, Len, Anno) ->
     scan(Rest, Bin, Len + 2, new_line(Anno));
 scan(<<$\r, Rest/binary>>, Bin, Len, Anno) ->
@@ -90,46 +96,38 @@ scan(<<>>, Bin, Len, Anno) ->
     % FIXME: The location (line, column) is incorrect in the last text token.
     maybe_prepend_text_token(Bin, Len, Anno, []).
 
-maybe_prepend_text_token(Bin, Len, Anno = #{position := Pos}, Tokens) ->
-    case string:trim(binary_part(Bin, Pos, Len)) of
-        <<>> ->
-            Tokens;
-        Text ->
-            [{text, token_anno(Anno), Text} | Tokens]
-    end.
-
-token_anno(Anno) ->
-    {token_source(Anno), token_location(Anno)}.
-
-token_source(#{module := Mod, function := Fun}) when Mod =/= undefined,
-                                                     Fun =/= undefined ->
-    {Mod, Fun};
-token_source(#{file := File}) ->
-    {file, File}.
-
-token_location(#{line := Ln, column := Col}) ->
-    {Ln, Col}.
-
 scan_expr(Rest0, Bin, ExprAnno) ->
-    case find_expr_end(Rest0, _Depth = 0, _Len = 0, ExprAnno) of
-        {ok, {Len, Anno, Rest}} ->
+    case scan_expr_end(Rest0, _Depth = 0, _Len = 0, ExprAnno) of
+        {ok, {Len, MarkerLen, Anno, Rest}} ->
             Pos = maps:get(position, ExprAnno),
             Expr = binary_part(Bin, Pos, Len),
             case expr_category(Expr) of
                 {ok, Category} ->
-                    [{Category, token_anno(ExprAnno), Expr} | scan(Rest, Bin, 0, Anno)];
+                    [{Category, token_anno(ExprAnno), Expr}
+                     | scan(Rest, Bin, 0, incr_anno_pos(Len + MarkerLen, Anno))];
                 error ->
-                    error({badexpr, Expr}, [Rest0, Bin, ExprAnno], [{error_info, error_info(Anno)}])
+                    error(badexpr, [Rest0, Bin, ExprAnno], [{error_info, error_info(Anno)}])
             end;
         {error, {Reason, Anno}} ->
             error(Reason, [Rest0, Bin, ExprAnno], [{error_info, error_info(Anno)}])
     end.
 
-error_info(Anno = #{module := Mod, function := Fun}) when Mod =/= undefined,
-                                                          Fun =/= undefined ->
-    maps:with([module, function, line, column], Anno);
-error_info(Anno) ->
-    maps:with([file, line, column], Anno).
+scan_expr_end(<<$}, Rest/binary>>, 0, Len, Anno) ->
+    {ok, {Len, _MarkerLen = 1, Anno, Rest}};
+scan_expr_end(<<$}, Rest/binary>>, Depth, Len, Anno) ->
+    scan_expr_end(Rest, Depth - 1, Len + 1, incr_anno_col(1, Anno));
+scan_expr_end(<<${, Rest/binary>>, Depth, Len, Anno) ->
+    scan_expr_end(Rest, Depth + 1, Len + 1, incr_anno_col(1, Anno));
+scan_expr_end(<<$\r, $\n, Rest/binary>>, Depth, Len, Anno) ->
+    scan_expr_end(Rest, Depth, Len + 2, new_line(Anno));
+scan_expr_end(<<$\r, Rest/binary>>, Depth, Len, Anno) ->
+    scan_expr_end(Rest, Depth, Len + 1, new_line(Anno));
+scan_expr_end(<<$\n, Rest/binary>>, Depth, Len, Anno) ->
+    scan_expr_end(Rest, Depth, Len + 1, new_line(Anno));
+scan_expr_end(<<_, Rest/binary>>, Depth, Len, Anno) ->
+    scan_expr_end(Rest, Depth, Len + 1, incr_anno_col(1, Anno));
+scan_expr_end(<<>>, _Depth, Len, Anno) ->
+    {error, {unexpected_expr_end, incr_anno_pos(Len, Anno)}}.
 
 expr_category(Expr) ->
     try
@@ -144,38 +142,215 @@ expr_category(Expr) ->
             error
     end.
 
-find_expr_end(<<$}, Rest/binary>>, 0, Len, Anno) ->
-    {ok, {Len, incr_anno_pos(Len + 1, Anno), Rest}};
-find_expr_end(<<$}, Rest/binary>>, Depth, Len, Anno) ->
-    find_expr_end(Rest, Depth - 1, Len + 1, incr_anno_col(1, Anno));
-find_expr_end(<<${, Rest/binary>>, Depth, Len, Anno) ->
-    find_expr_end(Rest, Depth + 1, Len + 1, incr_anno_col(1, Anno));
-find_expr_end(<<$", Rest0/binary>>, Depth, Len0, Anno0) ->
-    case find_string_end(Rest0, Len0 + 1, incr_anno_col(1, Anno0)) of
-        {ok, {Len, Anno, Rest}} ->
-            find_expr_end(Rest, Depth, Len, Anno);
-        {error, ErrInfo} ->
-            {error, ErrInfo}
-    end;
-find_expr_end(<<$\r, $\n, Rest/binary>>, Depth, Len, Anno) ->
-    find_expr_end(Rest, Depth, Len + 2, new_line(Anno));
-find_expr_end(<<$\r, Rest/binary>>, Depth, Len, Anno) ->
-    find_expr_end(Rest, Depth, Len + 1, new_line(Anno));
-find_expr_end(<<$\n, Rest/binary>>, Depth, Len, Anno) ->
-    find_expr_end(Rest, Depth, Len + 1, new_line(Anno));
-find_expr_end(<<_, Rest/binary>>, Depth, Len, Anno) ->
-    find_expr_end(Rest, Depth, Len + 1, incr_anno_col(1, Anno));
-find_expr_end(<<>>, _Depth, Len, Anno) ->
-    {error, {unexpected_expr_end, incr_anno_pos(Len, Anno)}}.
+scan_tag(Rest0, Bin, TagAnno) ->
+    case scan_tag_name(Rest0, 0, TagAnno) of
+        {ok, {Len, Anno, Rest}} when Len > 0 ->
+            Pos = maps:get(position, TagAnno),
+            TagName = binary_part(Bin, Pos, Len),
+            [{open_tag, TagName} | scan_tag_attrs(Rest, Bin, incr_anno_pos(Len, Anno))];
+        {error, {Reason, Anno}} ->
+            error(Reason, [Rest0, Bin, TagAnno], [{error_info, error_info(Anno)}])
+    end.
 
-find_string_end(<<$\\, $", Rest/binary>>, Len, Anno) ->
-    find_string_end(Rest, Len + 2, incr_anno_col(2, Anno));
-find_string_end(<<$", Rest/binary>>, Len, Anno) ->
-    {ok, {Len + 1, incr_anno_col(1, Anno), Rest}};
-find_string_end(<<_, Rest/binary>>, Len, Anno) ->
-    find_string_end(Rest, Len + 1, incr_anno_col(1, Anno));
-find_string_end(<<>>, Len, Anno) ->
+scan_tag_name(Rest = <<$/, $>, _/binary>>, Len, Anno) ->
+    {ok, {Len, Anno, Rest}};
+scan_tag_name(Rest = <<$>, _/binary>>, Len, Anno) ->
+    {ok, {Len, Anno, Rest}};
+scan_tag_name(Rest = <<$\s, _/binary>>, Len, Anno) ->
+    {ok, {Len, Anno, Rest}};
+scan_tag_name(Rest = <<$\r, _/binary>>, Len, Anno) ->
+    {ok, {Len, Anno, Rest}};
+scan_tag_name(Rest = <<$\n, _/binary>>, Len, Anno) ->
+    {ok, {Len, Anno, Rest}};
+scan_tag_name(<<_, Rest/binary>>, Len, Anno) ->
+    scan_tag_name(Rest, Len + 1, incr_anno_col(1, Anno));
+scan_tag_name(<<>>, Len, Anno) ->
+    {error, {unexpected_tag_end, incr_anno_pos(Len, Anno)}}.
+
+scan_tag_attrs(<<$/, $>, Rest/binary>>, Bin, Anno) ->
+    [close_void | scan(Rest, Bin, 0, incr_anno_col(2, incr_anno_pos(2, Anno)))];
+scan_tag_attrs(<<$>, Rest/binary>>, Bin, Anno) ->
+    [close_tag | scan(Rest, Bin, 0, incr_anno_col(1, incr_anno_pos(1, Anno)))];
+scan_tag_attrs(<<$\s, Rest/binary>>, Bin, Anno) ->
+    scan_tag_attrs(Rest, Bin, incr_anno_col(1, incr_anno_pos(1, Anno)));
+scan_tag_attrs(<<$\r, $\n, Rest/binary>>, Bin, Anno) ->
+    scan_tag_attrs(Rest, Bin, new_line(incr_anno_pos(2, Anno)));
+scan_tag_attrs(<<$\r, Rest/binary>>, Bin, Anno) ->
+    scan_tag_attrs(Rest, Bin, new_line(incr_anno_pos(1, Anno)));
+scan_tag_attrs(<<$\n, Rest/binary>>, Bin, Anno) ->
+    scan_tag_attrs(Rest, Bin, new_line(incr_anno_pos(1, Anno)));
+scan_tag_attrs(Rest0, Bin, AttrsAnno) ->
+    case scan_tag_attr_key(Rest0, 0, AttrsAnno) of
+        {ok, {KeyLen, KeyAnno, Rest1}} when KeyLen > 0 ->
+            KeyPos = maps:get(position, AttrsAnno),
+            Key = binary_part(Bin, KeyPos, KeyLen),
+            case scan_tag_attr_value(Rest1, Bin, KeyAnno) of
+                {ok, {Value, Anno, Rest}} ->
+                    [{attr_key, Key}, {attr_value, Value}
+                     | scan_tag_attr_value(Rest, Bin, Anno)];
+                none ->
+                    [{bool_attr, Key} | scan_tag_attrs(Rest1, Bin, KeyAnno)];
+                {error, {Reason, Anno}} ->
+                    error(Reason, [Rest0, Bin, AttrsAnno], [{error_info, error_info(Anno)}])
+            end;
+        {error, {Reason, Anno}} ->
+            error(Reason, [Rest0, Bin, AttrsAnno], [{error_info, error_info(Anno)}])
+    end.
+
+scan_tag_attr_key(Rest = <<$=, _/binary>>, Len, Anno) ->
+    {ok, {Len, Anno, Rest}};
+scan_tag_attr_key(Rest = <<$/, $>, _/binary>>, Len, Anno) ->
+    {ok, {Len, Anno, Rest}};
+scan_tag_attr_key(Rest = <<$>, _/binary>>, Len, Anno) ->
+    {ok, {Len, Anno, Rest}};
+scan_tag_attr_key(Rest = <<$\s, _/binary>>, Len, Anno) ->
+    {ok, {Len, Anno, Rest}};
+scan_tag_attr_key(Rest = <<$\r, _/binary>>, Len, Anno) ->
+    {ok, {Len, Anno, Rest}};
+scan_tag_attr_key(Rest = <<$\n, _/binary>>, Len, Anno) ->
+    {ok, {Len, Anno, Rest}};
+scan_tag_attr_key(<<_, Rest/binary>>, Len, Anno) ->
+    scan_tag_attr_key(Rest, Len + 1, incr_anno_col(1, Anno));
+scan_tag_attr_key(<<>>, Len, Anno) ->
+    {error, {unexpected_tag_end, incr_anno_pos(Len, Anno)}}.
+
+scan_tag_attr_value(<<$=, $', Rest0/binary>>, Bin, KeyAnno) ->
+    ValAnno = incr_anno_col(2, incr_anno_pos(2, KeyAnno)),
+    case scan_single_quoted_string(Rest0, 0, ValAnno) of
+        {ok, {Len, MarkerLen, TxtAnno, Rest}} ->
+            Pos = maps:get(position, ValAnno),
+            Txt = binary_part(Bin, Pos, Len),
+            Anno = incr_anno_col(Len + MarkerLen,
+                       incr_anno_pos(Len + MarkerLen, TxtAnno)),
+            {ok, {{text, Txt}, Anno, Rest}};
+        {error, {Reason, Anno}} ->
+            {error, {Reason, Anno}}
+    end;
+scan_tag_attr_value(<<$=, $", Rest0/binary>>, Bin, KeyAnno) ->
+    ValAnno = incr_anno_col(2, incr_anno_pos(2, KeyAnno)),
+    case scan_double_quoted_string(Rest0, 0, ValAnno) of
+        {ok, {Len, MarkerLen, TxtAnno, Rest}} ->
+            Pos = maps:get(position, ValAnno),
+            Txt = binary_part(Bin, Pos, Len),
+            Anno = incr_anno_col(Len + MarkerLen,
+                       incr_anno_pos(Len + MarkerLen, TxtAnno)),
+            {ok, {{text, Txt}, Anno, Rest}};
+        {error, {Reason, Anno}} ->
+            {error, {Reason, Anno}}
+    end;
+scan_tag_attr_value(<<$=, ${, Rest0/binary>>, Bin, KeyAnno) ->
+    ValAnno = incr_anno_col(2, incr_anno_pos(2, KeyAnno)),
+    case scan_expr_end(Rest0, _Depth = 0, _Len = 0, ValAnno) of
+        {ok, {Len, MarkerLen, ExprAnno, Rest}} ->
+            Pos = maps:get(position, ValAnno),
+            Expr = binary_part(Bin, Pos, Len),
+            case expr_category(Expr) of
+                {ok, expr} ->
+                    Anno = incr_anno_col(Len + MarkerLen,
+                               incr_anno_pos(Len + MarkerLen, ExprAnno)),
+                    {ok, {{expr, Expr}, Anno, Rest}};
+                {ok, comment} ->
+                    % Comments are not allowed in attributes, e.g.:
+                    % > id={% comment }
+                    {error, {unexpected_comment, ExprAnno}};
+                error ->
+                    {error, {badexpr, ExprAnno}}
+            end;
+        {error, {Reason, Anno}} ->
+            {error, {Reason, Anno}}
+    end;
+scan_tag_attr_value(_Rest, _Bin, _Anno) ->
+    none.
+
+% TODO: Use maybe expr.
+scan_closing_tag(Rest0, Bin, TagAnno) ->
+    case scan_closing_tag_name(Rest0, 0, TagAnno) of
+        {ok, {TagNameLen, TagNameAnno, Rest1}} when TagNameLen > 0 ->
+            case scan_closing_tag_end(Rest1, 0, incr_anno_pos(TagNameLen, TagNameAnno)) of
+                {ok, {Anno, Rest}} ->
+                    Pos = maps:get(position, TagAnno),
+                    TagName = binary_part(Bin, Pos, TagNameLen),
+                    [{closing_tag, TagName} | scan(Rest, Bin, 0, Anno)];
+                {error, {Reason, Anno}} ->
+                    error(Reason, [Rest0, Bin, TagAnno], [{error_info, error_info(Anno)}])
+            end;
+        {error, {Reason, Anno}} ->
+            error(Reason, [Rest0, Bin, TagAnno], [{error_info, error_info(Anno)}])
+    end.
+
+scan_closing_tag_name(Rest = <<$>, _/binary>>, Len, Anno) ->
+    {ok, {Len, Anno, Rest}};
+scan_closing_tag_name(Rest = <<$\s, _/binary>>, Len, Anno) ->
+    {ok, {Len, Anno, Rest}};
+scan_closing_tag_name(Rest = <<$\r, _/binary>>, Len, Anno) ->
+    {ok, {Len, Anno, Rest}};
+scan_closing_tag_name(Rest = <<$\n, _/binary>>, Len, Anno) ->
+    {ok, {Len, Anno, Rest}};
+scan_closing_tag_name(<<_, Rest/binary>>, Len, Anno) ->
+    scan_closing_tag_name(Rest, Len + 1, incr_anno_col(1, Anno));
+scan_closing_tag_name(<<>>, Len, Anno) ->
+    {error, {unexpected_tag_end, incr_anno_pos(Len, Anno)}}.
+
+scan_closing_tag_end(<<$>, Rest/binary>>, Len, Anno) ->
+    {ok, {incr_anno_col(1, incr_anno_pos(Len + 1, Anno)), Rest}};
+scan_closing_tag_end(<<$\r, $\n, Rest/binary>>, Len, Anno) ->
+    scan_closing_tag_end(Rest, Len + 2, new_line(Anno));
+scan_closing_tag_end(<<$\r, Rest/binary>>, Len, Anno) ->
+    scan_closing_tag_end(Rest, Len + 1, new_line(Anno));
+scan_closing_tag_end(<<$\n, Rest/binary>>, Len, Anno) ->
+    scan_closing_tag_end(Rest, Len + 1, new_line(Anno));
+scan_closing_tag_end(<<_, Rest/binary>>, Len, Anno) ->
+    scan_closing_tag_end(Rest, Len + 1, incr_anno_col(1, Anno));
+scan_closing_tag_end(<<>>, Len, Anno) ->
+    {error, {unexpected_tag_end, incr_anno_pos(Len, Anno)}}.
+
+scan_single_quoted_string(<<$\\, $', Rest/binary>>, Len, Anno) ->
+    scan_single_quoted_string(Rest, Len + 2, incr_anno_col(2, Anno));
+scan_single_quoted_string(<<$', Rest/binary>>, Len, Anno) ->
+    {ok, {Len, _MarkerLen = 1, Anno, Rest}};
+scan_single_quoted_string(<<_, Rest/binary>>, Len, Anno) ->
+    scan_single_quoted_string(Rest, Len + 1, incr_anno_col(1, Anno));
+scan_single_quoted_string(<<>>, Len, Anno) ->
     {error, {unexpected_string_end, incr_anno_pos(Len, Anno)}}.
+
+scan_double_quoted_string(<<$\\, $", Rest/binary>>, Len, Anno) ->
+    scan_double_quoted_string(Rest, Len + 2, incr_anno_col(2, Anno));
+scan_double_quoted_string(<<$", Rest/binary>>, Len, Anno) ->
+    {ok, {Len, _MarkerLen = 1, Anno, Rest}};
+scan_double_quoted_string(<<_, Rest/binary>>, Len, Anno) ->
+    scan_double_quoted_string(Rest, Len + 1, incr_anno_col(1, Anno));
+scan_double_quoted_string(<<>>, Len, Anno) ->
+    {error, {unexpected_string_end, incr_anno_pos(Len, Anno)}}.
+
+maybe_prepend_text_token(Bin, Len, Anno = #{position := Pos}, Tokens) ->
+    case string:trim(binary_part(Bin, Pos, Len)) of
+        <<>> ->
+            Tokens;
+        Text ->
+            [{text, token_anno(Anno), Text} | Tokens]
+    end.
+
+token_anno(Anno) ->
+    {token_source(Anno), token_location(Anno)}.
+
+token_source(#{module := Mod, function := Fun})
+    when Mod =/= undefined,
+         Fun =/= undefined ->
+    {Mod, Fun};
+token_source(#{file := File}) ->
+    {file, File}.
+
+token_location(#{line := Ln, column := Col}) ->
+    {Ln, Col}.
+
+error_info(Anno = #{module := Mod, function := Fun})
+    when Mod =/= undefined,
+         Fun =/= undefined ->
+    maps:with([module, function, line, column], Anno);
+error_info(Anno) ->
+    maps:with([file, line, column], Anno).
+
+%% Anno.
 
 default_anno() ->
     #{
@@ -233,9 +408,11 @@ scan_test() ->
             begin
             {% comment }
             {foo}
+            <div>bar</div>
+            <input id="input" class='input' hidden/>
             end
             """, ?ANNO)),
-        ?assertError({badexpr, <<"@">>}, scan(<<"foo{@}bar">>, ?ANNO))
+        ?assertError(badexpr, scan(<<"foo{@}bar">>, ?ANNO))
     ].
 
 expr_category_test() ->
@@ -245,22 +422,30 @@ expr_category_test() ->
         ?assertEqual(error, expr_category("@"))
     ].
 
-find_expr_end_test() ->
+scan_expr_end_test() ->
     [
-        ?assertMatch({ok, {10, _, <<"baz">>}},
-                     find_expr_end(<<"{foo\"bar\"}}baz">>, 0, 0, ?ANNO)),
-        ?assertMatch({ok, {8, _, <<"baz">>}},
-                     find_expr_end(<<"foo\"bar\"}baz">>, 0, 0, ?ANNO)),
+        ?assertMatch({ok, {10, 1, _, <<"baz">>}},
+                     scan_expr_end(<<"{foo\"bar\"}}baz">>, 0, 0, ?ANNO)),
+        ?assertMatch({ok, {8, 1, _, <<"baz">>}},
+                     scan_expr_end(<<"foo\"bar\"}baz">>, 0, 0, ?ANNO)),
         ?assertMatch({error, {unexpected_expr_end, _}},
-                     find_expr_end(<<"foo\"bar\"baz">>, 0, 0, ?ANNO))
+                     scan_expr_end(<<"foo\"bar\"baz">>, 0, 0, ?ANNO))
     ].
 
-find_string_end_test() ->
+scan_single_quoted_string_test() ->
     [
-        ?assertMatch({ok, {9, _, <<"baz">>}},
-                     find_string_end(<<"foo\\\"bar\"baz">>, 0, ?ANNO)),
+        ?assertMatch({ok, {8, 1, _, <<"baz">>}},
+                     scan_single_quoted_string(<<"foo\\'bar'baz">>, 0, ?ANNO)),
         ?assertMatch({error, {unexpected_string_end, _}},
-                     find_string_end(<<"foo">>, 0, ?ANNO))
+                     scan_single_quoted_string(<<"foo">>, 0, ?ANNO))
+    ].
+
+scan_double_quoted_string_test() ->
+    [
+        ?assertMatch({ok, {8, 1, _, <<"baz">>}},
+                     scan_double_quoted_string(<<"foo\\\"bar\"baz">>, 0, ?ANNO)),
+        ?assertMatch({error, {unexpected_string_end, _}},
+                     scan_double_quoted_string(<<"foo">>, 0, ?ANNO))
     ].
 
 new_anno_test() ->

--- a/src/arizona_template_scanner.erl
+++ b/src/arizona_template_scanner.erl
@@ -113,7 +113,7 @@ scan_expr(Rest0, Bin, ExprAnno) ->
     end.
 
 scan_expr_end(<<$}, Rest/binary>>, 0, Len, Anno) ->
-    {ok, {Len, _MarkerLen = 1, Anno, Rest}};
+    {ok, {Len, _MarkerLen = 1, incr_anno_col(1, Anno), Rest}};
 scan_expr_end(<<$}, Rest/binary>>, Depth, Len, Anno) ->
     scan_expr_end(Rest, Depth - 1, Len + 1, incr_anno_col(1, Anno));
 scan_expr_end(<<${, Rest/binary>>, Depth, Len, Anno) ->
@@ -168,9 +168,11 @@ scan_tag_name(<<>>, Len, Anno) ->
     {error, {unexpected_tag_end, incr_anno_pos(Len, Anno)}}.
 
 scan_tag_attrs(<<$/, $>, Rest/binary>>, Bin, Anno) ->
-    [close_void | scan(Rest, Bin, 0, incr_anno_col(2, incr_anno_pos(2, Anno)))];
+    [{close_tag, token_anno(Anno), void}
+     | scan(Rest, Bin, 0, incr_anno_col(2, incr_anno_pos(2, Anno)))];
 scan_tag_attrs(<<$>, Rest/binary>>, Bin, Anno) ->
-    [close_tag | scan(Rest, Bin, 0, incr_anno_col(1, incr_anno_pos(1, Anno)))];
+    [{close_tag, token_anno(Anno), nonvoid}
+     | scan(Rest, Bin, 0, incr_anno_col(1, incr_anno_pos(1, Anno)))];
 scan_tag_attrs(<<$\s, Rest/binary>>, Bin, Anno) ->
     scan_tag_attrs(Rest, Bin, incr_anno_col(1, incr_anno_pos(1, Anno)));
 scan_tag_attrs(<<$\r, $\n, Rest/binary>>, Bin, Anno) ->
@@ -184,12 +186,13 @@ scan_tag_attrs(Rest0, Bin, AttrsAnno) ->
         {ok, {KeyLen, KeyAnno, Rest1}} when KeyLen > 0 ->
             KeyPos = maps:get(position, AttrsAnno),
             Key = binary_part(Bin, KeyPos, KeyLen),
-            case scan_tag_attr_value(Rest1, Bin, KeyAnno) of
+            ValAnno = incr_anno_pos(KeyLen, KeyAnno),
+            case scan_tag_attr_value(Rest1, Bin, ValAnno) of
                 {ok, {Value, Anno, Rest}} ->
-                    [{attr_key, Key}, {attr_value, Value}
-                     | scan_tag_attr_value(Rest, Bin, Anno)];
-                none ->
-                    [{bool_attr, Key} | scan_tag_attrs(Rest1, Bin, KeyAnno)];
+                    [{attr_key, token_anno(KeyAnno), Key}, {attr_value, token_anno(ValAnno), Value}
+                     | scan_tag_attrs(Rest, Bin, Anno)];
+                {none, {Anno, Rest}} ->
+                    [{bool_attr, token_anno(ValAnno), Key} | scan_tag_attrs(Rest, Bin, Anno)];
                 {error, {Reason, Anno}} ->
                     error(Reason, [Rest0, Bin, AttrsAnno], [{error_info, error_info(Anno)}])
             end;
@@ -220,8 +223,7 @@ scan_tag_attr_value(<<$=, $', Rest0/binary>>, Bin, KeyAnno) ->
         {ok, {Len, MarkerLen, TxtAnno, Rest}} ->
             Pos = maps:get(position, ValAnno),
             Txt = binary_part(Bin, Pos, Len),
-            Anno = incr_anno_col(Len + MarkerLen,
-                       incr_anno_pos(Len + MarkerLen, TxtAnno)),
+            Anno = incr_anno_pos(Len + MarkerLen, TxtAnno),
             {ok, {{text, Txt}, Anno, Rest}};
         {error, {Reason, Anno}} ->
             {error, {Reason, Anno}}
@@ -232,8 +234,7 @@ scan_tag_attr_value(<<$=, $", Rest0/binary>>, Bin, KeyAnno) ->
         {ok, {Len, MarkerLen, TxtAnno, Rest}} ->
             Pos = maps:get(position, ValAnno),
             Txt = binary_part(Bin, Pos, Len),
-            Anno = incr_anno_col(Len + MarkerLen,
-                       incr_anno_pos(Len + MarkerLen, TxtAnno)),
+            Anno = incr_anno_pos(Len + MarkerLen, TxtAnno),
             {ok, {{text, Txt}, Anno, Rest}};
         {error, {Reason, Anno}} ->
             {error, {Reason, Anno}}
@@ -246,8 +247,7 @@ scan_tag_attr_value(<<$=, ${, Rest0/binary>>, Bin, KeyAnno) ->
             Expr = binary_part(Bin, Pos, Len),
             case expr_category(Expr) of
                 {ok, expr} ->
-                    Anno = incr_anno_col(Len + MarkerLen,
-                               incr_anno_pos(Len + MarkerLen, ExprAnno)),
+                    Anno = incr_anno_pos(Len + MarkerLen, ExprAnno),
                     {ok, {{expr, Expr}, Anno, Rest}};
                 {ok, comment} ->
                     % Comments are not allowed in attributes, e.g.:
@@ -259,8 +259,8 @@ scan_tag_attr_value(<<$=, ${, Rest0/binary>>, Bin, KeyAnno) ->
         {error, {Reason, Anno}} ->
             {error, {Reason, Anno}}
     end;
-scan_tag_attr_value(_Rest, _Bin, _Anno) ->
-    none.
+scan_tag_attr_value(Rest, _Bin, Anno) ->
+    {none, {Anno, Rest}}.
 
 % TODO: Use maybe expr.
 scan_closing_tag(Rest0, Bin, TagAnno) ->
@@ -270,7 +270,7 @@ scan_closing_tag(Rest0, Bin, TagAnno) ->
                 {ok, {Anno, Rest}} ->
                     Pos = maps:get(position, TagAnno),
                     TagName = binary_part(Bin, Pos, TagNameLen),
-                    [{closing_tag, TagName} | scan(Rest, Bin, 0, Anno)];
+                    [{closing_tag, token_anno(TagAnno), TagName} | scan(Rest, Bin, 0, Anno)];
                 {error, {Reason, Anno}} ->
                     error(Reason, [Rest0, Bin, TagAnno], [{error_info, error_info(Anno)}])
             end;
@@ -308,6 +308,12 @@ scan_single_quoted_string(<<$\\, $', Rest/binary>>, Len, Anno) ->
     scan_single_quoted_string(Rest, Len + 2, incr_anno_col(2, Anno));
 scan_single_quoted_string(<<$', Rest/binary>>, Len, Anno) ->
     {ok, {Len, _MarkerLen = 1, Anno, Rest}};
+scan_single_quoted_string(<<$\r, $\n, Rest/binary>>, Len, Anno) ->
+    scan_single_quoted_string(Rest, Len + 2, new_line(Anno));
+scan_single_quoted_string(<<$\r, Rest/binary>>, Len, Anno) ->
+    scan_single_quoted_string(Rest, Len + 1, new_line(Anno));
+scan_single_quoted_string(<<$\n, Rest/binary>>, Len, Anno) ->
+    scan_single_quoted_string(Rest, Len + 1, new_line(Anno));
 scan_single_quoted_string(<<_, Rest/binary>>, Len, Anno) ->
     scan_single_quoted_string(Rest, Len + 1, incr_anno_col(1, Anno));
 scan_single_quoted_string(<<>>, Len, Anno) ->
@@ -317,6 +323,12 @@ scan_double_quoted_string(<<$\\, $", Rest/binary>>, Len, Anno) ->
     scan_double_quoted_string(Rest, Len + 2, incr_anno_col(2, Anno));
 scan_double_quoted_string(<<$", Rest/binary>>, Len, Anno) ->
     {ok, {Len, _MarkerLen = 1, Anno, Rest}};
+scan_double_quoted_string(<<$\r, $\n, Rest/binary>>, Len, Anno) ->
+    scan_double_quoted_string(Rest, Len + 2, new_line(Anno));
+scan_double_quoted_string(<<$\r, Rest/binary>>, Len, Anno) ->
+    scan_double_quoted_string(Rest, Len + 1, new_line(Anno));
+scan_double_quoted_string(<<$\n, Rest/binary>>, Len, Anno) ->
+    scan_double_quoted_string(Rest, Len + 1, new_line(Anno));
 scan_double_quoted_string(<<_, Rest/binary>>, Len, Anno) ->
     scan_double_quoted_string(Rest, Len + 1, incr_anno_col(1, Anno));
 scan_double_quoted_string(<<>>, Len, Anno) ->

--- a/src/arizona_template_scanner.erl
+++ b/src/arizona_template_scanner.erl
@@ -233,6 +233,13 @@ scan_test() ->
         ?assertError({badexpr, <<"@">>}, scan(<<"foo{@}bar">>, ?ANNO))
     ].
 
+expr_category_test() ->
+    [
+        ?assertEqual({ok, expr}, expr_category("foo")),
+        ?assertEqual({ok, comment}, expr_category("%foo")),
+        ?assertEqual(error, expr_category("@"))
+    ].
+
 find_expr_end_test() ->
     [
         ?assertMatch({ok, {10, _, <<"baz">>}},

--- a/src/arizona_tpl_compile.erl
+++ b/src/arizona_tpl_compile.erl
@@ -82,7 +82,7 @@ compile_tag(#{directives := Directives} = Tag, Txt, T, P, I, State) ->
                     [{I, #{
                         id => Id,
                         'for' => expand(InExpr, InMacros, State#state.assign_fun_args),
-                        'when' => Cond,
+                        condition => Cond,
                         static => filter_static_tokens(Tokens),
                         dynamic => DynamicTokensMap,
                         indexes => lists:usort(maps:keys(DynamicTokensMap)),
@@ -113,7 +113,7 @@ compile_tag(#{directives := Directives} = Tag, Txt, T, P, I, State) ->
                     [{I, #{
                         id => Id,
                         'for' => expand(InExpr, InMacros, State#state.assign_fun_args),
-                        'when' => Cond,
+                        condition => Cond,
                         static => filter_static_tokens(Tokens),
                         dynamic => DynamicTokensMap,
                         indexes => lists:usort(maps:keys(DynamicTokensMap)),
@@ -127,12 +127,12 @@ compile_tag(#{directives := Directives} = Tag, Txt, T, P, I, State) ->
                         tag_tokens_state(Tag, P, I, State#state{assign_fun_args = FunArgs})),
                     DynamicTokensMap = maps:from_list(DynamicTokens),
                     Id = id(P, I),
-                    Cond = nocond,
+                    Cond = none,
                     Vars = expr_vars(DynamicTokens, Cond),
                     [{I, #{
                         id => Id,
                         'for' => expand(InExpr, InMacros, State#state.assign_fun_args),
-                        'when' => Cond,
+                        condition => Cond,
                         static => filter_static_tokens(Tokens),
                         dynamic => DynamicTokensMap,
                         indexes => lists:usort(maps:keys(DynamicTokensMap)),

--- a/src/arizona_tpl_parse.erl
+++ b/src/arizona_tpl_parse.erl
@@ -163,43 +163,6 @@ parse_expr_str(ExprStr, Macros, Eval) ->
 
 parse_expr_str(ExprStr, Macros, _Bindings, Eval) ->
     {expr, {ExprStr, {Macros, Eval}}}.
-    %ExprTree = merl:quote(ExprStr),
-    %case erl_syntax:type(ExprTree) =:= comment of
-    %    true ->
-    %        {comment, erl_syntax:comment_text(ExprTree)};
-    %    false ->
-    %        MacrosEnv = [{K, merl:term(V)} || K := V <- Macros],
-    %        MacrosTree = merl:tsubst(ExprTree, MacrosEnv),
-    %        AllVars = merl:template_vars(merl:template(MacrosTree)),
-    %        case AllVars -- maps:keys(Macros) of
-    %            [] ->
-    %                case Eval andalso
-    %                     lists:member(erl_syntax:type(MacrosTree),
-    %                                  arizona_html:safe_types()) of
-    %                    true ->
-    %                        {value, V, []} =
-    %                            erl_eval:exprs(
-    %                                [erl_syntax:revert(MacrosTree)], []),
-    %                        {text, arizona_html:safe(V)};
-    %                    false ->
-    %                        MacrosStr = iolist_to_binary(
-    %                            erl_pp:expr(erl_syntax:revert(MacrosTree))),
-    %                        expr_struct(MacrosStr, [], Bindings)
-    %                end;
-    %            Vars ->
-    %                FunStr = <<"_@subst">>,
-    %                VarsSubst = [{Var, subst_var(Var)} || Var <- Vars],
-    %                Env = [{subst, merl:subst(MacrosTree, VarsSubst)}],
-    %                Tree = erl_syntax:revert_forms([merl:qquote(FunStr, Env)]),
-    %                        TreeStr = iolist_to_binary(
-    %                            erl_pp:expr(Tree)),
-    %                expr_struct(TreeStr, Vars, Bindings)
-    %        end
-    %end.
-
-%subst_var(Var) ->
-%  VarStr = atom_to_binary(Var, utf8),
-%  merl:quote(<<"maps:get(", VarStr/binary, ", Assigns)">>).
 
 block_struct(Props) ->
     #{
@@ -226,10 +189,6 @@ check_directives(Directives) ->
         false ->
             Directives
     end.
-
-%expr_struct(Tree, Vars, _Bindings) ->
-%    %{value, Fun, _NewBindings} = erl_eval:exprs(Tree, Bindings),
-%    {expr, {Tree, Vars}}.
 
 get(K, L, D) ->
     proplists:get_value(K, L, D).

--- a/src/arizona_tpl_render.erl
+++ b/src/arizona_tpl_render.erl
@@ -99,30 +99,51 @@ render_indexes([], _Block, _Assigns, _Notify) ->
 
 % TODO: Rename all Assigns to Bindings. Now, Assigns is inside Bindings.
 %       Bindings is a list.
-maybe_render({'case', {expr, {Expr, _Vars}}, ToRender}, Assigns, Notify) ->
+maybe_render(#{
+    'case' := {expr, {Expr, _Vars}},
+    'of' := ToRender
+}, Assigns, Notify) ->
     case Expr(Assigns) of
         {true, Value} ->
             render(ToRender, [Value | Assigns], Notify);
         false ->
             <<>>
     end;
-maybe_render({'if', {expr, {Expr, _Vars}}, ToRender}, Assigns, Notify) ->
+maybe_render(#{
+    'if' := {expr, {Expr, _Vars}},
+    'then' := ToRender
+}, Assigns, Notify) ->
     case Expr(Assigns) of
         true ->
             render(ToRender, Assigns, Notify);
         false ->
             <<>>
     end;
-maybe_render({'for', {expr, {ForExpr, _Vars}},
-    nocond, Static, {Indexes, Dynamic}}, Assigns, Notify) ->
+maybe_render(#{
+    'for' := {expr, {ForExpr, _Vars}},
+    'when' := nocond,
+    static := Static,
+    dynamic := Dynamic,
+    indexes := Indexes
+}, Assigns, Notify) ->
     [ zip(Static, render_indexes(Indexes, Dynamic, [Item | Assigns], Notify))
     || Item <- ForExpr(Assigns)];
-maybe_render({'for', {expr, {ForExpr, _Vars}},
-    {'if', {expr, {IfExpr, _IfVars}}}, Static, {Indexes, Dynamic}}, Assigns, Notify) ->
+maybe_render(#{
+    'for' := {expr, {ForExpr, _Vars}},
+    'when' := {'if', {expr, {IfExpr, _IfVars}}},
+    static := Static,
+    dynamic := Dynamic,
+    indexes := Indexes
+}, Assigns, Notify) ->
     [ zip(Static, render_indexes(Indexes, Dynamic, [Item | Assigns], Notify))
     || Item <- ForExpr(Assigns), IfExpr([Item | Assigns])];
-maybe_render({'for', {expr, {ForExpr, _Vars}},
-    {'case', {expr, {CaseExpr, _CaseVars}}}, Static, {Indexes, Dynamic}}, Assigns, Notify) ->
+maybe_render(#{
+    'for' := {expr, {ForExpr, _Vars}},
+    'when' := {'case', {expr, {CaseExpr, _CaseVars}}},
+    static := Static,
+    dynamic := Dynamic,
+    indexes := Indexes
+}, Assigns, Notify) ->
     [ zip(Static, render_indexes(Indexes, Dynamic, [CaseValue, Item | Assigns], Notify))
     || Item <- ForExpr(Assigns),
        case CaseExpr([Item | Assigns]) of

--- a/src/arizona_tpl_render.erl
+++ b/src/arizona_tpl_render.erl
@@ -121,7 +121,7 @@ maybe_render(#{
     end;
 maybe_render(#{
     'for' := {expr, {ForExpr, _Vars}},
-    'when' := nocond,
+    condition := none,
     static := Static,
     dynamic := Dynamic,
     indexes := Indexes
@@ -130,7 +130,7 @@ maybe_render(#{
     || Item <- ForExpr(Assigns)];
 maybe_render(#{
     'for' := {expr, {ForExpr, _Vars}},
-    'when' := {'if', {expr, {IfExpr, _IfVars}}},
+    condition := {'if', {expr, {IfExpr, _IfVars}}},
     static := Static,
     dynamic := Dynamic,
     indexes := Indexes
@@ -139,7 +139,7 @@ maybe_render(#{
     || Item <- ForExpr(Assigns), IfExpr([Item | Assigns])];
 maybe_render(#{
     'for' := {expr, {ForExpr, _Vars}},
-    'when' := {'case', {expr, {CaseExpr, _CaseVars}}},
+    condition := {'case', {expr, {CaseExpr, _CaseVars}}},
     static := Static,
     dynamic := Dynamic,
     indexes := Indexes


### PR DESCRIPTION
# Description

This PR introduces `:if`, `:case` and `:for` directives.
`:if` and `:case` are conditionals and cannot be used together, the consumer should use one or another.
`:for` is a loop directive and can be used with a conditional.
Example:
```erlang
~"""
<div :if={_@bool}>
  I'll be visible when _@bool equals true
  {% NOTE: _@bool must be a boolean() }
</div>

<ul>
  <li 
    :for={Item = #{name := ItemName}} :in={_@list}
    :case={maps:get(available, Item)} :of={true}
    {% NOTE: :of accepts guards, like :of={X when is_integer(X)} }
  >
    <b>{ItemName}</b>
  </li>
</ul>

{% NOTE: blocks/components can also make use of :if, :case and : for, }
{%       but I've not tested this yet, e.g.:                          }
<.comp_mod:comp_fun :if={_@bool} />
"""
```

The compiled template:
```erlang
#{block =>
     #{0 =>
        {'if',
         {expr,{#Fun<erl_eval.42.39164016>,[bool]}},
         #{tag =>
            #{0 => #{id => [0,0],text => <<"<div>">>},
              1 =>
               #{id => [0,1],
                 text =>
                  <<"I'll be visible when _@bool equals true">>},
              2 => #{id => [0,2],text => <<"</div>">>}},
           indexes => [0,1,2]}},
       1 =>
        #{tag =>
           #{0 => #{id => [1,0],text => <<"<ul>">>},
             1 =>
              % :for has Static and Dynamic code, we zip them to get the rendered result.
              % IMPORTANT: We send Static only once to the client, after we send just what changes in Dynamic expressions.  
              {for,
               {expr,{#Fun<erl_eval.42.39164016>,[list]}},
               % IMPORTANT: :case is not implemented yet for loops, just :if. I'll implement it later in this PR.
               {'if',true},
               % The list below is static code, it never changes...
               [<<"<li>">>,<<"</li>">>],
               % and below is dynamic code (expressions), they could change...
               {[0],
                #{0 =>
                   #{tag =>
                      #{0 =>
                         #{id => [1,1,0,0],text => <<"<b>">>},
                        1 =>
                         #{id => [1,1,0,1],
                           expr => #Fun<erl_eval.42.39164016>,
                           vars => []},
                        2 =>
                         #{id => [1,1,0,2],
                           text => <<"</b>">>}},
                     indexes => [0,1,2]}}}},
             2 => #{id => [1,2],text => <<"</ul>">>}},
          indexes => [0,1,2]}},
    id => [0],
    view => arizona_tpl_compile,
    directives =>
     #{'if' => {expr,{<<"_@bool">>,{#{},false}}},
       stateful => true},
    attrs => #{},
    indexes => [0,1],
    % IMPORTANT: I'm not collecting vars right now. I'll fix it later in this PR.
    vars => #{}}
```

We have a simple, compact, and powerful template.
 
_Why this and not implement it in pure Erlang?_
The implementation of this PR provides a clear understanding of the consumer's intent. Given the flexible nature of the Erlang code, we must traverse the AST to accurately determine the consumer's objectives, and that's not so easy.
We must definitely provide the same functionality by writing Erlang code. However, for now, this "shortened" version addresses some important gaps in Arizona's templates.

Also, this PR changes our scanner, parser, and compiler, but just a bit:
- Comments are now tokenized in the scanner and not in the parser;
- Expansion code was moved from the parser to the compiler, so now we only transform data in the compiler. This was changed to make it possible for nested tokens to make use of loop and conditionals data, e.g., a loop has a list, and this list has items, we should be able to use the item in the nested tokens.

I haven't implemented the diff for the new struct yet. Due to the new loop rendering, I'll also need to change the JS code a bit.
The behavior of the diff patch remains the same even for loops and conditionals.

> [!IMPORTANT]
> I've removed some tokens concat to simplify the understanding and the development, e.g.:
> ```erlang
> % Before this PR (optimized)
> 5 =>
>{'case',
> {expr,{#Fun<erl_eval.42.39164016>,[foo]}},
> {text, <<"<p>bar</p>">>}},
>
> % After this PR
> 5 =>
>{'case',
> {expr,{#fun<erl_eval.42.39164016>,[foo]}},
> #{tag =>
>    #{0 => #{id => [5,0],text => <<"<p>">>},
>      1 => #{id => [5,1],text => <<"bar">>},
>      2 => #{id => [5,2],text => <<"</p>">>}},
>   indexes => [0,1,2]}},
> ```
> We can improve this in another PR.

> [!NOTE]
> - This PR introduced some TODOs, but they are just reminders of things to be done in this same PR; 
> - The ugly code is still there, and bad tests also, but this is a task to be done in https://github.com/arizona-framework/arizona/issues/8 :slightly_smiling_face: 
> - I started to look into this today, but I will have more time next week. It's 2:50 AM, I need to rest  :zzz:  

⚠️ Work in progress ⚠️

Closes #17, closes #18, closes #19.

- [ ] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
