### PR TITLE
Simplify maintenance by removing macros

### DIFF
--- a/elvis.config
+++ b/elvis.config
@@ -7,7 +7,6 @@
                  {elvis_style, atom_naming_convention, #{regex => "^([a-z][a-z_0-9]*_?)*(_SUITE)?$"}},
                  {elvis_style, function_naming_convention, #{regex => "^([a-z][a-z_0-9]*_?)*(_SUITE)?$"}},
                  {elvis_style, no_macros, #{allow => [
-                   'ARIZONA_LIVEVIEW',
                    'assert',
                    'assertEqual',
                    'assertMatch',
@@ -18,10 +17,8 @@
        filter => "*.erl",
        ruleset => erl_files_strict,
        rules => [{elvis_style, no_macros, #{allow => [
-                   'ARIZONA_ASSERT_BODY',
-                   'ARIZONA_ASSERT_STATUS',
-                   'ARIZONA_LIVEVIEW'
-                 ]}}]},
+                   'assert'
+                ]}}]},
      #{dirs => ["."],
        filter => "rebar.config",
        ruleset => rebar_config},

--- a/include/arizona.hrl
+++ b/include/arizona.hrl
@@ -1,3 +1,0 @@
--define(ARIZONA_LIVEVIEW(Macros, Str), (
-    arizona_live_view:parse_str(Str, Macros)
-)).

--- a/include/arizona_assert.hrl
+++ b/include/arizona_assert.hrl
@@ -1,9 +1,0 @@
--include_lib("stdlib/include/assert.hrl").
-
--define(ARIZONA_ASSERT_BODY(Pattern, Resp), (
-    ?assertNotEqual(nomatch, string:find(element(3, Resp), Pattern))
-)).
-
--define(ARIZONA_ASSERT_STATUS(Status, Resp), (
-    ?assertEqual(Status, element(2, element(1, Resp)))
-)).

--- a/rebar.config
+++ b/rebar.config
@@ -68,7 +68,6 @@
     {files, [
         "elvis.config",
         "rebar.config",
-        "include/*.hrl",
         "src/*.app.src",
         "src/**/*.erl",
         "test/**/*.erl"

--- a/src/arizona_live_view.erl
+++ b/src/arizona_live_view.erl
@@ -109,26 +109,25 @@ handle_event(Mod, Event, Payload, Socket) ->
 
 -ifdef(TEST).
 -compile([export_all, nowarn_export_all]).
--include("arizona.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
 % Start parse_str support.
 
 render(Macros) ->
-    ?ARIZONA_LIVEVIEW(Macros, """
+    arizona_live_view:parse_str("""
     <main :stateful>
         <h1>{_@title}</h1>
         <.arizona_live_view:counter/>
     </main>
-    """).
+    """, Macros).
 
 counter(Macros) ->
-    ?ARIZONA_LIVEVIEW(Macros, """
+    arizona_live_view:parse_str("""
     <div :stateful>
         <div>{_@count}</div>
         <button type="button">Increment</button>
     </div>
-    """).
+    """, Macros).
 
 % End parse_str support.
 

--- a/test/arizona_live_view_SUITE.erl
+++ b/test/arizona_live_view_SUITE.erl
@@ -19,6 +19,8 @@
 %%
 -module(arizona_live_view_SUITE).
 
+-include_lib("stdlib/include/assert.hrl").
+
 %% ct callbacks.
 -export([all/0]).
 -export([init_per_suite/1]).
@@ -30,10 +32,6 @@
 
 %% Test cases.
 -export([hello_world/1]).
-
-%% Libs
--include("arizona.hrl").
--include("arizona_assert.hrl").
 
 %% --------------------------------------------------------------------
 %% arizona_live_view callbacks.
@@ -64,7 +62,7 @@ mount(Socket) ->
     Socket.
 
 render(Macros) ->
-    ?ARIZONA_LIVEVIEW(Macros, ~s"""
+    arizona_live_view:parse_str(~s"""
     <html>
     <head>
     </head>
@@ -72,16 +70,25 @@ render(Macros) ->
         Hello, World!
     </body>
     </html>
-    """).
+    """, Macros).
 
 %% --------------------------------------------------------------------
 %% Test cases.
 %% --------------------------------------------------------------------
 
-hello_world(_Config) ->
-    {ok, Resp0} = httpc:request("http://localhost:8080/notfound"),
-    ?ARIZONA_ASSERT_STATUS(404, Resp0),
-    {ok, Resp1} = httpc:request("http://localhost:8080/helloworld"),
-    ?ARIZONA_ASSERT_STATUS(200, Resp1),
-    ?ARIZONA_ASSERT_BODY("Hello, World!", Resp1).
+hello_world(Config) when is_list(Config) ->
+    Resp0 = httpc:request("http://localhost:8080/notfound"),
+    ?assert(is_status(404, Resp0)),
+    Resp1 = httpc:request("http://localhost:8080/helloworld"),
+    ?assert(is_status(200, Resp1)),
+    ?assert(is_body("Hello, World!", Resp1)).
 
+is_body(Pattern, {ok, {{_HttpVersion, _StatusCode, _String}, _HttpHeaders, HttpBodyResult}}) ->
+  nomatch =/= string:find(HttpBodyResult, Pattern);
+is_body(_Pattern, _Result) ->
+  false.
+
+is_status(StatusCode, {ok, {{_HttpVersion, StatusCode, _String}, _HttpHeaders, _HttpBodyResult}}) ->
+  true;
+is_status(_StatusCode, _Result) ->
+  false.


### PR DESCRIPTION
# Description

We discussed not requiring those, for the time being, so we remove them. Maybe the code'll evolve in that sense, otherwise it's "future programming"...

Closes #105.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
