### PR TITLE
Move `xref` to `rebar3 ci`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,6 @@ jobs:
 
       - name: Continuous Integration
         run: |
-          rebar3 xref
           rebar3 as test ci
           npm run ci
 

--- a/rebar.config
+++ b/rebar.config
@@ -27,10 +27,6 @@
     incremental
 ]}.
 
-{xref_checks, [
-    exports_not_used
-]}.
-
 {alias, [
     {ci, [
         lint,
@@ -45,6 +41,11 @@
 ]}.
 
 {profiles, [
+    {default, [
+        {xref_checks, [
+            exports_not_used
+        ]}
+    ]},
     {test, [
         {cover_enabled, true},
         {cover_opts, [verbose]},
@@ -53,9 +54,9 @@
             nowarn_missing_spec,
             warnings_as_errors
         ]},
-        {extra_src_dirs, [{"test", [{recursive, true}]}]}
-    ]},
-    {xref_checks, []}
+        {extra_src_dirs, [{"test", [{recursive, true}]}]},
+        {xref_checks, []}
+    ]}
 ]}.
 
 {project_plugins,

--- a/rebar.config
+++ b/rebar.config
@@ -54,7 +54,8 @@
             warnings_as_errors
         ]},
         {extra_src_dirs, [{"test", [{recursive, true}]}]}
-    ]}
+    ]},
+    {xref_checks, []}
 ]}.
 
 {project_plugins,

--- a/rebar.config
+++ b/rebar.config
@@ -35,6 +35,7 @@
     {ci, [
         lint,
         hank,
+        xref,
         {do, "default as test dialyzer"},
         eunit,
         ct,


### PR DESCRIPTION
# Description

I eventually decided against using the `exports_not_used` rule in the `test` profile, since we're doing `export_all` which doesn't help. We get the same level of maintenance with a little less hassle. When/if we decide to move to CT later we can revisit this.

Closes #147.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
