### PR TITLE
Implement a new renderer

### DIFF
--- a/src/arizona_socket.erl
+++ b/src/arizona_socket.erl
@@ -34,12 +34,6 @@ Components state.
 -opaque t() :: map().
 -export_type([t/0]).
 
--type assigns() :: map().
--export_type([assigns/0]).
-
--type changes() :: map().
--export_type([changes/0]).
-
 -type view() :: module().
 -export_type([view/0]).
 
@@ -52,7 +46,7 @@ Components state.
 
 -spec new(View, Assigns) -> t()
     when View :: view(),
-         Assigns :: assigns().
+         Assigns :: arizona_template_renderer:assigns().
 new(View, Assigns) ->
     #{
         view => View,
@@ -62,7 +56,7 @@ new(View, Assigns) ->
     }.
 
 -spec put_assigns(Assigns, Socket1) -> Socket2
-    when Assigns :: assigns(),
+    when Assigns :: arizona_template_renderer:assigns(),
          Socket1 :: t(),
          Socket2 :: t().
 put_assigns(Assigns, Socket) ->
@@ -85,11 +79,11 @@ put_assign(Key, Value, Socket) ->
             }
     end.
 
--spec get_assigns(t()) -> assigns().
+-spec get_assigns(t()) -> arizona_template_renderer:assigns().
 get_assigns(#{assigns := Assigns}) ->
     Assigns.
 
--spec get_changes(t()) -> changes().
+-spec get_changes(t()) -> arizona_template_renderer:assigns().
 get_changes(#{changes := Changes}) ->
     Changes.
 

--- a/src/arizona_template_compiler.erl
+++ b/src/arizona_template_compiler.erl
@@ -26,32 +26,29 @@
 -type macros() :: #{atom() := term()}.
 -export_type([macros/0]).
 
--type assigns() :: #{atom() := term()}.
--export_type([assigns/0]).
+-type changeable_id() :: [non_neg_integer()].
+-export_type([changeable_id/0]).
 
--opaque changeable() :: {expr, expr()} | {block, block()}.
--export_type([changeable/0]).
-
--opaque expr() :: #{
-    id := [non_neg_integer()],
-    function := fun((assigns()) -> arizona_html:safe_type()),
+-type expr() :: #{
+    id := changeable_id(),
+    function := fun((arizona_template_renderer:assigns()) -> arizona_html:safe_type()),
     vars := [atom()]
 }.
 -export_type([expr/0]).
 
--opaque block() :: #{
-    id := [non_neg_integer()],
+-type block() :: #{
+    id := changeable_id(),
     module := module(),
     function := atom(),
     static := [binary()],
-    changeable := #{non_neg_integer() := changeable()},
-    changeable_vars := #{atom() := [[non_neg_integer()]]},
+    changeable := #{non_neg_integer() := {expr, expr()} | {block, block()}},
+    changeable_vars := #{atom() := [changeable_id()]},
     changeable_indexes := [non_neg_integer()],
     norm_assigns := #{atom() := #{
-        function := fun((assigns()) -> term()),
+        function := fun((arizona_template_renderer:assigns()) -> term()),
         vars := [atom()]
     }},
-    norm_assigns_vars := [{atom(), [non_neg_integer()]}]
+    norm_assigns_vars := [{atom(), changeable_id()}]
 }.
 -export_type([block/0]).
 

--- a/src/arizona_template_renderer.erl
+++ b/src/arizona_template_renderer.erl
@@ -53,16 +53,8 @@ server_render(Block, Assigns) ->
          ChangesVars :: [atom()],
          Assigns :: assigns(),
          Changes :: [[arizona_template_compiler:changeable_id() | binary()]].
-% NOTE
-% The correct type for 'Changes' should be:
-% > [[arizona_template_compiler:changeable_id(), binary()]].
-% But Erlang does not allow a "fixed" list type.
-% Why this instead of a proplist, for example?
-% This struct will be sent to the client via JSON, and proplists are not encoded
-% out of the box. A list of lists is the low cost and more straightforward here.
 render_changes(Target, Block, ChangesVars, Assigns) ->
     case do_render_changes(Target, Block, ChangesVars, Assigns) of
-        % Ensures a list of lists.
         [_, Bin] = Changes when is_binary(Bin) ->
             [Changes];
         Changes ->

--- a/src/arizona_template_renderer.erl
+++ b/src/arizona_template_renderer.erl
@@ -74,9 +74,8 @@ render_changeable_indexes([], _, _) ->
 render_changeable({expr, Expr}, Assigns) ->
     render_expr(Expr, Assigns);
 render_changeable({block, Block}, Assigns0) ->
-    Id = maps:get(id, Block),
     Mod = maps:get(module, Block),
-    Socket0 = arizona_socket:new(Id, Mod, Assigns0),
+    Socket0 = arizona_socket:new(Mod, Assigns0),
     Socket = arizona_live_view:mount(Mod, Socket0),
     Assigns = arizona_socket:get_assigns(Socket),
     NormAssigns = maps:get(norm_assigns, Block),
@@ -119,15 +118,14 @@ server_render_changeable({block, Block}, Assigns, Pid) ->
     server_render_block(Block, ChangeableAssigns, Pid).
 
 server_render_block(Block, Assigns0, Pid) ->
-    Id = maps:get(id, Block),
     Mod = maps:get(module, Block),
-    Socket0 = arizona_socket:new(Id, Mod, Assigns0),
+    Socket0 = arizona_socket:new(Mod, Assigns0),
     Socket = arizona_live_view:mount(Mod, Socket0),
     Assigns = arizona_socket:get_assigns(Socket),
     ChangeableIndexes = maps:get(changeable_indexes, Block),
     Changeable = maps:get(changeable, Block),
     Dynamic = server_render_changeable_indexes(ChangeableIndexes, Changeable, Assigns, Pid),
-    Pid ! {self(), {socket, Id, Socket}},
+    Pid ! {self(), {socket, maps:get(id, Block), Socket}},
     [maps:get(static, Block), Dynamic].
 
 server_render_loop(Pid, Timeout, Sockets) ->
@@ -233,9 +231,9 @@ server_render_test() ->
            % Dynamic
            [<<"88">>]]
         ]],
-        #{[0] => arizona_socket:new([0], ?MODULE, #{count => 0}),
-          [0, 0] => arizona_socket:new([0, 0], ?MODULE, #{count => 0}),
-          [0, 1] => arizona_socket:new([0, 1], ?MODULE, #{count => 88})}
+        #{[0] => arizona_socket:new(?MODULE, #{count => 0}),
+          [0, 0] => arizona_socket:new(?MODULE, #{count => 0}),
+          [0, 1] => arizona_socket:new(?MODULE, #{count => 88})}
     }}, server_render(block(), #{count => 0})).
 
 render_changes_test() ->

--- a/src/arizona_template_renderer.erl
+++ b/src/arizona_template_renderer.erl
@@ -123,23 +123,23 @@ render_test() ->
           "</head>"
           "<body>"
             "<h1>Arizona Counter</h1>">>,
-            [<<"<div arizona-id=\"[0]\"><span>Count:">>, <<"0">>, <<"</span>"
-               "<button arizona-target=\"[0]\" type=\"button\" "
+            [<<"<div arizona-id=\"[0,0]\"><span>Count:">>, <<"0">>, <<"</span>"
+               "<button arizona-target=\"[0,0]\" type=\"button\" "
                "onclick=\"arizona.send.bind(this)('incr')\">Increment</button></div>">>],
              <<>>,
-            [<<"<div arizona-id=\"[1]\"><span>Count:">>, <<"88">>, <<"</span>"
-               "<button arizona-target=\"[1]\" type=\"button\" "
+            [<<"<div arizona-id=\"[0,1]\"><span>Count:">>, <<"88">>, <<"</span>"
+               "<button arizona-target=\"[0,1]\" type=\"button\" "
                "onclick=\"arizona.send.bind(this)('incr')\">Increment #2</button></div>">>],
           <<"</body></html>">>
     ], render(block(), #{count => 0})).
 
 render_changes_test() ->
     [
-        ?assertEqual([{[0, 0], <<"1">>}],
+        ?assertEqual([{[0, 0, 0], <<"1">>}],
                      render_changes([0], block(), [count], #{count => 1})),
-        ?assertEqual([{[0, 0], <<"1">>}],
+        ?assertEqual([{[0, 0, 0], <<"1">>}],
                      render_changes([0, 0], block(), [count], #{count => 1})),
-        ?assertEqual([{[1, 0], <<"1">>}],
+        ?assertEqual([{[0, 1, 0], <<"1">>}],
                      render_changes([1, 0], block(), [count], #{count => 1}))
     ].
 

--- a/src/arizona_template_renderer.erl
+++ b/src/arizona_template_renderer.erl
@@ -1,0 +1,206 @@
+-module(arizona_template_renderer).
+
+%% --------------------------------------------------------------------
+%% API function exports
+%% --------------------------------------------------------------------
+
+-export([render/2]).
+-export([render_changes/4]).
+
+%
+
+-ignore_xref([render/2]).
+-ignore_xref([render_changes/4]).
+
+%% --------------------------------------------------------------------
+%% Types (and their exports)
+%% --------------------------------------------------------------------
+
+-type assigns() :: #{atom() := term()}.
+-export_type([assigns/0]).
+
+%% --------------------------------------------------------------------
+%% API function definitions
+%% --------------------------------------------------------------------
+
+-spec render(Block, Assigns) -> Rendered
+    when Block :: map(), % TODO: arizona_template_compiler::block(),
+         Assigns :: assigns(),
+         Rendered :: [binary() | [binary()]].
+render(Block, Assigns) ->
+    Static = maps:get(static, Block),
+    ChangeableIndexes = maps:get(changeable_indexes, Block),
+    Changeable = maps:get(changeable, Block),
+    Dynamic = render_changeable_indexes(ChangeableIndexes, Changeable, Assigns),
+    zip(Static, Dynamic).
+
+-spec render_changes(Target, Block, ChangesVars, Assigns) -> Changes
+    when Target :: [non_neg_integer()], % TODO: arizona_template_compiler:changeable_id()
+         Block :: map(), % TODO: arizona_template_compiler::block(),
+         ChangesVars :: [atom()],
+         Assigns :: assigns(),
+         Changes :: [{[non_neg_integer()], binary()}].
+render_changes(Target, Block, ChangesVars, Assigns) ->
+    case do_render_changes(Target, Block, ChangesVars, Assigns) of
+        Changes when is_tuple(Changes) ->
+            [Changes];
+        Changes ->
+            Changes
+    end.
+
+%% --------------------------------------------------------------------
+%% Private
+%% --------------------------------------------------------------------
+
+render_changeable({expr, Expr}, Assigns) ->
+    render_expr(Expr, Assigns);
+render_changeable({block, Block}, Assigns) ->
+    NormAssigns = maps:get(norm_assigns, Block),
+    ChangeableAssigns = changeable_assigns(Assigns, NormAssigns),
+    render(Block, ChangeableAssigns).
+
+render_expr(Expr, Assigns) ->
+    Fun = maps:get(function, Expr),
+    arizona_html:to_safe(Fun(Assigns)).
+
+changeable_assigns(Assigns, NormAssigns) ->
+    #{K => Fun(Assigns) || K := #{function := Fun} <- NormAssigns}.
+
+render_changeable_indexes([Index | Indexes], Changeable, Assigns) ->
+    [render_changeable(maps:get(Index, Changeable), Assigns)
+     | render_changeable_indexes(Indexes, Changeable, Assigns)];
+render_changeable_indexes([], _, _) ->
+    [].
+
+zip([S | Static], [D | Dynamic]) ->
+    [S, D | zip(Static, Dynamic)];
+zip([S | Static], []) ->
+    [S | zip(Static, [])];
+zip([], [D | Dynamic]) ->
+    [D | zip([], Dynamic)];
+zip([], []) ->
+    [].
+
+do_render_changes([Index], Block, ChangesVars, Assigns) ->
+    Changeable = maps:get(changeable, Block),
+    render_changeable_changes(maps:get(Index, Changeable), ChangesVars, Assigns);
+do_render_changes([Index | Indexes], Block, ChangesVars, Assigns) ->
+    Changeable = maps:get(changeable, Block),
+    {block, NestedBlock} = maps:get(Index, Changeable),
+    do_render_changes(Indexes, NestedBlock, ChangesVars, Assigns).
+
+render_changeable_changes({expr, #{id := Id}  = Expr}, _ChangesVars, Assigns) ->
+    {Id, render_expr(Expr, Assigns)};
+render_changeable_changes({block, Block}, ChangesVars, Assigns) ->
+    render_block_changes(Block, ChangesVars, Assigns).
+
+render_block_changes(Block, AssignsKeys, Assigns) ->
+    NormAssigns = maps:get(norm_assigns, Block),
+    Changes = changeable_assigns(Assigns, maps:with(AssignsKeys, NormAssigns)),
+    ChangesVars = maps:keys(Changes),
+    ChangeableVars = maps:get(changeable_vars, Block),
+    Vars = maps:with(ChangesVars, ChangeableVars),
+    [Targets] = maps:values(Vars),
+    [do_render_changes(Target, Block, ChangesVars, Changes) || Target <- Targets].
+
+%% --------------------------------------------------------------------
+%% EUnit
+%% --------------------------------------------------------------------
+
+-ifdef(TEST).
+-compile([export_all, nowarn_export_all]).
+-include_lib("eunit/include/eunit.hrl").
+
+render_test() ->
+    ?assertEqual([
+        <<"<!DOCTYPE html=\"html\" />"
+          "<html lang=\"en\">"
+          "<head><meta charset=\"UTF-8\" />"
+            "<title>Arizona Framework</title>"
+            "<script src=\"assets/js/morphdom.min.js\">"
+            "</script><script src=\"assets/js/arizona.js\"></script>"
+            "<script src=\"assets/js/main.js\"></script>"
+          "</head>"
+          "<body>"
+            "<h1>Arizona Counter</h1>">>,
+            [<<"<div arizona-id=\"[0]\"><span>Count:">>, <<"0">>, <<"</span>"
+               "<button arizona-target=\"[0]\" type=\"button\" "
+               "onclick=\"arizona.send.bind(this)('incr')\">Increment</button></div>">>],
+             <<>>,
+            [<<"<div arizona-id=\"[1]\"><span>Count:">>, <<"88">>, <<"</span>"
+               "<button arizona-target=\"[1]\" type=\"button\" "
+               "onclick=\"arizona.send.bind(this)('incr')\">Increment #2</button></div>">>],
+          <<"</body></html>">>
+    ], render(block(), #{count => 0})).
+
+render_changes_test() ->
+    [
+        ?assertEqual([{[0, 0], <<"1">>}],
+                     render_changes([0], block(), [count], #{count => 1})),
+        ?assertEqual([{[0, 0], <<"1">>}],
+                     render_changes([0, 0], block(), [count], #{count => 1})),
+        ?assertEqual([{[1, 0], <<"1">>}],
+                     render_changes([1, 0], block(), [count], #{count => 1}))
+    ].
+
+%% --------------------------------------------------------------------
+%% Test support
+%% --------------------------------------------------------------------
+
+block() ->
+    Macros = #{
+        title => ~"Arizona Framework",
+        inc_btn_text => ~"Increment #2"
+    },
+    {ok, Block} = arizona_template_compiler:compile(?MODULE, render, Macros),
+    Block.
+
+render(Macros) ->
+    maybe_parse(~"""
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <title>{_@title}</title>
+        <script src="assets/js/main.js"></script>
+    </head>
+    <body>
+        <h1>Arizona Counter</h1>
+        <.counter
+            count={_@count}
+            btn_text="Increment"
+        />
+        <.counter
+            count={88}
+            btn_text={_@inc_btn_text}
+        />
+    </body>
+    </html>
+    """, Macros).
+
+counter(Macros) ->
+    maybe_parse(~"""
+    <div :stateful>
+        <span>Count: {_@count}</span>
+        <.button event="incr" text={_@btn_text} />
+    </div>
+    """, Macros).
+
+button(Macros) ->
+    maybe_parse(~"""
+    <button type="button" :onclick={arizona_js:send(_@event)}>
+        {_@text}
+    </button>
+    """, Macros).
+
+maybe_parse(Template, Macros) ->
+    maybe
+        {ok, Tokens} ?= arizona_template_scanner:scan(Template),
+        {ok, Elems} ?= arizona_template_parser:parse(Tokens),
+        {ok, {Elems, Macros}}
+    else
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+-endif.

--- a/src/arizona_template_renderer.erl
+++ b/src/arizona_template_renderer.erl
@@ -28,11 +28,10 @@
          Assigns :: assigns(),
          Rendered :: [binary() | [binary()]].
 render(Block, Assigns) ->
-    Static = maps:get(static, Block),
     ChangeableIndexes = maps:get(changeable_indexes, Block),
     Changeable = maps:get(changeable, Block),
     Dynamic = render_changeable_indexes(ChangeableIndexes, Changeable, Assigns),
-    zip(Static, Dynamic).
+    zip(maps:get(static, Block), Dynamic).
 
 -spec render_changes(Target, Block, ChangesVars, Assigns) -> Changes
     when Target :: arizona_template_compiler:changeable_id(),
@@ -52,6 +51,12 @@ render_changes(Target, Block, ChangesVars, Assigns) ->
 %% Private
 %% --------------------------------------------------------------------
 
+render_changeable_indexes([Index | Indexes], Changeable, Assigns) ->
+    [render_changeable(maps:get(Index, Changeable), Assigns)
+     | render_changeable_indexes(Indexes, Changeable, Assigns)];
+render_changeable_indexes([], _, _) ->
+    [].
+
 render_changeable({expr, Expr}, Assigns) ->
     render_expr(Expr, Assigns);
 render_changeable({block, Block}, Assigns) ->
@@ -65,12 +70,6 @@ render_expr(Expr, Assigns) ->
 
 changeable_assigns(Assigns, NormAssigns) ->
     #{K => Fun(Assigns) || K := #{function := Fun} <- NormAssigns}.
-
-render_changeable_indexes([Index | Indexes], Changeable, Assigns) ->
-    [render_changeable(maps:get(Index, Changeable), Assigns)
-     | render_changeable_indexes(Indexes, Changeable, Assigns)];
-render_changeable_indexes([], _, _) ->
-    [].
 
 zip([S | Static], [D | Dynamic]) ->
     [S, D | zip(Static, Dynamic)];

--- a/src/arizona_template_renderer.erl
+++ b/src/arizona_template_renderer.erl
@@ -24,7 +24,7 @@
 %% --------------------------------------------------------------------
 
 -spec render(Block, Assigns) -> Rendered
-    when Block :: map(), % TODO: arizona_template_compiler::block(),
+    when Block :: arizona_template_compiler:block(),
          Assigns :: assigns(),
          Rendered :: [binary() | [binary()]].
 render(Block, Assigns) ->
@@ -35,11 +35,11 @@ render(Block, Assigns) ->
     zip(Static, Dynamic).
 
 -spec render_changes(Target, Block, ChangesVars, Assigns) -> Changes
-    when Target :: [non_neg_integer()], % TODO: arizona_template_compiler:changeable_id()
-         Block :: map(), % TODO: arizona_template_compiler::block(),
+    when Target :: arizona_template_compiler:changeable_id(),
+         Block :: arizona_template_compiler:block(),
          ChangesVars :: [atom()],
          Assigns :: assigns(),
-         Changes :: [{[non_neg_integer()], binary()}].
+         Changes :: [{arizona_template_compiler:changeable_id(), binary()}].
 render_changes(Target, Block, ChangesVars, Assigns) ->
     case do_render_changes(Target, Block, ChangesVars, Assigns) of
         Changes when is_tuple(Changes) ->

--- a/src/arizona_template_renderer.erl
+++ b/src/arizona_template_renderer.erl
@@ -70,7 +70,12 @@ render_changeable_indexes([], _, _) ->
 
 render_changeable({expr, Expr}, Assigns) ->
     render_expr(Expr, Assigns);
-render_changeable({block, Block}, Assigns) ->
+render_changeable({block, Block}, Assigns0) ->
+    Id = maps:get(id, Block),
+    Mod = maps:get(module, Block),
+    Socket0 = arizona_socket:new(Id, Mod, Assigns0),
+    Socket = arizona_live_view:mount(Mod, Socket0),
+    Assigns = arizona_socket:get_assigns(Socket),
     NormAssigns = maps:get(norm_assigns, Block),
     ChangeableAssigns = changeable_assigns(Assigns, NormAssigns),
     render(Block, ChangeableAssigns).

--- a/src/arizona_template_renderer.erl
+++ b/src/arizona_template_renderer.erl
@@ -47,14 +47,14 @@ server_render(Block, Assigns) ->
     Timeout = 5_000,
     server_render_loop(Pid, Timeout, _Sockets = []).
 
--spec render_changes(Target, Block, ChangesVars, Assigns) -> Changes
+-spec render_changes(Target, Block, ChangedVars, Assigns) -> Changes
     when Target :: arizona_template_compiler:changeable_id(),
          Block :: arizona_template_compiler:block(),
-         ChangesVars :: [atom()],
+         ChangedVars :: [atom()],
          Assigns :: assigns(),
          Changes :: [[arizona_template_compiler:changeable_id() | binary()]].
-render_changes(Target, Block, ChangesVars, Assigns) ->
-    case do_render_changes(Target, Block, ChangesVars, Assigns) of
+render_changes(Target, Block, ChangedVars, Assigns) ->
+    case do_render_changes(Target, Block, ChangedVars, Assigns) of
         [_, Bin] = Changes when is_binary(Bin) ->
             [Changes];
         Changes ->
@@ -139,27 +139,27 @@ server_render_loop(Pid, Timeout, Sockets) ->
             {error, timeout}
     end.
 
-do_render_changes([Index], Block, ChangesVars, Assigns) ->
+do_render_changes([Index], Block, ChangedVars, Assigns) ->
     Changeable = maps:get(changeable, Block),
-    render_changeable_changes(maps:get(Index, Changeable), ChangesVars, Assigns);
-do_render_changes([Index | Indexes], Block, ChangesVars, Assigns) ->
+    render_changeable_changes(maps:get(Index, Changeable), ChangedVars, Assigns);
+do_render_changes([Index | Indexes], Block, ChangedVars, Assigns) ->
     Changeable = maps:get(changeable, Block),
     {block, NestedBlock} = maps:get(Index, Changeable),
-    do_render_changes(Indexes, NestedBlock, ChangesVars, Assigns).
+    do_render_changes(Indexes, NestedBlock, ChangedVars, Assigns).
 
-render_changeable_changes({expr, #{id := Id}  = Expr}, _ChangesVars, Assigns) ->
+render_changeable_changes({expr, #{id := Id}  = Expr}, _ChangedVars, Assigns) ->
     [Id, render_expr(Expr, Assigns)];
-render_changeable_changes({block, Block}, ChangesVars, Assigns) ->
-    render_block_changes(Block, ChangesVars, Assigns).
+render_changeable_changes({block, Block}, ChangedVars, Assigns) ->
+    render_block_changes(Block, ChangedVars, Assigns).
 
 render_block_changes(Block, AssignsKeys, Assigns) ->
     NormAssigns = maps:get(norm_assigns, Block),
     Changes = changeable_assigns(Assigns, maps:with(AssignsKeys, NormAssigns)),
-    ChangesVars = maps:keys(Changes),
+    ChangedVars = maps:keys(Changes),
     ChangeableVars = maps:get(changeable_vars, Block),
-    Vars = maps:with(ChangesVars, ChangeableVars),
+    Vars = maps:with(ChangedVars, ChangeableVars),
     [Targets] = maps:values(Vars),
-    [do_render_changes(Target, Block, ChangesVars, Changes) || Target <- Targets].
+    [do_render_changes(Target, Block, ChangedVars, Changes) || Target <- Targets].
 
 %% --------------------------------------------------------------------
 %% EUnit

--- a/src/arizona_tpl_render.erl
+++ b/src/arizona_tpl_render.erl
@@ -25,8 +25,8 @@ Renderer.
 -spec render_target(Target, Block, Changes, Assigns) -> Rendered
     when Target :: root | json:decode_value(),
          Block :: arizona_tpl_compile:block(),
-         Changes :: arizona_socket:changes(),
-         Assigns :: arizona_socket:assigns(),
+         Changes :: arizona_template_renderer:assigns(),
+         Assigns :: arizona_template_renderer:assigns(),
          Rendered :: iolist().
 render_target(Target, Block, Changes, Assigns) when map_size(Changes) > 0 ->
     render_target_1(Target, Block, Changes, Assigns);
@@ -46,7 +46,7 @@ render_target_2([H | T], Block, Changes, Assigns) ->
 
 -spec render_block(Block, Assigns) -> Rendered
     when Block :: arizona_tpl_compile:block(),
-         Assigns :: arizona_socket:assigns(),
+         Assigns :: arizona_template_renderer:assigns(),
          Rendered :: iolist().
 render_block(Block, Assigns0) ->
     View = maps:get(view, Block),
@@ -59,7 +59,7 @@ render_block(Block, Assigns0) ->
 
 -spec mount(Block, Assigns) -> {Rendered, Sockets}
     when Block :: arizona_tpl_compile:block(),
-         Assigns :: arizona_socket:assigns(),
+         Assigns :: arizona_template_renderer:assigns(),
          Rendered :: iolist(),
          Sockets :: #{SocketId :: socket_target() := Socket :: arizona_socket:t()}.
 mount(#{id := Id, view := View} = Block, Assigns0) ->


### PR DESCRIPTION
# Description

This PR implements a new renderer called `arizona_template_renderer`. It will replace `arizona_tpl_render`.

Closes #166, closes #175.

## Further considerations

- The renderer module requires the `assigns()` type to render a template. Currently, the assigns type lives in `arizona_socket`, but I consider the renderer module "low-level" compared to the socket module, so I decided to define the assigns type in the new renderer module 
- To keep things simpler, I changed `expr` and `block` opaques to types
- To give more context to the implementation, the `client_render` function is called by the client to render a page via HTTP request, and `server_render` is called by the server via `arizona_websocket` to render the page and also stores all stateful blocks state. 
- ~~This PR will conflict with https://github.com/arizona-framework/arizona/pull/174~~ _It has been resolved_
- There is a small fix for the new compiler in [e19a077](https://github.com/arizona-framework/arizona/pull/168/commits/e19a077192f40e41395a8868fc86519a7275144f)

**EDIT**

I'm accepting function name suggestions :laughing: 

---

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
