### PR TITLE
Add required `rebar3 release` element

### DIFF
--- a/src/arizona.app.src
+++ b/src/arizona.app.src
@@ -6,6 +6,7 @@
         % OTP dependencies
         kernel,
         stdlib,
+        syntax_tools,
         % External dependencies
         cowboy,
         fs,


### PR DESCRIPTION
# Description

`merl` lives inside `syntax_tools`, and without this `arizona_example` cannot create a release and test it.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
