### PR TITLE
Create a Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+.PHONY: ci
+
+ci:
+	rebar3 ci
+	npm run ci


### PR DESCRIPTION
# Description

I always forget to run the npm CI command, and I think it's better to combine multiple related commands into one. Therefore, I'd like to suggest considering implementing a Makefile for this purpose. To run both CI commands, simply run `make` or `make ci`.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
