### PR TITLE
Introduce a new template scanner

### DIFF
--- a/elvis.config
+++ b/elvis.config
@@ -25,15 +25,19 @@
                 filter => "*.erl",
                 ruleset => erl_files_strict,
                 rules => [
-                    {elvis_style, no_macros, #{
-                        allow => []
-                    }},
                     {elvis_style, atom_naming_convention, #{
                         regex => "^[a-z][a-z_@0-9]*(_SUITE)?$"
                     }},
                     {elvis_style, function_naming_convention, #{
                         regex => "^[a-z][a-z_0-9]*(_SUITE)?$"
-                    }}
+                    }},
+                    {elvis_style, no_macros, #{
+                        allow => [
+                            'assertEqual',
+                            'assertError'
+                        ]
+                    }},
+                    {elvis_style, max_function_length, disable}
                 ]
             },
             #{

--- a/src/arizona_tpl_scanner.erl
+++ b/src/arizona_tpl_scanner.erl
@@ -1,0 +1,196 @@
+-module(arizona_tpl_scanner).
+
+%% --------------------------------------------------------------------
+%% API function exports
+%% --------------------------------------------------------------------
+
+-export([scan/2]).
+
+%
+
+-ignore_xref([scan/2]).
+
+%% --------------------------------------------------------------------
+%% Types (and their exports)
+%% --------------------------------------------------------------------
+
+-type scan_opts() :: #{
+    line => pos_integer(),
+    column => pos_integer(),
+    indentation => non_neg_integer()
+}.
+-export_type([scan_opts/0]).
+
+-type token() :: {
+    Category :: html | erlang | comment,
+    Location :: {Line :: pos_integer(), Column :: pos_integer()},
+    Content :: binary()
+}.
+-export_type([token/0]).
+
+%% --------------------------------------------------------------------
+%% Private types
+%% --------------------------------------------------------------------
+
+-record(state, {
+    line :: pos_integer(),
+    column :: pos_integer(),
+    indentation :: non_neg_integer(),
+    position :: non_neg_integer()
+}).
+
+%% --------------------------------------------------------------------
+%% API function definitions
+%% --------------------------------------------------------------------
+
+-doc ~"""
+Tokenizes a template.
+
+## Examples
+
+```
+> arizona_tpl_scanner:scan(~"foo{bar}{% baz }").
+[{html,{1,1},<<"foo">>},
+ {erlang,{1,4},<<"bar">>},
+ {comment,{1,9},<<"baz">>}]
+```
+
+## Result
+
+It returns `[Token]` where a Token is one of:
+
+- `{html, Location, Content}`
+- `{erlang, Location, Content}`
+- `{comment, Location, Content}`
+""".
+-spec scan(Opts, Template) -> [Token] when
+    Opts :: scan_opts(),
+    Template :: binary(),
+    Token :: token().
+scan(Opts, Template) when is_map(Opts), is_binary(Template) ->
+    State = #state{
+        line = maps:get(line, Opts, 1),
+        column = maps:get(column, Opts, 1 + maps:get(indentation, Opts, 0)),
+        indentation = maps:get(indentation, Opts, 0),
+        position = 0
+    },
+    scan(Template, Template, State).
+
+%% --------------------------------------------------------------------
+%% Private functions
+%% --------------------------------------------------------------------
+
+scan(Rest, Bin, State) ->
+    scan(Rest, Bin, 0, State, State).
+
+scan(<<${, Rest/binary>>, Bin, Len, TextState, State) ->
+    ExprTokens = scan_expr(Rest, Bin, 1, incr_pos(Len + 1, State)),
+    maybe_prepend_text_token(Bin, Len, TextState, ExprTokens);
+scan(<<$\r, $\n, Rest/binary>>, Bin, Len, TextState, State) ->
+    scan(Rest, Bin, Len + 2, TextState, new_line(State));
+scan(<<$\r, Rest/binary>>, Bin, Len, TextState, State) ->
+    scan(Rest, Bin, Len + 1, TextState, new_line(State));
+scan(<<$\n, Rest/binary>>, Bin, Len, TextState, State) ->
+    scan(Rest, Bin, Len + 1, TextState, new_line(State));
+scan(<<_, Rest/binary>>, Bin, Len, TextState, State) ->
+    scan(Rest, Bin, Len + 1, TextState, incr_col(1, State));
+scan(<<>>, Bin, Len, TextState, _State) ->
+    maybe_prepend_text_token(Bin, Len, TextState, []).
+
+maybe_prepend_text_token(Bin, Len, State, Tokens) ->
+    case string:trim(binary_part(Bin, State#state.position, Len)) of
+        <<>> ->
+            Tokens;
+        Text ->
+            [{html, location(State), Text} | Tokens]
+    end.
+
+scan_expr(Rest0, Bin, StartMarkerLen, State0) ->
+    {Len, EndMarkerLen, State1, Rest1} = scan_expr_end(Rest0, 0, 0, State0),
+    Expr0 = binary_part(Bin, State0#state.position, Len),
+    {Expr, Category} = expr_category(Expr0, State0),
+    case maybe_skip_new_line(Rest1) of
+        {true, NLMarkerLen, Rest} ->
+            State = new_line(incr_pos(Len + EndMarkerLen + NLMarkerLen, State1)),
+            [{Category, location(State0), Expr} | scan(Rest, Bin, State)];
+        false ->
+            State = incr_col(StartMarkerLen, incr_pos(Len + EndMarkerLen, State1)),
+            [{Category, location(State0), Expr} | scan(Rest1, Bin, State)]
+    end.
+
+scan_expr_end(<<$}, Rest/binary>>, 0, Len, State) ->
+    {Len, _MarkerLen = 1, incr_col(1, State), Rest};
+scan_expr_end(<<$}, Rest/binary>>, Depth, Len, State) ->
+    scan_expr_end(Rest, Depth - 1, Len + 1, incr_col(1, State));
+scan_expr_end(<<${, Rest/binary>>, Depth, Len, State) ->
+    scan_expr_end(Rest, Depth + 1, Len + 1, incr_col(1, State));
+scan_expr_end(<<$\r, $\n, Rest/binary>>, Depth, Len, State) ->
+    scan_expr_end(Rest, Depth, Len + 2, new_line(State));
+scan_expr_end(<<$\r, Rest/binary>>, Depth, Len, State) ->
+    scan_expr_end(Rest, Depth, Len + 1, new_line(State));
+scan_expr_end(<<$\n, Rest/binary>>, Depth, Len, State) ->
+    scan_expr_end(Rest, Depth, Len + 1, new_line(State));
+scan_expr_end(<<_, Rest/binary>>, Depth, Len, State) ->
+    scan_expr_end(Rest, Depth, Len + 1, incr_col(1, State));
+scan_expr_end(<<>>, _Depth, Len, State) ->
+    error({unexpected_expr_end, location(incr_pos(Len, State))}).
+
+maybe_skip_new_line(<<$\r, $\n, Rest/binary>>) ->
+    {true, 2, Rest};
+maybe_skip_new_line(<<$\r, Rest/binary>>) ->
+    {true, 1, Rest};
+maybe_skip_new_line(<<$\n, Rest/binary>>) ->
+    {true, 1, Rest};
+maybe_skip_new_line(_Rest) ->
+    false.
+
+expr_category(Expr, State) ->
+    try
+        case merl:quote(Expr) of
+            Forms when is_list(Forms) ->
+                case lists:all(fun is_comment/1, Forms) of
+                    true ->
+                        Comments0 = re:split(Expr, <<"\\n">>, [{return, binary}, {newline, lf}]),
+                        Comments1 = [norm_comment(Comment) || Comment <- Comments0],
+                        Comment = iolist_to_binary(lists:join("\n", Comments1)),
+                        {Comment, comment};
+                    false ->
+                        {Expr, erlang}
+                end;
+            Form ->
+                case is_comment(Form) of
+                    true ->
+                        {norm_comment(Expr), comment};
+                    false ->
+                        {Expr, erlang}
+                end
+        end
+    catch
+        _:_ ->
+            error({badexpr, location(State), Expr})
+    end.
+
+is_comment(Form) ->
+    erl_syntax:type(Form) =:= comment.
+
+norm_comment(<<$%, Rest/binary>>) ->
+    norm_comment(Rest);
+norm_comment(<<$\s, Rest/binary>>) ->
+    norm_comment(Rest);
+norm_comment(Comment) ->
+    string:trim(Comment, trailing).
+
+new_line(#state{line = Ln} = State) ->
+    State#state{line = Ln + 1, column = 1 + State#state.indentation}.
+
+incr_col(N, #state{column = Col} = State) ->
+    State#state{column = Col + N}.
+
+incr_pos(N, #state{position = Pos} = State) ->
+    State#state{position = Pos + N}.
+
+location(#state{line = Ln, column = Col}) ->
+    location(Ln, Col).
+
+location(Ln, Col) ->
+    {Ln, Col}.

--- a/test/arizona_tpl_scanner_SUITE.erl
+++ b/test/arizona_tpl_scanner_SUITE.erl
@@ -1,0 +1,181 @@
+-module(arizona_tpl_scanner_SUITE).
+-behaviour(ct_suite).
+-include_lib("stdlib/include/assert.hrl").
+-compile([export_all, nowarn_export_all]).
+
+%% --------------------------------------------------------------------
+%% Behaviour (ct_suite) callbacks
+%% --------------------------------------------------------------------
+
+all() ->
+    [{group, scan}].
+
+groups() ->
+    [
+        {scan, [parallel], [
+            scan,
+            scan_html,
+            scan_erlang,
+            scan_comment,
+            scan_start_html_end_html,
+            scan_start_html_end_erlang,
+            scan_start_erlang_end_html,
+            scan_start_erlang_end_erlang,
+            scan_new_line_cr,
+            scan_new_line_crlf,
+            scan_error_unexpected_expr_end,
+            scan_error_badexpr
+        ]}
+    ].
+
+%% --------------------------------------------------------------------
+%% Tests
+%% --------------------------------------------------------------------
+
+scan(Config) when is_list(Config) ->
+    Expect = [
+        {comment, {59, 5}, ~"start"},
+        {html, {60, 5}, ~"Text1"},
+        {erlang, {61, 5}, ~"{{{expr1}}}"},
+        {comment, {62, 5}, ~"before text"},
+        {html, {62, 20}, ~"Text2\nText3"},
+        {comment, {63, 10}, ~"after text"},
+        {comment, {64, 5}, ~"before expr"},
+        {erlang, {64, 21}, ~"expr2"},
+        {erlang, {65, 5}, ~"expr3"},
+        {comment, {65, 12}, ~"after expr"},
+        {html, {66, 5}, ~"Text4"},
+        {comment, {66, 10}, ~"between text"},
+        {html, {66, 26}, ~"Text5"},
+        {erlang, {67, 5}, ~"expr4"},
+        {comment, {67, 12}, ~"between expr"},
+        {erlang, {67, 28}, ~"expr5"},
+        {comment, {68, 5}, ~"mutiple\nlines of\ncomment"},
+        {erlang, {71, 5}, ~"expr6"},
+        {erlang, {71, 12}, ~"Foo = foo, case Foo of foo -> {foo, expr7}; _ -> expr7 end"},
+        {comment, {72, 5}, ~"end"}
+    ],
+    Got = arizona_tpl_scanner:scan(#{line => ?LINE + 1, indentation => 4}, ~"""
+    {%   start  }
+    Text1
+    {{{{expr1}}}}
+    {%before text }Text2
+    Text3{% after text}
+    {% before expr }{expr2}
+    {expr3}{%after expr}
+    Text4{%between text }Text5
+    {expr4}{% between expr}{expr5}
+    {% mutiple
+     % lines of
+     % comment}
+    {expr6}{Foo = foo, case Foo of foo -> {foo, expr7}; _ -> expr7 end}
+    {%end}
+    """),
+    ?assertEqual(Expect, Got).
+
+scan_html(Config) when is_list(Config) ->
+    Expect = [{html, {1, 1}, ~"Text1"}],
+    Got = arizona_tpl_scanner:scan(#{}, ~"""
+    Text1
+    """),
+    ?assertEqual(Expect, Got).
+
+scan_erlang(Config) when is_list(Config) ->
+    Expect = [{erlang, {1, 1}, ~"expr1"}],
+    Got = arizona_tpl_scanner:scan(#{}, ~"""
+    {expr1}
+    """),
+    ?assertEqual(Expect, Got).
+
+scan_comment(Config) when is_list(Config) ->
+    Expect = [{comment, {1, 1}, ~"comment"}],
+    Got = arizona_tpl_scanner:scan(#{}, ~"""
+    {% comment }
+    """),
+    ?assertEqual(Expect, Got).
+
+scan_start_html_end_html(Config) when is_list(Config) ->
+    Expect = [
+        {html, {104, 5}, ~"Text1\nText2"},
+        {erlang, {105, 10}, ~"expr1"},
+        {html, {105, 17}, ~"Text3\nText4"}
+    ],
+    Got = arizona_tpl_scanner:scan(#{line => ?LINE + 1, indentation => 4}, ~"""
+    Text1
+    Text2{expr1}Text3
+    Text4
+    """),
+    ?assertEqual(Expect, Got).
+
+scan_start_html_end_erlang(Config) when is_list(Config) ->
+    Expect = [
+        {html, {118, 5}, ~"Text1\nText2"},
+        {erlang, {119, 10}, ~"expr1"},
+        {html, {119, 17}, ~"Text3\nText4"},
+        {erlang, {121, 5}, ~"expr2"}
+    ],
+    Got = arizona_tpl_scanner:scan(#{line => ?LINE + 1, indentation => 4}, ~"""
+    Text1
+    Text2{expr1}Text3
+    Text4
+    {expr2}
+    """),
+    ?assertEqual(Expect, Got).
+
+scan_start_erlang_end_html(Config) when is_list(Config) ->
+    Expect = [
+        {erlang, {133, 5}, ~"expr1"},
+        {html, {134, 5}, ~"Text1\nText2"},
+        {erlang, {135, 10}, ~"expr2"},
+        {html, {135, 17}, ~"Text3\nText4"}
+    ],
+    Got = arizona_tpl_scanner:scan(#{line => ?LINE + 1, indentation => 4}, ~"""
+    {expr1}
+    Text1
+    Text2{expr2}Text3
+    Text4
+    """),
+    ?assertEqual(Expect, Got).
+
+scan_start_erlang_end_erlang(Config) when is_list(Config) ->
+    Expect = [
+        {erlang, {149, 5}, ~"expr1"},
+        {html, {150, 5}, ~"Text1\nText2"},
+        {erlang, {151, 10}, ~"expr2"},
+        {html, {151, 17}, ~"Text3\nText4"},
+        {erlang, {153, 5}, ~"expr3"}
+    ],
+    Got = arizona_tpl_scanner:scan(#{line => ?LINE + 1, indentation => 4}, ~"""
+    {expr1}
+    Text1
+    Text2{expr2}Text3
+    Text4
+    {expr3}
+    """),
+    ?assertEqual(Expect, Got).
+
+scan_new_line_cr(Config) when is_list(Config) ->
+    Expect = [
+        {html, {1, 1}, ~"1"},
+        {erlang, {2, 1}, ~"[2,\r3]"},
+        {html, {4, 1}, ~"4"}
+    ],
+    Got = arizona_tpl_scanner:scan(#{}, ~"1\r{[2,\r3]}\r4"),
+    ?assertEqual(Expect, Got).
+
+scan_new_line_crlf(Config) when is_list(Config) ->
+    Expect = [
+        {html, {1, 1}, ~"1"},
+        {erlang, {2, 1}, ~"[2,\r\n3]"},
+        {html, {4, 1}, ~"4"}
+    ],
+    Got = arizona_tpl_scanner:scan(#{}, ~"1\r\n{[2,\r\n3]}\r\n4"),
+    ?assertEqual(Expect, Got).
+
+scan_error_unexpected_expr_end(Config) when is_list(Config) ->
+    Error = {unexpected_expr_end, {1, 6}},
+    ?assertError(Error, arizona_tpl_scanner:scan(#{}, ~"{error")).
+
+scan_error_badexpr(Config) when is_list(Config) ->
+    Error = {badexpr, {1, 1}, ~"[error"},
+    ?assertError(Error, arizona_tpl_scanner:scan(#{}, ~"{[error}")).


### PR DESCRIPTION
# Description

This PR introduces a new simple scanner that tokenizes the template into `html`, `erlang`, or `comment`.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
