### PR TITLE
Remove `tpl` from scanner and parser modules name

### DIFF
--- a/src/arizona_parser.erl
+++ b/src/arizona_parser.erl
@@ -1,4 +1,4 @@
--module(arizona_tpl_parser).
+-module(arizona_parser).
 
 %% --------------------------------------------------------------------
 %% API function exports
@@ -20,9 +20,9 @@ Parses scanned template tokens.
 ## Examples
 
 ```
-> Tokens = arizona_tpl_scanner:scan(#{}, ~"foo{bar}").
+> Tokens = arizona_scanner:scan(#{}, ~"foo{bar}").
 [{html,{1,1},<<"foo">>},{erlang,{1,4},<<"bar">>}]
-> arizona_tpl_parser:parse(Tokens).
+> arizona_parser:parse(Tokens).
 {[{bin,1,[{bin_element,1,{string,1,"foo"},default,[utf8]}]}],[{atom,1,bar}]}
 ```
 
@@ -33,7 +33,7 @@ binaries and the Dynamic is an AST list of Erlang terms.
 """.
 -spec parse(Tokens) -> {Static, Dynamic} when
     Tokens :: [Token],
-    Token :: arizona_tpl_scanner:token(),
+    Token :: arizona_scanner:token(),
     Static :: [Ast],
     Dynamic :: [Ast],
     Ast :: tuple().

--- a/src/arizona_render.erl
+++ b/src/arizona_render.erl
@@ -53,8 +53,8 @@ put_rendered(Value, View0, Socket) ->
     {View, Socket}.
 
 parse_template(Bindings, Template) ->
-    Tokens = arizona_tpl_scanner:scan(#{}, Template),
-    {StaticAst, DynamicAst} = arizona_tpl_parser:parse(Tokens),
+    Tokens = arizona_scanner:scan(#{}, Template),
+    {StaticAst, DynamicAst} = arizona_parser:parse(Tokens),
     Static = eval_static_ast(StaticAst),
     Dynamic = eval_dynamic_ast(Bindings, DynamicAst),
     {Static, Dynamic}.

--- a/src/arizona_scanner.erl
+++ b/src/arizona_scanner.erl
@@ -1,4 +1,4 @@
--module(arizona_tpl_scanner).
+-module(arizona_scanner).
 
 %% --------------------------------------------------------------------
 %% API function exports
@@ -49,7 +49,7 @@ Tokenizes a template.
 ## Examples
 
 ```
-> arizona_tpl_scanner:scan(~"foo{bar}{% baz }").
+> arizona_scanner:scan(~"foo{bar}{% baz }").
 [{html,{1,1},<<"foo">>},
  {erlang,{1,4},<<"bar">>},
  {comment,{1,9},<<"baz">>}]

--- a/test/arizona_parser_SUITE.erl
+++ b/test/arizona_parser_SUITE.erl
@@ -1,4 +1,4 @@
--module(arizona_tpl_parser_SUITE).
+-module(arizona_parser_SUITE).
 -behaviour(ct_suite).
 -include_lib("stdlib/include/assert.hrl").
 -compile([export_all, nowarn_export_all]).
@@ -35,8 +35,8 @@ parse(Config) when is_list(Config) ->
             {cons, 1, {atom, 1, bar}, {nil, 1}}
         ]
     },
-    Tokens = arizona_tpl_scanner:scan(#{}, ~"""
+    Tokens = arizona_scanner:scan(#{}, ~"""
     foo{foo}{{bar}}{% drop this }bar{[bar]}qu"o"t\"ed
     """),
-    Got = arizona_tpl_parser:parse(Tokens),
+    Got = arizona_parser:parse(Tokens),
     ?assertEqual(Expect, Got).

--- a/test/arizona_scanner_SUITE.erl
+++ b/test/arizona_scanner_SUITE.erl
@@ -1,4 +1,4 @@
--module(arizona_tpl_scanner_SUITE).
+-module(arizona_scanner_SUITE).
 -behaviour(ct_suite).
 -include_lib("stdlib/include/assert.hrl").
 -compile([export_all, nowarn_export_all]).
@@ -55,7 +55,7 @@ scan(Config) when is_list(Config) ->
         {erlang, {71, 12}, ~"Foo = foo, case Foo of foo -> {foo, expr7}; _ -> expr7 end"},
         {comment, {72, 5}, ~"end"}
     ],
-    Got = arizona_tpl_scanner:scan(#{line => ?LINE + 1, indentation => 4}, ~"""
+    Got = arizona_scanner:scan(#{line => ?LINE + 1, indentation => 4}, ~"""
     {%   start  }
     Text1
     {{{{expr1}}}}
@@ -75,21 +75,21 @@ scan(Config) when is_list(Config) ->
 
 scan_html(Config) when is_list(Config) ->
     Expect = [{html, {1, 1}, ~"Text1"}],
-    Got = arizona_tpl_scanner:scan(#{}, ~"""
+    Got = arizona_scanner:scan(#{}, ~"""
     Text1
     """),
     ?assertEqual(Expect, Got).
 
 scan_erlang(Config) when is_list(Config) ->
     Expect = [{erlang, {1, 1}, ~"expr1"}],
-    Got = arizona_tpl_scanner:scan(#{}, ~"""
+    Got = arizona_scanner:scan(#{}, ~"""
     {expr1}
     """),
     ?assertEqual(Expect, Got).
 
 scan_comment(Config) when is_list(Config) ->
     Expect = [{comment, {1, 1}, ~"comment"}],
-    Got = arizona_tpl_scanner:scan(#{}, ~"""
+    Got = arizona_scanner:scan(#{}, ~"""
     {% comment }
     """),
     ?assertEqual(Expect, Got).
@@ -100,7 +100,7 @@ scan_start_html_end_html(Config) when is_list(Config) ->
         {erlang, {105, 10}, ~"expr1"},
         {html, {105, 17}, ~"Text3\nText4"}
     ],
-    Got = arizona_tpl_scanner:scan(#{line => ?LINE + 1, indentation => 4}, ~"""
+    Got = arizona_scanner:scan(#{line => ?LINE + 1, indentation => 4}, ~"""
     Text1
     Text2{expr1}Text3
     Text4
@@ -114,7 +114,7 @@ scan_start_html_end_erlang(Config) when is_list(Config) ->
         {html, {119, 17}, ~"Text3\nText4"},
         {erlang, {121, 5}, ~"expr2"}
     ],
-    Got = arizona_tpl_scanner:scan(#{line => ?LINE + 1, indentation => 4}, ~"""
+    Got = arizona_scanner:scan(#{line => ?LINE + 1, indentation => 4}, ~"""
     Text1
     Text2{expr1}Text3
     Text4
@@ -129,7 +129,7 @@ scan_start_erlang_end_html(Config) when is_list(Config) ->
         {erlang, {135, 10}, ~"expr2"},
         {html, {135, 17}, ~"Text3\nText4"}
     ],
-    Got = arizona_tpl_scanner:scan(#{line => ?LINE + 1, indentation => 4}, ~"""
+    Got = arizona_scanner:scan(#{line => ?LINE + 1, indentation => 4}, ~"""
     {expr1}
     Text1
     Text2{expr2}Text3
@@ -145,7 +145,7 @@ scan_start_erlang_end_erlang(Config) when is_list(Config) ->
         {html, {151, 17}, ~"Text3\nText4"},
         {erlang, {153, 5}, ~"expr3"}
     ],
-    Got = arizona_tpl_scanner:scan(#{line => ?LINE + 1, indentation => 4}, ~"""
+    Got = arizona_scanner:scan(#{line => ?LINE + 1, indentation => 4}, ~"""
     {expr1}
     Text1
     Text2{expr2}Text3
@@ -160,7 +160,7 @@ scan_new_line_cr(Config) when is_list(Config) ->
         {erlang, {2, 1}, ~"[2,\r3]"},
         {html, {4, 1}, ~"4"}
     ],
-    Got = arizona_tpl_scanner:scan(#{}, ~"1\r{[2,\r3]}\r4"),
+    Got = arizona_scanner:scan(#{}, ~"1\r{[2,\r3]}\r4"),
     ?assertEqual(Expect, Got).
 
 scan_new_line_crlf(Config) when is_list(Config) ->
@@ -169,13 +169,13 @@ scan_new_line_crlf(Config) when is_list(Config) ->
         {erlang, {2, 1}, ~"[2,\r\n3]"},
         {html, {4, 1}, ~"4"}
     ],
-    Got = arizona_tpl_scanner:scan(#{}, ~"1\r\n{[2,\r\n3]}\r\n4"),
+    Got = arizona_scanner:scan(#{}, ~"1\r\n{[2,\r\n3]}\r\n4"),
     ?assertEqual(Expect, Got).
 
 scan_error_unexpected_expr_end(Config) when is_list(Config) ->
     Error = {unexpected_expr_end, {1, 6}},
-    ?assertError(Error, arizona_tpl_scanner:scan(#{}, ~"{error")).
+    ?assertError(Error, arizona_scanner:scan(#{}, ~"{error")).
 
 scan_error_badexpr(Config) when is_list(Config) ->
     Error = {badexpr, {1, 1}, ~"[error"},
-    ?assertError(Error, arizona_tpl_scanner:scan(#{}, ~"{[error}")).
+    ?assertError(Error, arizona_scanner:scan(#{}, ~"{[error}")).


### PR DESCRIPTION
# Description

Personally, this reads better.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
