### PR TITLE
Render view inside templates

### DIFF
--- a/elvis.config
+++ b/elvis.config
@@ -33,6 +33,8 @@
                     }},
                     {elvis_style, no_macros, #{
                         allow => [
+                            'assert',
+                            'assertNot',
                             'assertEqual',
                             'assertError'
                         ]

--- a/elvis.config
+++ b/elvis.config
@@ -33,8 +33,6 @@
                     }},
                     {elvis_style, no_macros, #{
                         allow => [
-                            'assert',
-                            'assertNot',
                             'assertEqual',
                             'assertError'
                         ]

--- a/src/arizona_render.erl
+++ b/src/arizona_render.erl
@@ -61,7 +61,7 @@ Socket is `t:arizona_socket:socket/0`.
     View1 :: arizona_view:view(),
     Socket1 :: arizona_socket:socket().
 template(View, Socket, {Static, Dynamic}) ->
-    render_view_template(View, Socket, Static, Dynamic);
+    render_template(View, Socket, Static, Dynamic);
 template(View, Socket, Template) when is_binary(Template) ->
     Bindings = #{'View' => View, 'Socket' => Socket},
     {Static, Dynamic} = parse_template(Bindings, Template),
@@ -71,7 +71,7 @@ template(View, Socket, Template) when is_binary(Template) ->
 %% Private functions
 %% --------------------------------------------------------------------
 
-render_view_template(View0, Socket0, Static, Dynamic0) ->
+render_template(View0, Socket0, Static, Dynamic0) ->
     {View1, Socket1} = render_dynamic(Dynamic0, View0, Socket0),
     Dynamic = lists:reverse(arizona_view:rendered(View1)),
     Template = [template, Static, Dynamic],

--- a/src/arizona_render.erl
+++ b/src/arizona_render.erl
@@ -14,6 +14,44 @@
 %% API function definitions
 %% --------------------------------------------------------------------
 
+-doc ~""""
+Renders a top level template.
+
+## Examples
+
+```
+> ViewMod = mymodule.
+> Assigns = #{id => ~"foo", bar => ~"bar"}.
+> ChangedAssigns = #{}.
+> Rendered = [].
+> View = arizona_view:new(ViewMod, Assigns, ChangedAssigns, Rendered).
+> Views = #{}.
+> Socket = arizona_socket:new(Views).
+> arizona_render:template(View, Socket, ~"""
+  <div id="{arizona_view:get_assign(id, View)}">
+    {arizona_view:get_assign(bar, View)}
+  </div>
+  """).
+{{view,mymodule,
+       #{id => <<"foo">>,bar => <<"bar">>},
+       #{},
+       [template,
+        [<<"<div id=\"">>,<<"\">">>,<<"</div>">>],
+        [<<"foo">>,<<"bar">>]]},
+ {socket,#{<<"foo">> =>
+               {view,mymodule,
+                     #{id => <<"foo">>,bar => <<"bar">>},
+                     #{},
+                     [template,
+                      [<<"<div id=\"">>,<<"\">">>,<<"</div>">>],
+                      [<<"foo">>,<<"bar">>]]}}}}
+```
+
+## Returns
+
+It returns `{View, Socket}` where View is `t:arizona_view:view/0` and
+Socket is `t:arizona_socket:socket/0`.
+"""".
 -spec template(View0, Socket0, Template) -> {View1, Socket1} when
     View0 :: arizona_view:view(),
     Socket0 :: arizona_socket:socket(),

--- a/src/arizona_render.erl
+++ b/src/arizona_render.erl
@@ -158,20 +158,8 @@ render_dynamic([Value | T], View0, Socket0) ->
     {View, Socket} = put_rendered(Value, View0, Socket0),
     render_dynamic(T, View, Socket).
 
-put_rendered({RenderedView, Socket}, View0, _Socket) ->
-    case arizona_view:equals(View0, RenderedView) of
-        true ->
-            {RenderedView, Socket};
-        false ->
-            case arizona_view:rendered(RenderedView) of
-                [Rendered] ->
-                    View = arizona_view:put_rendered(Rendered, View0),
-                    {View, Socket};
-                Rendered ->
-                    View = arizona_view:put_rendered(Rendered, View0),
-                    {View, Socket}
-            end
-    end;
+put_rendered({RenderedView, Socket}, _View, _Socket) ->
+    {RenderedView, Socket};
 put_rendered(Value, View0, Socket) ->
     View = arizona_view:put_rendered(Value, View0),
     {View, Socket}.

--- a/src/arizona_view.erl
+++ b/src/arizona_view.erl
@@ -16,6 +16,28 @@
 -ignore_xref([new/4]).
 
 %% --------------------------------------------------------------------
+%% Callback support function exports
+%% --------------------------------------------------------------------
+
+-export([mount/3]).
+-export([render/3]).
+
+%% --------------------------------------------------------------------
+%% Callback definitions
+%% --------------------------------------------------------------------
+
+-callback mount(Assigns, Socket) -> {ok, View} | ignore when
+    Assigns :: assigns(),
+    Socket :: arizona_socket:socket(),
+    View :: view().
+
+-callback render(View0, Socket0) -> {View1, Socket1} when
+    View0 :: view(),
+    Socket0 :: arizona_socket:socket(),
+    View1 :: view(),
+    Socket1 :: arizona_socket:socket().
+
+%% --------------------------------------------------------------------
 %% Types (and their exports)
 %% --------------------------------------------------------------------
 
@@ -96,3 +118,24 @@ put_rendered(Rendered, #view{} = View) when is_binary(Rendered); is_list(Rendere
     View1 :: view().
 merge_changed_assigns(View) ->
     View#view{assigns = maps:merge(View#view.assigns, View#view.changed_assigns)}.
+
+%% --------------------------------------------------------------------
+%% Callback support function definitions
+%% --------------------------------------------------------------------
+
+-spec mount(Mod, Assigns, Socket) -> {ok, View} | ignore when
+    Mod :: module(),
+    Assigns :: assigns(),
+    Socket :: arizona_socket:socket(),
+    View :: view().
+mount(Mod, Assigns, Socket) when is_atom(Mod), is_map(Assigns) ->
+    erlang:apply(Mod, mount, [Assigns, Socket]).
+
+-spec render(Mod, View0, Socket0) -> {View1, Socket1} when
+    Mod :: module(),
+    View0 :: view(),
+    Socket0 :: arizona_socket:socket(),
+    View1 :: view(),
+    Socket1 :: arizona_socket:socket().
+render(Mod, View, Socket) when is_atom(Mod) ->
+    erlang:apply(Mod, render, [View, Socket]).

--- a/src/arizona_view.erl
+++ b/src/arizona_view.erl
@@ -11,7 +11,6 @@
 -export([set_rendered/2]).
 -export([put_rendered/2]).
 -export([merge_changed_assigns/1]).
--export([equals/2]).
 
 %
 
@@ -128,21 +127,6 @@ put_rendered(Rendered, #view{} = View) when is_binary(Rendered); is_list(Rendere
     View1 :: view().
 merge_changed_assigns(View) ->
     View#view{assigns = maps:merge(View#view.assigns, View#view.changed_assigns)}.
-
--spec equals(ViewA, ViewB) -> boolean() when
-    ViewA :: view(),
-    ViewB :: view().
-equals(#view{module = undefined}, _ViewB) ->
-    false;
-equals(_ViewA, #view{module = undefined}) ->
-    false;
-equals(
-    #view{module = Mod, assigns = #{id := Id}},
-    #view{module = Mod, assigns = #{id := Id}}
-) ->
-    true;
-equals(_ViewA, _ViewB) ->
-    false.
 
 %% --------------------------------------------------------------------
 %% Callback support function definitions

--- a/src/arizona_view.erl
+++ b/src/arizona_view.erl
@@ -88,7 +88,7 @@ set_rendered(Rendered, #view{} = View) when is_list(Rendered) ->
     Rendered :: rendered_value(),
     View0 :: view(),
     View1 :: view().
-put_rendered(Rendered, #view{} = View) when is_binary(Rendered) ->
+put_rendered(Rendered, #view{} = View) when is_binary(Rendered); is_list(Rendered) ->
     View#view{rendered = [Rendered | View#view.rendered]}.
 
 -spec merge_changed_assigns(View0) -> View1 when

--- a/src/arizona_view.erl
+++ b/src/arizona_view.erl
@@ -4,6 +4,7 @@
 %% API function exports
 %% --------------------------------------------------------------------
 
+-export([new/2]).
 -export([new/4]).
 -export([get_assign/2]).
 -export([rendered/1]).
@@ -13,6 +14,7 @@
 
 %
 
+-ignore_xref([new/2]).
 -ignore_xref([new/4]).
 
 %% --------------------------------------------------------------------
@@ -71,6 +73,13 @@
 %% --------------------------------------------------------------------
 %% API function definitions
 %% --------------------------------------------------------------------
+
+-spec new(Mod, Assigns) -> View when
+    Mod :: module(),
+    Assigns :: assigns(),
+    View :: view().
+new(Mod, Assigns) ->
+    new(Mod, Assigns, #{}, []).
 
 -spec new(Mod, Assigns, ChangedAssigns, Rendered) -> View when
     Mod :: module(),

--- a/src/arizona_view.erl
+++ b/src/arizona_view.erl
@@ -11,6 +11,7 @@
 -export([set_rendered/2]).
 -export([put_rendered/2]).
 -export([merge_changed_assigns/1]).
+-export([equals/2]).
 
 %
 
@@ -127,6 +128,21 @@ put_rendered(Rendered, #view{} = View) when is_binary(Rendered); is_list(Rendere
     View1 :: view().
 merge_changed_assigns(View) ->
     View#view{assigns = maps:merge(View#view.assigns, View#view.changed_assigns)}.
+
+-spec equals(ViewA, ViewB) -> boolean() when
+    ViewA :: view(),
+    ViewB :: view().
+equals(#view{module = undefined}, _ViewB) ->
+    false;
+equals(_ViewA, #view{module = undefined}) ->
+    false;
+equals(
+    #view{module = Mod, assigns = #{id := Id}},
+    #view{module = Mod, assigns = #{id := Id}}
+) ->
+    true;
+equals(_ViewA, _ViewB) ->
+    false.
 
 %% --------------------------------------------------------------------
 %% Callback support function definitions

--- a/test/arizona_render_SUITE.erl
+++ b/test/arizona_render_SUITE.erl
@@ -13,7 +13,9 @@ all() ->
 groups() ->
     [
         {render, [parallel], [
-            render_template
+            render_template,
+            render_view,
+            ignore_view
         ]}
     ].
 
@@ -46,4 +48,38 @@ render_template(Config) when is_list(Config) ->
       {arizona_view:get_assign(bar, View)}{~"baz"}
     </div>
     """),
+    ?assertEqual(Expect, Got).
+
+render_view(Config) when is_list(Config) ->
+    Expect = {
+        arizona_view:new(?MODULE, #{}, #{}, [
+            [
+                template,
+                [<<"<div id=\"">>, <<"\">">>, <<"</div>">>],
+                [<<"counter">>, <<"0">>]
+            ]
+        ]),
+        arizona_socket:new(
+            #{
+                <<"counter">> => arizona_view:new(arizona_example_counter, #{
+                    id => <<"counter">>, count => 0
+                })
+            }
+        )
+    },
+    Callback = arizona_render:view(arizona_example_counter, #{id => ~"counter", count => 0}),
+    ParentView = arizona_view:new(?MODULE, #{}, #{}, []),
+    Socket = arizona_socket:new(#{}),
+    Got = erlang:apply(Callback, [ParentView, Socket]),
+    ?assertEqual(Expect, Got).
+
+ignore_view(Config) when is_list(Config) ->
+    Expect = {
+        arizona_view:new(?MODULE, #{}, #{}, []),
+        arizona_socket:new(#{})
+    },
+    Callback = arizona_render:view(arizona_example_ignore, #{}),
+    ParentView = arizona_view:new(?MODULE, #{}, #{}, []),
+    Socket = arizona_socket:new(#{}),
+    Got = erlang:apply(Callback, [ParentView, Socket]),
     ?assertEqual(Expect, Got).

--- a/test/arizona_view_SUITE.erl
+++ b/test/arizona_view_SUITE.erl
@@ -15,8 +15,7 @@ groups() ->
         {callback, [parallel], [
             mount,
             mount_ignore,
-            render,
-            equals
+            render
         ]}
     ].
 
@@ -82,29 +81,3 @@ render(Config) when is_list(Config) ->
     {ok, View} = arizona_view:mount(arizona_example_template, #{id => ~"app", count => 0}, Socket),
     Got = arizona_view:render(arizona_example_template, View, Socket),
     ?assertEqual(Expect, Got).
-
-equals(Config) when is_list(Config) ->
-    ?assertNot(
-        arizona_view:equals(
-            arizona_view:new(undefined, #{}, #{}, []),
-            arizona_view:new(bar, #{}, #{}, [])
-        )
-    ),
-        ?assertNot(
-        arizona_view:equals(
-            arizona_view:new(foo, #{}, #{}, []),
-            arizona_view:new(undefined, #{}, #{}, [])
-        )
-    ),
-        ?assert(
-        arizona_view:equals(
-            arizona_view:new(foo, #{id => ~"foo"}, #{}, []),
-            arizona_view:new(foo, #{id => ~"foo"}, #{}, [])
-        )
-    ),
-        ?assertNot(
-        arizona_view:equals(
-            arizona_view:new(foo, #{id => ~"foo"}, #{}, []),
-            arizona_view:new(foo, #{id => ~"bar"}, #{}, [])
-        )
-    ).

--- a/test/arizona_view_SUITE.erl
+++ b/test/arizona_view_SUITE.erl
@@ -1,0 +1,110 @@
+-module(arizona_view_SUITE).
+-behaviour(ct_suite).
+-include_lib("stdlib/include/assert.hrl").
+-compile([export_all, nowarn_export_all]).
+
+%% --------------------------------------------------------------------
+%% Behaviour (ct_suite) callbacks
+%% --------------------------------------------------------------------
+
+all() ->
+    [{group, callback}].
+
+groups() ->
+    [
+        {callback, [parallel], [
+            mount,
+            mount_ignore,
+            render,
+            equals
+        ]}
+    ].
+
+%% --------------------------------------------------------------------
+%% Tests
+%% --------------------------------------------------------------------
+
+mount(Config) when is_list(Config) ->
+    Expect = {ok, arizona_view:new(arizona_example_template, #{id => ~"app", count => 0}, #{}, [])},
+    Socket = arizona_socket:new(#{}),
+    Got = arizona_view:mount(arizona_example_template, #{id => ~"app", count => 0}, Socket),
+    ?assertEqual(Expect, Got).
+
+mount_ignore(Config) when is_list(Config) ->
+    Expect = ignore,
+    Socket = arizona_socket:new(#{}),
+    Got = arizona_view:mount(arizona_example_ignore, #{}, Socket),
+    ?assertEqual(Expect, Got).
+
+render(Config) when is_list(Config) ->
+    Expect = {
+        arizona_view:new(arizona_example_template, #{count => 0, id => <<"app">>}, #{}, [
+            template,
+            [
+                <<"<html>\n    <head></head>\n    <body id=\"">>,
+                <<"\">">>,
+                <<"</body>\n</html>">>
+            ],
+            [
+                <<"app">>,
+                [
+                    template,
+                    [<<"<div id=\"">>, <<"\">">>, <<"</div>">>],
+                    [<<"counter">>, <<"0">>]
+                ]
+            ]
+        ]),
+        arizona_socket:new(#{
+            <<"app">> => arizona_view:new(
+                arizona_example_template, #{count => 0, id => <<"app">>}, #{}, [
+                    template,
+                    [
+                        <<"<html>\n    <head></head>\n    <body id=\"">>,
+                        <<"\">">>,
+                        <<"</body>\n</html>">>
+                    ],
+                    [
+                        <<"app">>,
+                        [
+                            template,
+                            [<<"<div id=\"">>, <<"\">">>, <<"</div>">>],
+                            [<<"counter">>, <<"0">>]
+                        ]
+                    ]
+                ]
+            ),
+            <<"counter">> => arizona_view:new(
+                arizona_example_counter, #{count => 0, id => <<"counter">>}, #{}, []
+            )
+        })
+    },
+    Socket = arizona_socket:new(#{}),
+    {ok, View} = arizona_view:mount(arizona_example_template, #{id => ~"app", count => 0}, Socket),
+    Got = arizona_view:render(arizona_example_template, View, Socket),
+    ?assertEqual(Expect, Got).
+
+equals(Config) when is_list(Config) ->
+    ?assertNot(
+        arizona_view:equals(
+            arizona_view:new(undefined, #{}, #{}, []),
+            arizona_view:new(bar, #{}, #{}, [])
+        )
+    ),
+        ?assertNot(
+        arizona_view:equals(
+            arizona_view:new(foo, #{}, #{}, []),
+            arizona_view:new(undefined, #{}, #{}, [])
+        )
+    ),
+        ?assert(
+        arizona_view:equals(
+            arizona_view:new(foo, #{id => ~"foo"}, #{}, []),
+            arizona_view:new(foo, #{id => ~"foo"}, #{}, [])
+        )
+    ),
+        ?assertNot(
+        arizona_view:equals(
+            arizona_view:new(foo, #{id => ~"foo"}, #{}, []),
+            arizona_view:new(foo, #{id => ~"bar"}, #{}, [])
+        )
+    ).

--- a/test/support/arizona_example_counter.erl
+++ b/test/support/arizona_example_counter.erl
@@ -1,0 +1,18 @@
+-module(arizona_example_counter).
+-behaviour(arizona_view).
+
+-export([mount/2]).
+-export([render/2]).
+
+mount(Assigns, _Socket) ->
+    View = arizona_view:new(?MODULE, Assigns#{
+        id => maps:get(id, Assigns, ~"counter")
+    }),
+    {ok, View}.
+
+render(View, Socket) ->
+    arizona_render:template(View, Socket, ~""""
+    <div id="{arizona_view:get_assign(id, View)}">
+      {integer_to_binary(arizona_view:get_assign(count, View))}
+    </div>
+    """").

--- a/test/support/arizona_example_ignore.erl
+++ b/test/support/arizona_example_ignore.erl
@@ -1,0 +1,13 @@
+-module(arizona_example_ignore).
+-behaviour(arizona_view).
+
+-export([mount/2]).
+-export([render/2]).
+
+mount(_Assigns, _Socket) ->
+    ignore.
+
+render(View, Socket) ->
+    arizona_render:template(View, Socket, ~""""
+    ignored
+    """").

--- a/test/support/arizona_example_template.erl
+++ b/test/support/arizona_example_template.erl
@@ -1,0 +1,22 @@
+-module(arizona_example_template).
+-behaviour(arizona_view).
+
+-export([mount/2]).
+-export([render/2]).
+
+mount(Assigns, _Socket) ->
+    View = arizona_view:new(?MODULE, Assigns),
+    {ok, View}.
+
+render(View, Socket) ->
+    arizona_render:template(View, Socket, ~""""
+    <html>
+        <head></head>
+        <body id="{arizona_view:get_assign(id, View)}">
+            {arizona_render:view(arizona_example_counter, #{
+                id => ~"counter",
+                count => arizona_view:get_assign(count, View)
+            })}
+        </body>
+    </html>
+    """").


### PR DESCRIPTION
# Description

We can now call `arizona_render:view/2` to render a view inside a template. The rendered view must implement the `arizona_view` behavior. The view is first mounted and then rendered.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
