### PR TITLE
Introduce component render

### DIFF
--- a/elvis.config
+++ b/elvis.config
@@ -25,6 +25,7 @@
                 filter => "*.erl",
                 ruleset => erl_files_strict,
                 rules => [
+                    {elvis_style, dont_repeat_yourself, disable},
                     {elvis_style, atom_naming_convention, #{
                         regex => "^[a-z][a-z_@0-9]*(_SUITE)?$"
                     }},

--- a/src/arizona_component.erl
+++ b/src/arizona_component.erl
@@ -1,0 +1,21 @@
+-module(arizona_component).
+
+%% --------------------------------------------------------------------
+%% API function exports
+%% --------------------------------------------------------------------
+
+-export([render/4]).
+
+%% --------------------------------------------------------------------
+%% API function definitions
+%% --------------------------------------------------------------------
+
+-spec render(Mod, Fun, View0, Socket0) -> {View1, Socket1} when
+    Mod :: module(),
+    Fun :: atom(),
+    View0 :: arizona_view:view(),
+    Socket0 :: arizona_socket:socket(),
+    View1 :: arizona_view:view(),
+    Socket1 :: arizona_socket:socket().
+render(Mod, Fun, View, Socket) when is_atom(Mod), is_atom(Fun) ->
+    erlang:apply(Mod, Fun, [View, Socket]).

--- a/src/arizona_view.erl
+++ b/src/arizona_view.erl
@@ -44,7 +44,7 @@
 %% --------------------------------------------------------------------
 
 -record(view, {
-    module :: module(),
+    module :: undefined | module(),
     assigns :: assigns(),
     changed_assigns :: assigns(),
     rendered :: rendered()
@@ -75,14 +75,14 @@
 %% --------------------------------------------------------------------
 
 -spec new(Mod, Assigns) -> View when
-    Mod :: module(),
+    Mod :: undefined | module(),
     Assigns :: assigns(),
     View :: view().
 new(Mod, Assigns) ->
     new(Mod, Assigns, #{}, []).
 
 -spec new(Mod, Assigns, ChangedAssigns, Rendered) -> View when
-    Mod :: module(),
+    Mod :: undefined | module(),
     Assigns :: assigns(),
     ChangedAssigns :: assigns(),
     Rendered :: rendered(),
@@ -137,7 +137,7 @@ merge_changed_assigns(View) ->
     Assigns :: assigns(),
     Socket :: arizona_socket:socket(),
     View :: view().
-mount(Mod, Assigns, Socket) when is_atom(Mod), is_map(Assigns) ->
+mount(Mod, Assigns, Socket) when is_atom(Mod), Mod =/= undefined, is_map(Assigns) ->
     erlang:apply(Mod, mount, [Assigns, Socket]).
 
 -spec render(Mod, View0, Socket0) -> {View1, Socket1} when
@@ -146,5 +146,5 @@ mount(Mod, Assigns, Socket) when is_atom(Mod), is_map(Assigns) ->
     Socket0 :: arizona_socket:socket(),
     View1 :: view(),
     Socket1 :: arizona_socket:socket().
-render(Mod, View, Socket) when is_atom(Mod) ->
+render(Mod, View, Socket) when is_atom(Mod), Mod =/= undefined ->
     erlang:apply(Mod, render, [View, Socket]).

--- a/test/arizona_view_SUITE.erl
+++ b/test/arizona_view_SUITE.erl
@@ -37,43 +37,66 @@ mount_ignore(Config) when is_list(Config) ->
 
 render(Config) when is_list(Config) ->
     Expect = {
-        arizona_view:new(arizona_example_template, #{count => 0, id => <<"app">>}, #{}, [
-            template,
-            [
-                <<"<html>\n    <head></head>\n    <body id=\"">>,
-                <<"\">">>,
-                <<"</body>\n</html>">>
-            ],
-            [
-                <<"app">>,
+        arizona_view:new(
+            arizona_example_template, #{count => 0, id => ~"app"}, #{}, [
+                template,
                 [
-                    template,
-                    [<<"<div id=\"">>, <<"\">">>, <<"</div>">>],
-                    [<<"counter">>, <<"0">>]
+                    ~"<html>\n    <head></head>\n    <body id=\"",
+                    ~"\">",
+                    ~"</body>\n</html>"
+                ],
+                [
+                    ~"app",
+                    [
+                        template,
+                        [~"<div id=\"", ~"\">", ~"", ~"</div>"],
+                        [
+                            ~"counter",
+                            ~"0",
+                            [
+                                template,
+                                [~"<button>", ~"</button>"],
+                                [~"Increment"]
+                            ]
+                        ]
+                    ]
                 ]
             ]
-        ]),
+        ),
         arizona_socket:new(#{
-            <<"app">> => arizona_view:new(
-                arizona_example_template, #{count => 0, id => <<"app">>}, #{}, [
+            ~"app" => arizona_view:new(
+                arizona_example_template, #{count => 0, id => ~"app"}, #{}, [
                     template,
                     [
-                        <<"<html>\n    <head></head>\n    <body id=\"">>,
-                        <<"\">">>,
-                        <<"</body>\n</html>">>
+                        ~"<html>\n    <head></head>\n    <body id=\"",
+                        ~"\">",
+                        ~"</body>\n</html>"
                     ],
                     [
-                        <<"app">>,
+                        ~"app",
                         [
                             template,
-                            [<<"<div id=\"">>, <<"\">">>, <<"</div>">>],
-                            [<<"counter">>, <<"0">>]
+                            [
+                                ~"<div id=\"",
+                                ~"\">",
+                                ~"",
+                                ~"</div>"
+                            ],
+                            [
+                                ~"counter",
+                                ~"0",
+                                [
+                                    template,
+                                    [~"<button>", ~"</button>"],
+                                    [~"Increment"]
+                                ]
+                            ]
                         ]
                     ]
                 ]
             ),
-            <<"counter">> => arizona_view:new(
-                arizona_example_counter, #{count => 0, id => <<"counter">>}, #{}, []
+            ~"counter" => arizona_view:new(
+                arizona_example_counter, #{count => 0, id => ~"counter"}, #{}, []
             )
         })
     },

--- a/test/support/arizona_example_components.erl
+++ b/test/support/arizona_example_components.erl
@@ -1,0 +1,9 @@
+-module(arizona_example_components).
+-export([button/2]).
+
+button(View, Socket) ->
+    arizona_render:component_template(View, Socket, ~"""
+    <button>
+        {arizona_view:get_assign(text, View)}
+    </button>
+    """).

--- a/test/support/arizona_example_counter.erl
+++ b/test/support/arizona_example_counter.erl
@@ -11,8 +11,11 @@ mount(Assigns, _Socket) ->
     {ok, View}.
 
 render(View, Socket) ->
-    arizona_render:template(View, Socket, ~""""
+    arizona_render:view_template(View, Socket, ~""""
     <div id="{arizona_view:get_assign(id, View)}">
-      {integer_to_binary(arizona_view:get_assign(count, View))}
+        {integer_to_binary(arizona_view:get_assign(count, View))}
+        {arizona_render:component(arizona_example_components, button, #{
+            text => ~"Increment"
+        })}
     </div>
     """").

--- a/test/support/arizona_example_ignore.erl
+++ b/test/support/arizona_example_ignore.erl
@@ -8,6 +8,6 @@ mount(_Assigns, _Socket) ->
     ignore.
 
 render(View, Socket) ->
-    arizona_render:template(View, Socket, ~""""
+    arizona_render:view_template(View, Socket, ~""""
     ignored
     """").

--- a/test/support/arizona_example_template.erl
+++ b/test/support/arizona_example_template.erl
@@ -9,7 +9,7 @@ mount(Assigns, _Socket) ->
     {ok, View}.
 
 render(View, Socket) ->
-    arizona_render:template(View, Socket, ~""""
+    arizona_render:view_template(View, Socket, ~""""
     <html>
         <head></head>
         <body id="{arizona_view:get_assign(id, View)}">


### PR DESCRIPTION
# Description

We are now able to render components that don't hold it's own state, i.e. are stateless.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
