### PR TITLE
Install `eqwalizer_support` for Erlang Language Platform usage

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -35,7 +35,8 @@
         xref,
         {do, "default as test dialyzer"},
         eunit,
-        {ct, "--cover"}, % Remove options when cover_compiled bug fixed.
+        % Remove options when cover_compiled bug fixed.
+        {ct, "--cover"},
         cover,
         ex_doc
     ]}

--- a/rebar.config
+++ b/rebar.config
@@ -6,7 +6,11 @@
     warn_missing_spec
 ]}.
 
-{deps, []}.
+{deps, [
+    {eqwalizer_support,
+        {git_subdir, "https://github.com/whatsapp/eqwalizer.git", {branch, "main"},
+            "eqwalizer_support"}}
+]}.
 
 {dialyzer, [
     {plt_apps, all_deps},

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,1 +1,5 @@
-[].
+[{<<"eqwalizer_support">>,
+  {git_subdir,"https://github.com/whatsapp/eqwalizer.git",
+              {ref,"f5bc995b7fa48fdb3e23c751082f0f7dc33508cd"},
+              "eqwalizer_support"},
+  0}].


### PR DESCRIPTION
# Description

This PR installs the `eqwalizer_support` for a better experience by fixing spec warnings as described [here](https://github.com/WhatsApp/eqwalizer/blob/main/README.md#using-it-with-rebar3-projects) when using [ELP (Erlang Language Platform)](https://github.com/WhatsApp/erlang-language-platform).

Note: A minor adjustment in the `rebar.config` when executing `rebar3 fmt`.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
