### PR TITLE
Render view content to iolist

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -103,4 +103,7 @@
 
 {hex, [{doc, #{provider => ex_doc}}]}.
 
-{eunit_opts, [no_tty, {report, {doctest_eunit_report, []}}]}.
+{eunit_opts, [
+    no_tty,
+    {report, {doctest_eunit_report, [{print_depth, 200}]}}
+]}.

--- a/src/arizona_view.erl
+++ b/src/arizona_view.erl
@@ -17,6 +17,7 @@
 
 -ignore_xref([new/2]).
 -ignore_xref([new/4]).
+-ignore_xref([rendered_to_iolist/1]).
 
 %% --------------------------------------------------------------------
 %% Callback support function exports

--- a/src/arizona_view.erl
+++ b/src/arizona_view.erl
@@ -72,6 +72,14 @@
 -export_type([id/0]).
 
 %% --------------------------------------------------------------------
+%% Doctests
+%% --------------------------------------------------------------------
+
+-ifdef(TEST).
+-include_lib("doctest/include/doctest.hrl").
+-endif.
+
+%% --------------------------------------------------------------------
 %% API function definitions
 %% --------------------------------------------------------------------
 
@@ -129,6 +137,23 @@ put_rendered(Rendered, #view{} = View) when is_binary(Rendered); is_list(Rendere
 merge_changed_assigns(View) ->
     View#view{assigns = maps:merge(View#view.assigns, View#view.changed_assigns)}.
 
+-doc ~"""
+Formats the rendered content to `t:iolist/0`.
+
+## Examples
+
+```
+> Socket = arizona_socket:new(#{}).
+> {ok, View0} = arizona_view:mount(arizona_example_template, #{id => ~"app", count => 0}, Socket).
+> {View, _Socket} = arizona_view:render(arizona_example_template, View0, Socket).
+> arizona_view:rendered_to_iolist(View).
+[<<"<html>\n    <head></head>\n    <body id=\"">>,<<"app">>,<<"\">">>,
+ [<<"<div id=\"">>,<<"counter">>,<<"\">">>,<<"0">>,<<>>,
+  [<<"<button>">>,<<"Increment">>,<<"</button>">>],
+  <<"</div>">>],
+ <<"</body>\n</html>">>]
+```
+""".
 -spec rendered_to_iolist(View) -> iolist() when
     View :: view().
 rendered_to_iolist(#view{} = View) ->

--- a/test/arizona_view_SUITE.erl
+++ b/test/arizona_view_SUITE.erl
@@ -8,7 +8,10 @@
 %% --------------------------------------------------------------------
 
 all() ->
-    [{group, callback}].
+    [
+        {group, callback},
+        {group, to_iolist}
+    ].
 
 groups() ->
     [
@@ -16,6 +19,9 @@ groups() ->
             mount,
             mount_ignore,
             render
+        ]},
+        {to_iolist, [
+            rendered_to_iolist
         ]}
     ].
 
@@ -103,4 +109,26 @@ render(Config) when is_list(Config) ->
     Socket = arizona_socket:new(#{}),
     {ok, View} = arizona_view:mount(arizona_example_template, #{id => ~"app", count => 0}, Socket),
     Got = arizona_view:render(arizona_example_template, View, Socket),
+    ?assertEqual(Expect, Got).
+
+rendered_to_iolist(Config) when is_list(Config) ->
+    Expect = [
+        ~"<html>\n    <head></head>\n    <body id=\"",
+        ~"app",
+        ~"\">",
+        [
+            ~"<div id=\"",
+            ~"counter",
+            ~"\">",
+            ~"0",
+            ~"",
+            [~"<button>", ~"Increment", ~"</button>"],
+            ~"</div>"
+        ],
+        ~"</body>\n</html>"
+    ],
+    Socket = arizona_socket:new(#{}),
+    {ok, View0} = arizona_view:mount(arizona_example_template, #{id => ~"app", count => 0}, Socket),
+    {View, _Socket} = arizona_view:render(arizona_example_template, View0, Socket),
+    Got = arizona_view:rendered_to_iolist(View),
     ?assertEqual(Expect, Got).


### PR DESCRIPTION
# Description

Now the rendered content of a view can be rendered as iolist.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
