### PR TITLE
Change template tokens struct and render strategy

### DIFF
--- a/src/arizona_component.erl
+++ b/src/arizona_component.erl
@@ -4,17 +4,16 @@
 %% API function exports
 %% --------------------------------------------------------------------
 
--export([render/4]).
+-export([render/3]).
 
 %% --------------------------------------------------------------------
 %% API function definitions
 %% --------------------------------------------------------------------
 
--spec render(Mod, Fun, View, Socket) -> Token when
+-spec render(Mod, Fun, View) -> Token when
     Mod :: module(),
     Fun :: atom(),
     View :: arizona_view:view(),
-    Socket :: arizona_socket:socket(),
     Token :: arizona_render:token().
-render(Mod, Fun, View, Socket) when is_atom(Mod), is_atom(Fun) ->
-    erlang:apply(Mod, Fun, [View, Socket]).
+render(Mod, Fun, View) when is_atom(Mod), is_atom(Fun) ->
+    erlang:apply(Mod, Fun, [View]).

--- a/src/arizona_render.erl
+++ b/src/arizona_render.erl
@@ -4,19 +4,19 @@
 %% API function exports
 %% --------------------------------------------------------------------
 
--export([render/3]).
--export([view_template/3]).
--export([component_template/3]).
--export([nested_template/1]).
+-export([render/4]).
+-export([view_template/2]).
+-export([component_template/2]).
+-export([nested_template/2]).
 -export([view/2]).
 -export([component/3]).
 
 %
 
--ignore_xref([render/3]).
--ignore_xref([view_template/3]).
--ignore_xref([component_template/3]).
--ignore_xref([nested_template/1]).
+-ignore_xref([render/4]).
+-ignore_xref([view_template/2]).
+-ignore_xref([component_template/2]).
+-ignore_xref([nested_template/2]).
 -ignore_xref([view/2]).
 -ignore_xref([component/3]).
 
@@ -24,28 +24,25 @@
 %% Types (and their exports)
 %% --------------------------------------------------------------------
 
--type token() ::
-    {view_template, View :: arizona_view:view(), Socket :: arizona_socket:socket(),
-        Static :: [binary()], Dynamic :: [binary()]}
-    | {component_template, View :: arizona_view:view(), Socket :: arizona_socket:socket(),
-        Static :: [binary()], Dynamic :: [binary()]}
-    | {nested_template, ParentView :: arizona_view:view(), Socket :: arizona_socket:socket(),
-        Static :: [binary()], Dynamic :: [binary()]}
-    | {view, ParentView :: arizona_view:view(), Socket :: arizona_socket:socket(), Mod :: module(),
-        Assigns :: arizona_view:assigns()}
-    | {component, ParentView :: arizona_view:view(), Socket :: arizona_socket:socket(),
-        Mod :: module(), Fun :: atom(), Assigns :: arizona_view:assigns()}
-    | {callback, callback(Token :: token())}.
--export_type([token/0]).
+-type static_list() :: [binary()].
+-export_type([static_list/0]).
 
--type callback(Token) :: fun(
-    (View :: arizona_view:view(), Socket :: arizona_socket:socket()) -> Token
-).
--export_type([callback/1]).
+-type dynamic_list() :: [
+    fun((ViewAcc :: arizona_view:view(), Socket :: arizona_socket:socket()) -> binary())
+].
+-export_type([dynamic_list/0]).
+
+-type token() ::
+    {view_template, Static :: static_list(), Dynamic :: dynamic_list()}
+    | {component_template, Static :: static_list(), Dynamic :: dynamic_list()}
+    | {nested_template, Static :: static_list(), Dynamic :: dynamic_list()}
+    | {view, Mod :: module(), Assigns :: arizona_view:assigns()}
+    | {component, Mod :: module(), Fun :: atom(), Assigns :: arizona_view:assigns()}.
+-export_type([token/0]).
 
 -type rendered() ::
     [rendered_value()]
-    | [template | Static :: [binary()] | Dynamic :: [binary()]].
+    | [template | Static :: static_list() | Dynamic :: dynamic_list()].
 -export_type([rendered/0]).
 
 -type rendered_value() ::
@@ -67,7 +64,7 @@
 %% API function definitions
 %% --------------------------------------------------------------------
 
--spec render(Payload, ParentView, ParentSocket) -> {View, Socket} when
+-spec render(Payload, View, ParentView, ParentSocket) -> {View, Socket} when
     Payload :: Token | Rendered,
     Token :: token(),
     Rendered :: rendered(),
@@ -75,101 +72,95 @@
     ParentSocket :: arizona_socket:socket(),
     View :: ParentView | arizona_view:view(),
     Socket :: ParentSocket | arizona_socket:socket().
-render({view_template, View, Socket, Static, Dynamic}, _ParentView, _ParentSocket) ->
+render({view_template, Static, Dynamic}, View, _ParentView, Socket) ->
     render_view_template(View, Socket, Static, Dynamic);
-render({component_template, View, Socket, Static, Dynamic}, _ParentView, _ParentSocket) ->
+render({component_template, Static, Dynamic}, View, _ParentView, Socket) ->
     render_component_template(View, Socket, Static, Dynamic);
-render({nested_template, ParentView, Socket, Static, Dynamic}, _ParentView, _ParentSocket) ->
+render({nested_template, Static, Dynamic}, _View, ParentView, Socket) ->
     render_nested_template(ParentView, Socket, Static, Dynamic);
-render({view, ParentView, Socket, Mod, Assigns}, _ParentView, _ParentSocket) ->
+render({view, Mod, Assigns}, _View, ParentView, Socket) ->
     render_view(ParentView, Socket, Mod, Assigns);
-render({component, ParentView, Socket, Mod, Fun, Assigns}, _ParentView, _ParentSocket) ->
+render({component, Mod, Fun, Assigns}, _View, ParentView, Socket) ->
     render_component(ParentView, Socket, Mod, Fun, Assigns);
-render({callback, Callback}, ParentView, ParentSocket) ->
-    Token = erlang:apply(Callback, [ParentView, ParentSocket]),
-    render(Token, ParentView, ParentSocket);
-render(Rendered, View0, Socket) ->
+render(Rendered, _View, View0, Socket) ->
     View = arizona_view:put_rendered(Rendered, View0),
     {View, Socket}.
 
--spec view_template(View, Socket, Template) -> Token when
+-spec view_template(View, Template) -> Token when
     View :: arizona_view:view(),
-    Socket :: arizona_socket:socket(),
-    Template :: binary() | {Static, Dynamic},
-    Token :: {view_template, View, Socket, Static, Dynamic},
-    Static :: [binary()],
-    Dynamic :: [binary()].
-view_template(View, Socket, {Static, Dynamic}) ->
-    {view_template, View, Socket, Static, Dynamic};
-view_template(View, Socket, Template) when is_binary(Template) ->
-    Bindings = #{'View' => View, 'Socket' => Socket},
+    Template :: binary(),
+    Token :: {view_template, Static, Dynamic},
+    Static :: static_list(),
+    Dynamic :: dynamic_list().
+view_template(View, Template) when is_binary(Template) ->
+    Bindings = #{'View' => View},
     {Static, Dynamic} = parse_template(Bindings, Template),
-    view_template(View, Socket, {Static, Dynamic}).
+    view_template({Static, Dynamic}).
 
--spec component_template(View, Socket, Template) -> Token when
+-spec component_template(View, Template) -> Token when
     View :: arizona_view:view(),
-    Socket :: arizona_socket:socket(),
-    Template :: binary() | {Static, Dynamic},
-    Token :: {component_template, View, Socket, Static, Dynamic},
-    Static :: [binary()],
-    Dynamic :: [binary()].
-component_template(View, Socket, {Static, Dynamic}) ->
-    {component_template, View, Socket, Static, Dynamic};
-component_template(View, Socket, Template) ->
-    Bindings = #{'View' => View, 'Socket' => Socket},
+    Template :: binary(),
+    Token :: {component_template, Static, Dynamic},
+    Static :: static_list(),
+    Dynamic :: dynamic_list().
+component_template(View, Template) ->
+    Bindings = #{'View' => View},
     {Static, Dynamic} = parse_template(Bindings, Template),
-    component_template(View, Socket, {Static, Dynamic}).
+    component_template({Static, Dynamic}).
 
--spec nested_template(Template) -> Callback when
-    Template :: binary() | {Static, Dynamic},
-    Static :: [binary()],
-    Dynamic :: [binary()],
-    Callback :: {callback, callback(Token)},
-    Token :: {nested_template, ParentView, Socket, Static, Dynamic},
+-spec nested_template(ParentView, Template) -> Token when
     ParentView :: arizona_view:view(),
-    Socket :: arizona_socket:socket().
-nested_template({Static, Dynamic}) ->
-    {callback, fun(ParentView, Socket) ->
-        {nested_template, ParentView, Socket, Static, Dynamic}
-    end};
-nested_template(Template) ->
-    {callback, fun(ParentView, Socket) ->
-        Bindings = #{'View' => ParentView, 'Socket' => Socket},
-        {Static, Dynamic} = parse_template(Bindings, Template),
-        {nested_template, ParentView, Socket, Static, Dynamic}
-    end}.
+    Template :: binary(),
+    Token :: {nested_template, Static, Dynamic},
+    Static :: static_list(),
+    Dynamic :: dynamic_list().
+nested_template(ParentView, Template) ->
+    Bindings = #{'View' => ParentView},
+    {Static, Dynamic} = parse_template(Bindings, Template),
+    nested_template({Static, Dynamic}).
 
--spec view(Mod, Assigns) -> Callback when
+-spec view(Mod, Assigns) -> Token when
     Mod :: module(),
     Assigns :: arizona_view:assigns(),
-    Callback :: {callback, callback(Token)},
-    Token :: {view, ParentView, Socket, Mod, Assigns},
-    ParentView :: arizona_view:view(),
-    Socket :: arizona_socket:socket().
+    Token :: {view, Mod, Assigns}.
 view(Mod, Assigns) when is_atom(Mod), is_map(Assigns), is_map_key(id, Assigns) ->
-    {callback, fun(ParentView, Socket) ->
-        {view, ParentView, Socket, Mod, Assigns}
-    end}.
+    {view, Mod, Assigns}.
 
--spec component(Mod, Fun, Assigns) -> Callback when
+-spec component(Mod, Fun, Assigns) -> Token when
     Mod :: module(),
     Fun :: atom(),
     Assigns :: arizona_view:assigns(),
-    Callback :: {callback, callback(Token)},
-    Token :: {component, ParentView, Socket, Mod, Fun, Assigns},
-    ParentView :: arizona_view:view(),
-    Socket :: arizona_socket:socket().
+    Token :: {component, Mod, Fun, Assigns}.
 component(Mod, Fun, Assigns) when is_atom(Mod), is_atom(Fun), is_map(Assigns) ->
-    {callback, fun(ParentView, Socket) ->
-        {component, ParentView, Socket, Mod, Fun, Assigns}
-    end}.
+    {component, Mod, Fun, Assigns}.
 
 %% --------------------------------------------------------------------
 %% Private functions
 %% --------------------------------------------------------------------
 
+-spec view_template({Static, Dynamic}) -> Token when
+    Static :: static_list(),
+    Dynamic :: dynamic_list(),
+    Token :: {view_template, Static, Dynamic}.
+view_template({Static, Dynamic}) when is_list(Static), is_list(Dynamic) ->
+    {view_template, Static, Dynamic}.
+
+-spec component_template({Static, Dynamic}) -> Token when
+    Static :: static_list(),
+    Dynamic :: dynamic_list(),
+    Token :: {component_template, Static, Dynamic}.
+component_template({Static, Dynamic}) ->
+    {component_template, Static, Dynamic}.
+
+-spec nested_template({Static, Dynamic}) -> Token when
+    Static :: static_list(),
+    Dynamic :: dynamic_list(),
+    Token :: {nested_template, Static, Dynamic}.
+nested_template({Static, Dynamic}) ->
+    {nested_template, Static, Dynamic}.
+
 render_view_template(View0, Socket0, Static, Dynamic0) ->
-    {View1, Socket1} = render_dynamic(Dynamic0, View0, Socket0),
+    {View1, Socket1} = render_dynamic(Dynamic0, View0, View0, Socket0),
     Dynamic = lists:reverse(arizona_view:rendered(View1)),
     Template = [template, Static, Dynamic],
     View2 = arizona_view:set_rendered(Template, View1),
@@ -178,7 +169,7 @@ render_view_template(View0, Socket0, Static, Dynamic0) ->
     {View, Socket}.
 
 render_component_template(View0, Socket0, Static, Dynamic0) ->
-    {View1, Socket} = render_dynamic(Dynamic0, View0, Socket0),
+    {View1, Socket} = render_dynamic(Dynamic0, View0, View0, Socket0),
     Dynamic = lists:reverse(arizona_view:rendered(View1)),
     Template = [template, Static, Dynamic],
     View = arizona_view:set_rendered(Template, View1),
@@ -187,7 +178,7 @@ render_component_template(View0, Socket0, Static, Dynamic0) ->
 render_nested_template(ParentView0, Socket0, Static, Dynamic0) ->
     Assigns = arizona_view:assigns(ParentView0),
     View0 = arizona_view:new(Assigns),
-    {View1, Socket} = render_dynamic(Dynamic0, View0, Socket0),
+    {View1, Socket} = render_dynamic(Dynamic0, View0, View0, Socket0),
     Dynamic = arizona_view:rendered(View1),
     Template = [template, Static, Dynamic],
     ParentView = arizona_view:put_rendered(Template, ParentView0),
@@ -196,8 +187,8 @@ render_nested_template(ParentView0, Socket0, Static, Dynamic0) ->
 render_view(ParentView0, Socket0, Mod, Assigns) ->
     case arizona_view:mount(Mod, Assigns, Socket0) of
         {ok, View0} ->
-            Token = arizona_view:render(Mod, View0, Socket0),
-            {View1, Socket1} = render(Token, ParentView0, Socket0),
+            Token = arizona_view:render(Mod, View0),
+            {View1, Socket1} = render(Token, View0, ParentView0, Socket0),
             Rendered = arizona_view:rendered(View1),
             ParentView = arizona_view:put_rendered(Rendered, ParentView0),
             View = arizona_view:set_rendered([], View1),
@@ -209,17 +200,17 @@ render_view(ParentView0, Socket0, Mod, Assigns) ->
 
 render_component(ParentView0, Socket0, Mod, Fun, Assigns) ->
     View0 = arizona_view:new(Assigns),
-    Token = arizona_component:render(Mod, Fun, View0, Socket0),
-    {View, Socket1} = render(Token, ParentView0, Socket0),
+    Token = arizona_component:render(Mod, Fun, View0),
+    {View, Socket1} = render(Token, View0, ParentView0, Socket0),
     Rendered = arizona_view:rendered(View),
     ParentView = arizona_view:put_rendered(Rendered, ParentView0),
     {ParentView, Socket1}.
 
-render_dynamic([], View, Socket) ->
-    {View, Socket};
-render_dynamic([Payload | T], View0, Socket0) ->
-    {View, Socket} = render(Payload, View0, Socket0),
-    render_dynamic(T, View, Socket).
+render_dynamic([], _View, ViewAcc, Socket) ->
+    {ViewAcc, Socket};
+render_dynamic([Callback | T], View, ViewAcc0, Socket0) ->
+    {ViewAcc, Socket} = erlang:apply(Callback, [ViewAcc0, Socket0]),
+    render_dynamic(T, View, ViewAcc, Socket).
 
 parse_template(Bindings, Template) ->
     Tokens = arizona_scanner:scan(#{}, Template),

--- a/src/arizona_view.erl
+++ b/src/arizona_view.erl
@@ -26,7 +26,7 @@
 %% --------------------------------------------------------------------
 
 -export([mount/3]).
--export([render/3]).
+-export([render/2]).
 
 %% --------------------------------------------------------------------
 %% Callback definitions
@@ -37,9 +37,8 @@
     Socket :: arizona_socket:socket(),
     View :: view().
 
--callback render(View, Socket) -> Token when
+-callback render(View) -> Token when
     View :: view(),
-    Socket :: arizona_socket:socket(),
     Token :: arizona_render:token().
 
 %% --------------------------------------------------------------------
@@ -149,8 +148,8 @@ Formats the rendered content to `t:iolist/0`.
 > Assigns = #{id => ~"app", count => 0}.
 > Socket = arizona_socket:new().
 > {ok, View0} = arizona_view:mount(Mod, Assigns, Socket).
-> Rendered = arizona_view:render(Mod, View0, Socket).
-> {View, _Socket} = arizona_render:render(Rendered, View0, Socket).
+> Rendered = arizona_view:render(Mod, View0).
+> {View, _Socket} = arizona_render:render(Rendered, View0, View0, Socket).
 > arizona_view:rendered_to_iolist(View).
 [<<"<html>\n    <head></head>\n    <body id=\"">>,<<"app">>,<<"\">">>,
  [<<"<div id=\"">>,<<"counter">>,<<"\">">>,<<"0">>,<<>>,
@@ -176,13 +175,12 @@ rendered_to_iolist(#view{} = View) ->
 mount(Mod, Assigns, Socket) when is_atom(Mod), Mod =/= undefined, is_map(Assigns) ->
     erlang:apply(Mod, mount, [Assigns, Socket]).
 
--spec render(Mod, View, Socket) -> Token when
+-spec render(Mod, View) -> Token when
     Mod :: module(),
     View :: view(),
-    Socket :: arizona_socket:socket(),
     Token :: arizona_render:token().
-render(Mod, View, Socket) when is_atom(Mod), Mod =/= undefined ->
-    erlang:apply(Mod, render, [View, Socket]).
+render(Mod, View) when is_atom(Mod), Mod =/= undefined ->
+    erlang:apply(Mod, render, [View]).
 
 %% --------------------------------------------------------------------
 %% Private functions

--- a/test/arizona_parser_SUITE.erl
+++ b/test/arizona_parser_SUITE.erl
@@ -30,9 +30,39 @@ parse(Config) when is_list(Config) ->
             {bin, 1, [{bin_element, 1, {string, 1, "qu\"o\"t\\\"ed"}, default, [utf8]}]}
         ],
         _Dynamic = [
-            {atom, 1, foo},
-            {tuple, 1, [{atom, 1, bar}]},
-            {cons, 1, {atom, 1, bar}, {nil, 1}}
+            {'fun', 1,
+                {clauses, [
+                    {clause, 1, [{var, 1, 'ViewAcc'}, {var, 1, 'Socket'}], [], [
+                        {call, 2, {remote, 2, {atom, 2, arizona_render}, {atom, 2, render}}, [
+                            {atom, 2, foo},
+                            {var, 2, 'View'},
+                            {var, 2, 'ViewAcc'},
+                            {var, 2, 'Socket'}
+                        ]}
+                    ]}
+                ]}},
+            {'fun', 1,
+                {clauses, [
+                    {clause, 1, [{var, 1, 'ViewAcc'}, {var, 1, 'Socket'}], [], [
+                        {call, 2, {remote, 2, {atom, 2, arizona_render}, {atom, 2, render}}, [
+                            {tuple, 2, [{atom, 2, bar}]},
+                            {var, 2, 'View'},
+                            {var, 2, 'ViewAcc'},
+                            {var, 2, 'Socket'}
+                        ]}
+                    ]}
+                ]}},
+            {'fun', 1,
+                {clauses, [
+                    {clause, 1, [{var, 1, 'ViewAcc'}, {var, 1, 'Socket'}], [], [
+                        {call, 2, {remote, 2, {atom, 2, arizona_render}, {atom, 2, render}}, [
+                            {cons, 2, {atom, 2, bar}, {nil, 2}},
+                            {var, 2, 'View'},
+                            {var, 2, 'ViewAcc'},
+                            {var, 2, 'Socket'}
+                        ]}
+                    ]}
+                ]}}
         ]
     },
     Tokens = arizona_scanner:scan(#{}, ~"""

--- a/test/arizona_render_SUITE.erl
+++ b/test/arizona_render_SUITE.erl
@@ -27,61 +27,56 @@ groups() ->
 
 render_view_template(Config) when is_list(Config) ->
     View = arizona_view:new(#{id => ~"foo", foo => ~"foo", bar => ~"bar"}),
-    Socket = arizona_socket:new(),
-    Expect =
-        {view_template, View, Socket, [~"<div id=\"", ~"\">", ~"", ~"</div>"], [
-            ~"foo", ~"foo", ~"bar"
-        ]},
-    Got = arizona_render:view_template(View, Socket, ~"""
+    Got = arizona_render:view_template(View, ~"""
     <div id="{arizona_view:get_assign(id, View)}">
       {arizona_view:get_assign(foo, View)}
       {arizona_view:get_assign(bar, View)}
     </div>
     """),
-    ?assertEqual(Expect, Got).
+    ?assertMatch(
+        {view_template, [~"<div id=\"", ~"\">", ~"", ~"</div>"], [Callback, _, _]} when
+            is_function(Callback, 2),
+        Got
+    ).
 
 render_component_template(Config) when is_list(Config) ->
     View = arizona_view:new(#{foo => ~"foo", bar => ~"bar"}),
-    Socket = arizona_socket:new(),
-    Expect = {component_template, View, Socket, [~"<div>", ~"", ~"</div>"], [~"foo", ~"bar"]},
-    Got = arizona_render:component_template(View, Socket, ~"""
+    Got = arizona_render:component_template(View, ~"""
     <div>
       {arizona_view:get_assign(foo, View)}
       {arizona_view:get_assign(bar, View)}
     </div>
     """),
-    ?assertEqual(Expect, Got).
+    ?assertMatch(
+        {component_template, [~"<div>", ~"", ~"</div>"], [Callback, _]} when
+            is_function(Callback, 2),
+        Got
+    ).
 
 render_nested_template(Config) when is_list(Config) ->
     View = arizona_view:new(#{foo => ~"foo", bar => ~"bar"}),
-    Socket = arizona_socket:new(),
-    Expect = {nested_template, View, Socket, [~"<div>", ~"", ~"</div>"], [~"foo", ~"bar"]},
-    {callback, Callback} = arizona_render:nested_template(~"""
+    Got = arizona_render:nested_template(View, ~"""
     <div>
       {arizona_view:get_assign(foo, View)}
       {arizona_view:get_assign(bar, View)}
     </div>
     """),
-    Got = erlang:apply(Callback, [View, Socket]),
-    ?assertEqual(Expect, Got).
+    ?assertMatch(
+        {nested_template, [~"<div>", ~"", ~"</div>"], [Callback, _]} when is_function(Callback, 2),
+        Got
+    ).
 
 render_view(Config) when is_list(Config) ->
     Mod = foo,
     Assigns = #{id => ~"foo"},
-    ParentView = arizona_view:new(#{}),
-    Socket = arizona_socket:new(),
-    Expect = {view, ParentView, Socket, Mod, Assigns},
-    {callback, Callback} = arizona_render:view(Mod, Assigns),
-    Got = erlang:apply(Callback, [ParentView, Socket]),
+    Expect = {view, Mod, Assigns},
+    Got = arizona_render:view(Mod, Assigns),
     ?assertEqual(Expect, Got).
 
 render_component(Config) when is_list(Config) ->
     Mod = foo,
     Fun = bar,
     Assigns = #{},
-    ParentView = arizona_view:new(#{}),
-    Socket = arizona_socket:new(),
-    Expect = {component, ParentView, Socket, Mod, Fun, Assigns},
-    {callback, Callback} = arizona_render:component(Mod, Fun, Assigns),
-    Got = erlang:apply(Callback, [ParentView, Socket]),
+    Expect = {component, Mod, Fun, Assigns},
+    Got = arizona_render:component(Mod, Fun, Assigns),
     ?assertEqual(Expect, Got).

--- a/test/arizona_view_SUITE.erl
+++ b/test/arizona_view_SUITE.erl
@@ -83,8 +83,8 @@ render(Config) when is_list(Config) ->
     ParentView = arizona_view:new(#{}),
     Socket = arizona_socket:new(),
     {ok, View} = arizona_view:mount(Mod, Assigns, Socket),
-    Token = arizona_view:render(Mod, View, Socket),
-    Got = arizona_render:render(Token, ParentView, Socket),
+    Token = arizona_view:render(Mod, View),
+    Got = arizona_render:render(Token, View, ParentView, Socket),
     ?assertEqual(Expect, Got).
 
 rendered_to_iolist(Config) when is_list(Config) ->
@@ -108,8 +108,8 @@ rendered_to_iolist(Config) when is_list(Config) ->
     Mod = arizona_example_template,
     Assigns = #{id => ~"app", count => 0},
     {ok, View0} = arizona_view:mount(Mod, Assigns, Socket),
-    Token = arizona_view:render(Mod, View0, Socket),
-    {View, _Socket} = arizona_render:render(Token, ParentView, Socket),
+    Token = arizona_view:render(Mod, View0),
+    {View, _Socket} = arizona_render:render(Token, View0, ParentView, Socket),
     Got = arizona_view:rendered_to_iolist(View),
     ?assertEqual(Expect, Got).
 
@@ -122,12 +122,11 @@ render_nested_template_to_iolist(Config) when is_list(Config) ->
         ]
     ],
     ParentView0 = arizona_view:new(#{show_dialog => true, message => ~"Hello, World!"}),
-    Socket = arizona_socket:new(),
-    Token = arizona_render:nested_template(~""""
+    Token = arizona_render:nested_template(ParentView0, ~""""
     <div>
         {case arizona_view:get_assign(show_dialog, View) of
              true ->
-                 arizona_render:nested_template(~"""
+                 arizona_render:nested_template(View, ~"""
                  <dialog open>
                      {arizona_view:get_assign(message, View)}
                  </dialog>
@@ -137,6 +136,7 @@ render_nested_template_to_iolist(Config) when is_list(Config) ->
          end}
     </div>
     """"),
-    {ParentView, _Socket} = arizona_render:render(Token, ParentView0, Socket),
+    Socket = arizona_socket:new(),
+    {ParentView, _Socket} = arizona_render:render(Token, ParentView0, ParentView0, Socket),
     Got = arizona_view:rendered_to_iolist(ParentView),
     ?assertEqual(Expect, Got).

--- a/test/support/arizona_example_components.erl
+++ b/test/support/arizona_example_components.erl
@@ -1,8 +1,8 @@
 -module(arizona_example_components).
--export([button/2]).
+-export([button/1]).
 
-button(View, Socket) ->
-    arizona_render:component_template(View, Socket, ~"""
+button(View) ->
+    arizona_render:component_template(View, ~"""
     <button>
         {arizona_view:get_assign(text, View)}
     </button>

--- a/test/support/arizona_example_counter.erl
+++ b/test/support/arizona_example_counter.erl
@@ -2,7 +2,7 @@
 -behaviour(arizona_view).
 
 -export([mount/2]).
--export([render/2]).
+-export([render/1]).
 
 mount(Assigns, _Socket) ->
     View = arizona_view:new(?MODULE, Assigns#{
@@ -10,8 +10,8 @@ mount(Assigns, _Socket) ->
     }),
     {ok, View}.
 
-render(View, Socket) ->
-    arizona_render:view_template(View, Socket, ~""""
+render(View) ->
+    arizona_render:view_template(View, ~""""
     <div id="{arizona_view:get_assign(id, View)}">
         {integer_to_binary(arizona_view:get_assign(count, View))}
         {arizona_render:component(arizona_example_components, button, #{

--- a/test/support/arizona_example_ignore.erl
+++ b/test/support/arizona_example_ignore.erl
@@ -2,12 +2,12 @@
 -behaviour(arizona_view).
 
 -export([mount/2]).
--export([render/2]).
+-export([render/1]).
 
 mount(_Assigns, _Socket) ->
     ignore.
 
-render(View, Socket) ->
-    arizona_render:view_template(View, Socket, ~""""
+render(View) ->
+    arizona_render:view_template(View, ~""""
     ignored
     """").

--- a/test/support/arizona_example_template.erl
+++ b/test/support/arizona_example_template.erl
@@ -2,14 +2,14 @@
 -behaviour(arizona_view).
 
 -export([mount/2]).
--export([render/2]).
+-export([render/1]).
 
 mount(Assigns, _Socket) ->
     View = arizona_view:new(?MODULE, Assigns),
     {ok, View}.
 
-render(View, Socket) ->
-    arizona_render:view_template(View, Socket, ~""""
+render(View) ->
+    arizona_render:view_template(View, ~""""
     <html>
         <head></head>
         <body id="{arizona_view:get_assign(id, View)}">


### PR DESCRIPTION
# Description

This PR restructures the template tokens and changes the dynamic list to a list of callbacks instead of binaries.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
