### PR TITLE
Introduce `arizona_render:if_true/2` function

### DIFF
--- a/src/arizona_render.erl
+++ b/src/arizona_render.erl
@@ -10,6 +10,7 @@
 -export([nested_template/2]).
 -export([view/2]).
 -export([component/3]).
+-export([if_true/2]).
 
 %
 
@@ -19,6 +20,7 @@
 -ignore_xref([nested_template/2]).
 -ignore_xref([view/2]).
 -ignore_xref([component/3]).
+-ignore_xref([if_true/2]).
 
 %% --------------------------------------------------------------------
 %% Types (and their exports)
@@ -133,6 +135,18 @@ view(Mod, Assigns) when is_atom(Mod), is_map(Assigns), is_map_key(id, Assigns) -
     Token :: {component, Mod, Fun, Assigns}.
 component(Mod, Fun, Assigns) when is_atom(Mod), is_atom(Fun), is_map(Assigns) ->
     {component, Mod, Fun, Assigns}.
+
+-spec if_true(Cond, Callback) -> Rendered when
+    Cond :: boolean(),
+    Callback :: fun(() -> Rendered),
+    Rendered :: rendered_value().
+if_true(Cond, Callback) when is_function(Callback, 0) ->
+    case Cond of
+        true ->
+            erlang:apply(Callback, []);
+        false ->
+            ~""
+    end.
 
 %% --------------------------------------------------------------------
 %% Private functions

--- a/test/arizona_view_SUITE.erl
+++ b/test/arizona_view_SUITE.erl
@@ -124,16 +124,13 @@ render_nested_template_to_iolist(Config) when is_list(Config) ->
     ParentView0 = arizona_view:new(#{show_dialog => true, message => ~"Hello, World!"}),
     Token = arizona_render:nested_template(ParentView0, ~""""
     <div>
-        {case arizona_view:get_assign(show_dialog, View) of
-             true ->
-                 arizona_render:nested_template(View, ~"""
-                 <dialog open>
-                     {arizona_view:get_assign(message, View)}
-                 </dialog>
-                 """);
-             false ->
-                 ~""
-         end}
+        {arizona_render:if_true(arizona_view:get_assign(show_dialog, View), fun() ->
+             arizona_render:nested_template(View, ~"""
+             <dialog open>
+                 {arizona_view:get_assign(message, View)}
+             </dialog>
+             """)
+         end)}
     </div>
     """"),
     Socket = arizona_socket:new(),


### PR DESCRIPTION
# Description

This is a useful conditional function.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
