### PR TITLE
Introduce static files generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ _build/
 _checkouts/
 doc/
 node_modules/
+static/
 package-lock.json
 erl_crash.dump
 rebar3.crashdump

--- a/src/arizona_config.erl
+++ b/src/arizona_config.erl
@@ -4,11 +4,16 @@
 %% API function exports
 %% --------------------------------------------------------------------
 
+-export([static_dir/0]).
 -export([endpoint/0]).
 
 %% --------------------------------------------------------------------
 %% API function definitions
 %% --------------------------------------------------------------------
+
+-spec static_dir() -> file:filename_all().
+static_dir() ->
+    get_env(static_dir, "static").
 
 -spec endpoint() -> arizona_server:opts().
 endpoint() ->

--- a/src/arizona_server.erl
+++ b/src/arizona_server.erl
@@ -36,12 +36,6 @@
 }.
 -export_type([opts/0]).
 
--type route() ::
-    {ok, cowboy_req:req(), cowboy_middleware:env()}
-    | {suspend, module(), atom(), [any()]}
-    | {stop, cowboy_req:req()}.
--export_type([route/0]).
-
 %% --------------------------------------------------------------------
 %% API function definitions
 %% --------------------------------------------------------------------
@@ -55,7 +49,10 @@ start(Opts) when is_map(Opts) ->
 
 -spec req_route(Req) -> Route when
     Req :: cowboy_req:req(),
-    Route :: route().
+    Route ::
+        {ok, cowboy_req:req(), cowboy_middleware:env()}
+        | {suspend, module(), atom(), [term()]}
+        | {stop, cowboy_req:req()}.
 req_route(Req) ->
     Qs = cowboy_req:match_qs([path], Req),
     Path = maps:get(path, Qs),
@@ -65,7 +62,7 @@ req_route(Req) ->
     ).
 
 %% --------------------------------------------------------------------
-%% Private
+%% Private functions
 %% --------------------------------------------------------------------
 
 start_1(#{scheme := http, transport := Transport, proto := Proto}) ->

--- a/src/arizona_static.erl
+++ b/src/arizona_static.erl
@@ -19,30 +19,43 @@
 -spec generate() -> ok.
 generate() ->
     Routes = maps:get(routes, arizona_config:endpoint()),
-    OutDir = arizona_config:static_dir(),
-    generate(Routes, OutDir).
+    StaticDir = arizona_config:static_dir(),
+    generate(Routes, StaticDir).
 
--spec generate(Routes, OutDir) -> ok when
+-spec generate(Routes, StaticDir) -> ok when
     Routes :: list(),
-    OutDir :: file:filename_all().
-generate(Routes, OutDir) when is_list(Routes), is_list(OutDir) ->
-    ok = filelib:ensure_path(OutDir),
-    lists:foreach(fun(Route) -> parse_route(Route, OutDir) end, Routes).
+    StaticDir :: file:filename_all().
+generate(Routes, StaticDir) when
+    is_list(Routes), (is_list(StaticDir) orelse is_binary(StaticDir))
+->
+    ok = filelib:ensure_path(StaticDir),
+    lists:foreach(fun(Route) -> parse_route(Route, StaticDir) end, Routes).
 
 %% --------------------------------------------------------------------
 %% Private functions
 %% --------------------------------------------------------------------
 
-parse_route({Path, cowboy_static, {priv_file, App, Filename}}, OutDir) ->
+parse_route({Path, cowboy_static, {priv_file, App, Filename}}, StaticDir) ->
+    parse_priv_file(Path, App, Filename, StaticDir);
+parse_route({Path, cowboy_static, {priv_dir, App, Dir}}, StaticDir) ->
+    parse_priv_dir(Path, App, Dir, StaticDir);
+parse_route({Path, arizona_view_handler, {Mod, Assigns}}, StaticDir) ->
+    parse_view(Path, Mod, Assigns, StaticDir);
+parse_route(Route, StaticDir) ->
+    error(invalid_route, [Route, StaticDir], [
+        {error_info, #{cause => ~"only static route is allowed"}}
+    ]).
+
+parse_priv_file(Path, App, Filename, StaticDir) ->
     ok = check_path_segments(Path),
     AppDir = code:lib_dir(App),
     Source = filename:join([AppDir, "priv", Filename]),
-    Destination = filename:join([OutDir, tl(Path)]),
+    Destination = filename:join([StaticDir, tl(Path)]),
     {ok, Bin} = file:read_file(Source),
     ok = filelib:ensure_path(filename:dirname(Destination)),
-    ok = file:write_file(Destination, Bin),
-    ok;
-parse_route({Path0, cowboy_static, {priv_dir, App, Dir}}, OutDir) ->
+    ok = file:write_file(Destination, Bin).
+
+parse_priv_dir(Path0, App, Dir, StaticDir) ->
     Path = lists:flatten(string:replace(Path0, "/[...]", "")),
     ok = check_path_segments(Path),
     AppDir = code:lib_dir(App),
@@ -51,47 +64,42 @@ parse_route({Path0, cowboy_static, {priv_dir, App, Dir}}, OutDir) ->
     ok = lists:foreach(
         fun(Filename) ->
             Source = filename:join([AppDir, "priv", Filename]),
-            Destination = filename:join([OutDir, tl(Path), filename:basename(Filename)]),
+            Destination = filename:join([StaticDir, tl(Path), filename:basename(Filename)]),
             {ok, Bin} = file:read_file(Source),
             ok = filelib:ensure_path(filename:dirname(Destination)),
-            ok = file:write_file(Destination, Bin),
-            ok
+            ok = file:write_file(Destination, Bin)
         end,
         Files
-    ),
-    ok;
-parse_route({Path, arizona_view_handler, {Mod, Assigns}}, OutDir) ->
+    ).
+
+parse_view(Path, Mod, Assigns, StaticDir) ->
     ok = check_path_segments(Path),
     Socket0 = arizona_socket:new(render),
     {ok, View0} = arizona_view:mount(Mod, Assigns, Socket0),
     Token = arizona_view:render(Mod, View0),
     {View, _Socket} = arizona_render:render(Token, View0, View0, Socket0),
     Html = arizona_view:rendered_to_iolist(View),
-    Destination = filename:join([OutDir, tl(Path), "index.html"]),
-    ok = file:write_file(Destination, Html),
-    ok;
-parse_route(Route, OutDir) ->
-    error(invalid_route, [Route, OutDir], [
-        {error_info, #{cause => ~"only static files are allowed"}}
-    ]).
+    Destination = filename:join([StaticDir, tl(Path), "index.html"]),
+    ok = file:write_file(Destination, Html).
 
 check_path_segments(Path) ->
     [[] | Segments] = string:split(Path, "/", all),
-    case check_path_segments_1(Segments) of
-        ok ->
-            ok;
-        error ->
+    case contains_dynamic_segment(Segments) of
+        true ->
             error(badpath, [Path], [
                 {error_info, #{cause => ~"match syntax is not allowed"}}
-            ])
+            ]);
+        false ->
+            ok
     end.
 
-check_path_segments_1([]) ->
+% Searches for dynamic segments, e.g "/[:user_id]/profile".
+contains_dynamic_segment([]) ->
     ok;
-check_path_segments_1([Segment | T]) ->
+contains_dynamic_segment([Segment | T]) ->
     case Segment =/= [] andalso hd(Segment) of
         $[ ->
             error;
         _ ->
-            check_path_segments_1(T)
+            contains_dynamic_segment(T)
     end.

--- a/src/arizona_static.erl
+++ b/src/arizona_static.erl
@@ -28,7 +28,6 @@ generate() ->
 generate(Routes, StaticDir) when
     is_list(Routes), (is_list(StaticDir) orelse is_binary(StaticDir))
 ->
-    ok = filelib:ensure_path(StaticDir),
     lists:foreach(fun(Route) -> process_route(Route, StaticDir) end, Routes).
 
 %% --------------------------------------------------------------------

--- a/src/arizona_static.erl
+++ b/src/arizona_static.erl
@@ -1,0 +1,97 @@
+-module(arizona_static).
+
+%% --------------------------------------------------------------------
+%% API function exports
+%% --------------------------------------------------------------------
+
+-export([generate/0]).
+-export([generate/2]).
+
+%
+
+-ignore_xref([generate/0]).
+-ignore_xref([generate/2]).
+
+%% --------------------------------------------------------------------
+%% API function definitions
+%% --------------------------------------------------------------------
+
+-spec generate() -> ok.
+generate() ->
+    Routes = maps:get(routes, arizona_config:endpoint()),
+    OutDir = arizona_config:static_dir(),
+    generate(Routes, OutDir).
+
+-spec generate(Routes, OutDir) -> ok when
+    Routes :: list(),
+    OutDir :: file:filename_all().
+generate(Routes, OutDir) when is_list(Routes), is_list(OutDir) ->
+    ok = filelib:ensure_path(OutDir),
+    lists:foreach(fun(Route) -> parse_route(Route, OutDir) end, Routes).
+
+%% --------------------------------------------------------------------
+%% Private functions
+%% --------------------------------------------------------------------
+
+parse_route({Path, cowboy_static, {priv_file, App, Filename}}, OutDir) ->
+    ok = check_path_segments(Path),
+    AppDir = code:lib_dir(App),
+    Source = filename:join([AppDir, "priv", Filename]),
+    Destination = filename:join([OutDir, tl(Path)]),
+    {ok, Bin} = file:read_file(Source),
+    ok = filelib:ensure_path(filename:dirname(Destination)),
+    ok = file:write_file(Destination, Bin),
+    ok;
+parse_route({Path0, cowboy_static, {priv_dir, App, Dir}}, OutDir) ->
+    Path = lists:flatten(string:replace(Path0, "/[...]", "")),
+    ok = check_path_segments(Path),
+    AppDir = code:lib_dir(App),
+    Wildcard = filename:join([AppDir, "priv", Dir, "**", "*"]),
+    Files = [File || File <- filelib:wildcard(Wildcard), filelib:is_regular(File)],
+    ok = lists:foreach(
+        fun(Filename) ->
+            Source = filename:join([AppDir, "priv", Filename]),
+            Destination = filename:join([OutDir, tl(Path), filename:basename(Filename)]),
+            {ok, Bin} = file:read_file(Source),
+            ok = filelib:ensure_path(filename:dirname(Destination)),
+            ok = file:write_file(Destination, Bin),
+            ok
+        end,
+        Files
+    ),
+    ok;
+parse_route({Path, arizona_view_handler, {Mod, Assigns}}, OutDir) ->
+    ok = check_path_segments(Path),
+    Socket0 = arizona_socket:new(render),
+    {ok, View0} = arizona_view:mount(Mod, Assigns, Socket0),
+    Token = arizona_view:render(Mod, View0),
+    {View, _Socket} = arizona_render:render(Token, View0, View0, Socket0),
+    Html = arizona_view:rendered_to_iolist(View),
+    Destination = filename:join([OutDir, tl(Path), "index.html"]),
+    ok = file:write_file(Destination, Html),
+    ok;
+parse_route(Route, OutDir) ->
+    error(invalid_route, [Route, OutDir], [
+        {error_info, #{cause => ~"only static files are allowed"}}
+    ]).
+
+check_path_segments(Path) ->
+    [[] | Segments] = string:split(Path, "/", all),
+    case check_path_segments_1(Segments) of
+        ok ->
+            ok;
+        error ->
+            error(badpath, [Path], [
+                {error_info, #{cause => ~"match syntax is not allowed"}}
+            ])
+    end.
+
+check_path_segments_1([]) ->
+    ok;
+check_path_segments_1([Segment | T]) ->
+    case Segment =/= [] andalso hd(Segment) of
+        $[ ->
+            error;
+        _ ->
+            check_path_segments_1(T)
+    end.

--- a/test/arizona_static_SUITE.erl
+++ b/test/arizona_static_SUITE.erl
@@ -1,0 +1,87 @@
+-module(arizona_static_SUITE).
+-behaviour(ct_suite).
+-include_lib("stdlib/include/assert.hrl").
+-compile([export_all, nowarn_export_all]).
+
+%% --------------------------------------------------------------------
+%% Behaviour (ct_suite) callbacks
+%% --------------------------------------------------------------------
+
+all() ->
+    [
+        {group, write},
+        {group, error}
+    ].
+
+groups() ->
+    [
+        {write, [parallel], [
+            write_priv_file,
+            write_deep_priv_file,
+            write_priv_dir,
+            write_deep_priv_dir,
+            write_view_as_html,
+            write_deep_view_as_html
+        ]},
+        {error, [parallel], [
+            badpath_error,
+            invalid_route_error
+        ]}
+    ].
+
+%% --------------------------------------------------------------------
+%% Tests
+%% --------------------------------------------------------------------
+
+write_priv_file(Config) when is_list(Config) ->
+    Route = {"/arizona.js", cowboy_static, {priv_file, arizona, "static/assets/js/arizona.js"}},
+    ?assertEqual(ok, generate(Route)),
+    ?assert(exists("arizona.js")).
+
+write_deep_priv_file(Config) when is_list(Config) ->
+    Route =
+        {"/a/b/c/arizona.js", cowboy_static, {priv_file, arizona, "static/assets/js/arizona.js"}},
+    ?assertEqual(ok, generate(Route)),
+    ?assert(exists("a/b/c/arizona.js")).
+
+write_priv_dir(Config) when is_list(Config) ->
+    Route = {"/[...]", cowboy_static, {priv_dir, arizona, "static/assets/js"}},
+    ?assertEqual(ok, generate(Route)),
+    ?assert(exists("arizona.js")),
+    ?assert(exists("arizona-worker.js")).
+
+write_deep_priv_dir(Config) when is_list(Config) ->
+    Route = {"/a/b/c/[...]", cowboy_static, {priv_dir, arizona, "static/assets/js"}},
+    ?assertEqual(ok, generate(Route)),
+    ?assert(exists("a/b/c/arizona.js")),
+    ?assert(exists("a/b/c/arizona-worker.js")).
+
+write_view_as_html(Config) when is_list(Config) ->
+    Route = {"/", arizona_view_handler, {arizona_example_counter, #{count => 0}}},
+    ?assertEqual(ok, generate(Route)),
+    ?assert(exists("index.html")).
+
+write_deep_view_as_html(Config) when is_list(Config) ->
+    Route = {"/a/b/c/", arizona_view_handler, {arizona_example_counter, #{count => 0}}},
+    ?assertEqual(ok, generate(Route)),
+    ?assert(exists("a/b/c/index.html")).
+
+badpath_error(Config) when is_list(Config) ->
+    Route = {"/[:user_id]/profile", cowboy_static, {priv_file, foo, "foo.html"}},
+    ?assertError(badpath, generate(Route)).
+
+invalid_route_error(Config) when is_list(Config) ->
+    Route = {"/websocket", arizona_websocket, []},
+    ?assertError(invalid_route, generate(Route)).
+
+%% --------------------------------------------------------------------
+%% Support
+%% --------------------------------------------------------------------
+
+generate(Route) ->
+    arizona_static:generate([Route], static_dir()).
+
+exists(Filename) ->
+    filelib:is_regular(filename:join(static_dir(), Filename)).
+
+static_dir() -> ~"static".


### PR DESCRIPTION
# Description

This PR introduces the `arizona_static` module to generate static files.

Valid paths:

- `priv_file`: the file is copied
- `priv_dir`: the files of the dir are copied
- `arizona_view_handler`: the view is rendered and saved as HTML and named as `index.html`

Probably valid routes/paths are missing, but I'll keep it as it is for now.

## Example

In the `config/sys.config`:

```erlang
[
    {arizona, [
        {static_dir, "static"}, % <- relative output folder
        {endpoint, #{
            routes => [
                % Static
                {"/favicon.ico", cowboy_static, {priv_file, arizona_example, "static/favicon.ico"}},
                {"/robots.txt", cowboy_static, {priv_file, arizona_example, "static/robots.txt"}},
                {"/assets/[...]", cowboy_static, {priv_dir, arizona_example, "static/assets"}},
                % Views
                {"/", arizona_view_handler,
                    {arizona_example_view_counter, #{
                        title => ~"Arizona Example",
                        id => ~"app"
                    }}}
            ]
        }}
    ]}
].
```

Running the command via shell:

```bash
$ rebar3 shell
1> arizona_static:generate().
ok
```

Generated struct:

![image](https://github.com/user-attachments/assets/e85e78b4-eea0-4311-be5a-96d359df1af6)

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
