### PR TITLE
Introduce `arizona_render:layout/4`

### DIFF
--- a/src/arizona_render.erl
+++ b/src/arizona_render.erl
@@ -13,6 +13,7 @@
 -export([component/3]).
 -export([if_true/2]).
 -export([list/2]).
+-export([layout/4]).
 
 %
 
@@ -25,6 +26,7 @@
 -ignore_xref([component/3]).
 -ignore_xref([if_true/2]).
 -ignore_xref([list/2]).
+-ignore_xref([layout/4]).
 
 %% --------------------------------------------------------------------
 %% Types (and their exports)
@@ -200,6 +202,21 @@ list(Callback, List) when is_function(Callback, 1), is_list(List) ->
     {nested_template, Static, _Dynamic} = hd(NestedTemplates),
     DynamicList = [Dynamic || {nested_template, _Static, Dynamic} <- NestedTemplates],
     {list, Static, DynamicList}.
+
+-spec layout(LayoutMod, Assigns, InnerContent, Socket0) -> Layout when
+    LayoutMod :: module(),
+    Assigns :: arizona_view:assigns(),
+    InnerContent :: token(),
+    Socket0 :: arizona_socket:socket(),
+    Layout :: {LayoutView, Socket1},
+    LayoutView :: arizona_view:view(),
+    Socket1 :: arizona_socket:socket().
+layout(LayoutMod, Assigns, InnerContent, Socket) ->
+    LayoutView = arizona_view:new(Assigns#{
+        inner_content => [InnerContent]
+    }),
+    Token = arizona_component:render(LayoutMod, render, LayoutView),
+    render(Token, LayoutView, LayoutView, Socket).
 
 %% --------------------------------------------------------------------
 %% Private functions

--- a/src/arizona_view_handler.erl
+++ b/src/arizona_view_handler.erl
@@ -8,21 +8,49 @@
 -export([init/2]).
 
 %% --------------------------------------------------------------------
+%% Types (and their exports)
+%% --------------------------------------------------------------------
+
+-type opts() :: #{
+    layout => module()
+}.
+-export_type([opts/0]).
+
+%% --------------------------------------------------------------------
 %% Behaviour (cowboy_handler) callbacks
 %% --------------------------------------------------------------------
 
 -spec init(Req0, State) -> {ok, Req1, State} when
     Req0 :: cowboy_req:req(),
-    State :: {Mod, Assigns},
+    State :: {Mod, Assigns, Opts},
     Mod :: module(),
     Assigns :: arizona_view:assigns(),
+    Opts :: opts(),
     Req1 :: cowboy_req:req().
-init(Req0, {Mod, Assigns} = State) when is_atom(Mod), is_map(Assigns) ->
+init(Req0, {Mod, Assigns, Opts} = State) when is_atom(Mod), is_map(Assigns), is_map(Opts) ->
     Socket0 = arizona_socket:new(render),
     {ok, View0} = arizona_view:mount(Mod, Assigns, Socket0),
-    Token = arizona_view:render(Mod, View0),
-    {View, _Socket} = arizona_render:render(Token, View0, View0, Socket0),
+    TemplateToken = arizona_view:render(Mod, View0),
+    {View1, Token} = maybe_render_layout(View0, TemplateToken, Opts),
+    {View, _Socket} = arizona_render:render(Token, View1, View1, Socket0),
     Html = arizona_view:rendered_to_iolist(View),
     Headers = #{~"content-type" => ~"text/html"},
     Req = cowboy_req:reply(200, Headers, Html, Req0),
     {ok, Req, State}.
+
+%% --------------------------------------------------------------------
+%% Private functions
+%% --------------------------------------------------------------------
+
+maybe_render_layout(View, TemplateToken, Opts) ->
+    case Opts of
+        #{layout := Mod} ->
+            Assigns = arizona_view:assigns(View),
+            LayoutView = arizona_view:new(Assigns#{
+                inner_content => TemplateToken
+            }),
+            Token = arizona_component:render(Mod, render, LayoutView),
+            {LayoutView, Token};
+        #{} ->
+            {View, TemplateToken}
+    end.

--- a/test/arizona_view_handler_SUITE.erl
+++ b/test/arizona_view_handler_SUITE.erl
@@ -17,11 +17,13 @@ init_per_suite(Config) ->
             {endpoint, #{
                 routes => [
                     {"/helloworld", arizona_view_handler,
-                        {?MODULE, #{
-                            title => ~"Arizona",
-                            id => ~"app",
-                            name => ~"World"
-                        }}}
+                        {?MODULE,
+                            #{
+                                title => ~"Arizona",
+                                id => ~"app",
+                                name => ~"World"
+                            },
+                            #{layout => arizona_example_layout}}}
                 ]
             }}
         ]}
@@ -49,19 +51,9 @@ mount(Assigns, _Socket) ->
     Token :: arizona_render:token().
 render(View) ->
     arizona_render:view_template(View, ~""""
-    <!DOCTYPE html>
-    <html lang="en">
-    <head>
-        <meta charset="UTF-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>{arizona_view:get_assign(title, View)}</title>
-        <script src="assets/js/main.js"></script>
-    </head>
-    <body id="{arizona_view:get_assign(id, View)}">
+    <main id="{arizona_view:get_assign(id, View)}">
        Hello, {arizona_view:get_assign(name, View)}!
-    </body>
-    </html>
+    </main>
     """").
 
 %% --------------------------------------------------------------------

--- a/test/arizona_view_handler_SUITE.erl
+++ b/test/arizona_view_handler_SUITE.erl
@@ -16,11 +16,11 @@ init_per_suite(Config) ->
         {arizona, [
             {endpoint, #{
                 routes => [
-                    {"/helloworld", arizona_view_handler,
+                    {"/hello-world", arizona_view_handler,
                         {?MODULE,
                             #{
                                 title => ~"Arizona",
-                                id => ~"app",
+                                id => ~"helloWorld",
                                 name => ~"World"
                             },
                             #{layout => arizona_example_layout}}}
@@ -52,7 +52,7 @@ mount(Assigns, _Socket) ->
 render(View) ->
     arizona_render:view_template(View, ~""""
     <main id="{arizona_view:get_assign(id, View)}">
-       Hello, {arizona_view:get_assign(name, View)}!
+        Hello, {arizona_view:get_assign(name, View)}!
     </main>
     """").
 
@@ -61,22 +61,32 @@ render(View) ->
 %% --------------------------------------------------------------------
 
 hello_world(Config) when is_list(Config) ->
-    Resp0 = httpc:request("http://localhost:8080/notfound"),
-    ?assert(is_status(404, Resp0)),
-    Resp1 = httpc:request("http://localhost:8080/helloworld"),
-    ?assert(is_status(200, Resp1)),
-    ?assert(is_body("Hello, World!", Resp1)).
+    ?assertEqual({404, ~""}, request("/404")),
+    ?assertEqual({200, ~"""
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Arizona</title>
+        <script src="assets/js/arizona/worker.js"></script>
+        <script src="assets/js/arizona/main.js"></script>
+    </head>
+    <body> <main id="helloWorld">
+        Hello, World!
+    </main></body>
+    </html>
+    """}, request("/hello-world")).
 
 %% --------------------------------------------------------------------
 %% Test support
 %% --------------------------------------------------------------------
 
-is_body(Pattern, {ok, {{_HttpVersion, _StatusCode, _String}, _HttpHeaders, HttpBodyResult}}) ->
-    nomatch =/= string:find(HttpBodyResult, Pattern);
-is_body(_Pattern, _Result) ->
-    false.
-
-is_status(StatusCode, {ok, {{_HttpVersion, StatusCode, _String}, _HttpHeaders, _HttpBodyResult}}) ->
-    true;
-is_status(_StatusCode, _Result) ->
-    false.
+request(Uri) ->
+    Url = io_lib:format("http://localhost:8080~s", [Uri]),
+    Headers = [],
+    HttpOptions = [],
+    Options = [{body_format, binary}, {full_result, false}],
+    {ok, Response} = httpc:request(get, {Url, Headers}, HttpOptions, Options),
+    Response.

--- a/test/support/arizona_example_layout.erl
+++ b/test/support/arizona_example_layout.erl
@@ -1,0 +1,21 @@
+-module(arizona_example_layout).
+
+-export([render/1]).
+
+render(View) ->
+    arizona_render:component_template(View, ~"""
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>{arizona_view:get_assign(title, View)}</title>
+        <script src="assets/js/arizona/worker.js"></script>
+        <script src="assets/js/arizona/main.js"></script>
+    </head>
+    <body>
+        {arizona_view:get_assign(inner_content, View)}
+    </body>
+    </html>
+    """).


### PR DESCRIPTION
# Description

This PR makes it possible to render layouts.

A  layout is just a component rendered via a render function in a module, for example:

```erlang
-module(arizona_example_layout).

-export([render/1]).

render(View) ->
    arizona_render:component_template(View, ~"""
    <!DOCTYPE html>
    <html lang="en">
    <head>
        <meta charset="UTF-8">
        <meta http-equiv="X-UA-Compatible" content="IE=edge">
        <meta name="viewport" content="width=device-width, initial-scale=1.0">
        <title>{arizona_view:get_assign(title, View)}</title>
        <script src="assets/js/arizona/worker.js"></script>
        <script src="assets/js/arizona/main.js"></script>
    </head>
    <body>
        {arizona_view:get_assign(inner_content, View)}
    </body>
    </html>
    """).
```

The layout is defined in the route:

```erlang
% config/sys.config
[
    {arizona, [
        {endpoint, #{
            routes => [
                {"/hello-world", arizona_view_handler,
                    {hello_world_view_module,
                        #{
                            title => ~"Arizona",
                            id => ~"helloWorld",
                            name => ~"World"
                        },
                        #{layout => arizona_example_layout}}} % <- layout option
            ]
        }}
    ]}
]),
```

The `inner_content` assigned in the layout is replaced by the rendered view,

- [ ] I have performed a self-review of my changes
- [ ] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
