### PR TITLE
Add `diff` field to the view record

### DIFF
--- a/src/arizona_diff.erl
+++ b/src/arizona_diff.erl
@@ -14,6 +14,9 @@
 %% Types (and their exports)
 %% --------------------------------------------------------------------
 
+-type diff() :: [{index(), arizona_render:rendered_value() | diff()}].
+-export_type([diff/0]).
+
 -type index() :: non_neg_integer().
 -export_type([index/0]).
 
@@ -107,9 +110,9 @@ diff_component_template(View0, Socket0, Dynamic) ->
 diff_nested_template(ParentView0, Socket0, Dynamic, Index) ->
     Assigns = arizona_view:assigns(ParentView0),
     ChangedAssigns = arizona_view:changed_assigns(ParentView0),
-    View0 = arizona_view:new(undefined, Assigns, ChangedAssigns, []),
+    View0 = arizona_view:new(undefined, Assigns, ChangedAssigns, [], []),
     {View, Socket} = diff_dynamic(Dynamic, View0, Socket0, #{}),
-    Diff = arizona_view:rendered(View),
+    Diff = arizona_view:diff(View),
     ParentView = arizona_view:put_diff(Index, Diff, ParentView0),
     {ParentView, Socket}.
 
@@ -125,7 +128,7 @@ diff_dynamic_list_callback([Item | T], Callback, Index, View, Socket) ->
     Dynamic = erlang:apply(Callback, [Item]),
     {DiffView, _Socket} = diff(Dynamic, Index, View, Socket),
     [
-        arizona_view:rendered(DiffView)
+        arizona_view:diff(DiffView)
         | diff_dynamic_list_callback(T, Callback, Index, View, Socket)
     ].
 
@@ -134,12 +137,12 @@ diff_view(ParentView, Socket, Mod, Assigns, Index) ->
     case arizona_socket:get_view(ViewId, Socket) of
         {ok, View0} ->
             View = arizona_view:set_changed_assigns(Assigns, View0),
-            render_view(ParentView, Socket, Mod, Assigns, Index, View, ViewId);
+            diff_view_1(ParentView, Socket, Mod, Assigns, Index, View, ViewId);
         error ->
             mount_view(ParentView, Socket, Mod, Assigns, Index)
     end.
 
-render_view(ParentView0, Socket0, Mod, NewAssigns, Index, View0, ViewId) ->
+diff_view_1(ParentView0, Socket0, Mod, NewAssigns, Index, View0, ViewId) ->
     {view_template, _Static, Dynamic} = arizona_view:render(View0),
     OldAssigns = arizona_view:assigns(View0),
     ChangedAssigns = view_changed_assigns(OldAssigns, NewAssigns),
@@ -151,9 +154,9 @@ render_view(ParentView0, Socket0, Mod, NewAssigns, Index, View0, ViewId) ->
             mount_view(ParentView0, Socket2, Mod, NewAssigns, Index);
         #{} ->
             View3 = arizona_view:merge_changed_assigns(View2),
-            Rendered = arizona_view:rendered(View3),
-            ParentView = arizona_view:put_diff(Index, Rendered, ParentView0),
-            View = arizona_view:set_rendered([], View3),
+            Diff = arizona_view:diff(View3),
+            ParentView = arizona_view:put_diff(Index, Diff, ParentView0),
+            View = arizona_view:set_diff([], View3),
             Socket = arizona_socket:put_view(View, Socket1),
             {ParentView, Socket}
     end.
@@ -174,7 +177,8 @@ mount_view(ParentView0, Socket0, Mod, Assigns, Index) ->
             {View1, Socket2} = arizona_render:render(Token, View0, ParentView0, Socket1),
             Rendered = arizona_view:rendered(View1),
             ParentView = arizona_view:put_diff(Index, Rendered, ParentView0),
-            View = arizona_view:set_rendered([], View1),
+            View2 = arizona_view:set_rendered([], View1),
+            View = arizona_view:set_diff([], View2),
             Socket3 = arizona_socket:put_view(View, Socket2),
             Socket = arizona_socket:set_render_context(diff, Socket3),
             {ParentView, Socket};
@@ -186,7 +190,7 @@ diff_component(ParentView0, Socket0, Mod, Fun, Assigns, Index) ->
     View0 = arizona_view:new(Assigns),
     {component_template, _Static, Dynamic} = arizona_component:render(Mod, Fun, View0),
     {View, Socket} = diff_dynamic(Dynamic, View0, Socket0, #{force_changed => true}),
-    Diff = arizona_view:rendered(View),
+    Diff = arizona_view:diff(View),
     ParentView = arizona_view:put_diff(Index, Diff, ParentView0),
     {ParentView, Socket}.
 
@@ -199,8 +203,8 @@ diff_list(ParentView0, Socket, DynamicList0, Index) ->
 diff_dynamic_list([], _View, _Socket) ->
     [];
 diff_dynamic_list([Dynamic | T], View, Socket) ->
-    {RenderedView, _Socket} = diff_dynamic(Dynamic, View, Socket, #{force_changed => true}),
-    [arizona_view:rendered(RenderedView) | diff_dynamic_list(T, View, Socket)].
+    {DiffView, _Socket} = diff_dynamic(Dynamic, View, Socket, #{force_changed => true}),
+    [arizona_view:diff(DiffView) | diff_dynamic_list(T, View, Socket)].
 
 diff_dynamic([], View, Socket, _Opts) ->
     {View, Socket};

--- a/src/arizona_render.erl
+++ b/src/arizona_render.erl
@@ -65,7 +65,6 @@
 -type rendered_value() ::
     binary()
     | rendered()
-    | {arizona_diff:index(), binary() | rendered()}
     % I could not figure out a correct type without the `dynamic/0`.
     | dynamic().
 -export_type([rendered_value/0]).

--- a/test/arizona_diff_SUITE.erl
+++ b/test/arizona_diff_SUITE.erl
@@ -39,12 +39,12 @@ diff_view_template(Config) when is_list(Config) ->
     ExpectAssigns = maps:merge(Assigns, ChangedAssigns),
     Diff = [{2, ~"baz"}],
     Expect = {
-        arizona_view:new(Mod, ExpectAssigns, ChangedAssigns, Diff),
+        arizona_view:new(Mod, ExpectAssigns, ChangedAssigns, [], Diff),
         arizona_socket:new(diff, #{
-            ViewId => arizona_view:new(Mod, ExpectAssigns, ChangedAssigns, Diff)
+            ViewId => arizona_view:new(Mod, ExpectAssigns, ChangedAssigns, [], Diff)
         })
     },
-    View = arizona_view:new(Mod, Assigns, ChangedAssigns, []),
+    View = arizona_view:new(Mod, Assigns, ChangedAssigns, [], []),
     Token = arizona_render:view_template(View, ~"""
     <div id={arizona_view:get_assign(id, View)}>
     {arizona_view:get_assign(foo, View)}
@@ -64,10 +64,10 @@ diff_component_template(Config) when is_list(Config) ->
     ChangedAssigns = #{bar => ~"baz"},
     Diff = [{1, ~"baz"}],
     Expect = {
-        arizona_view:new(Mod, Assigns, ChangedAssigns, Diff),
+        arizona_view:new(Mod, Assigns, ChangedAssigns, [], Diff),
         arizona_socket:new(diff)
     },
-    View = arizona_view:new(Mod, Assigns, ChangedAssigns, []),
+    View = arizona_view:new(Mod, Assigns, ChangedAssigns, [], []),
     Token = arizona_render:component_template(View, ~"""
     <div>
         {arizona_view:get_assign(foo, View)}
@@ -87,10 +87,10 @@ diff_nested_template(Config) when is_list(Config) ->
     ChangedAssigns = #{bar => ~"baz"},
     Diff = [{0, [{1, ~"baz"}]}],
     Expect = {
-        arizona_view:new(Mod, Assigns, ChangedAssigns, Diff),
+        arizona_view:new(Mod, Assigns, ChangedAssigns, [], Diff),
         arizona_socket:new(diff)
     },
-    View = arizona_view:new(Mod, Assigns, ChangedAssigns, []),
+    View = arizona_view:new(Mod, Assigns, ChangedAssigns, [], []),
     Token = arizona_render:nested_template(View, ~"""
     <div>
         {arizona_view:get_assign(foo, View)}
@@ -115,10 +115,10 @@ diff_list_template(Config) when is_list(Config) ->
         ]}
     ],
     Expect = {
-        arizona_view:new(Mod, Assigns, ChangedAssigns, Diff),
+        arizona_view:new(Mod, Assigns, ChangedAssigns, [], Diff),
         arizona_socket:new(diff)
     },
-    View = arizona_view:new(Mod, Assigns, ChangedAssigns, []),
+    View = arizona_view:new(Mod, Assigns, ChangedAssigns, [], []),
     Token = arizona_render:list(
         fun(Item) ->
             arizona_render:nested_template(#{'View' => View, 'Item' => Item}, ~"""
@@ -161,11 +161,11 @@ diff_view(Config) when is_list(Config) ->
         ]}
     ],
     Expect = {
-        arizona_view:new(Mod, ExpectAssigns, ChangedAssigns, Diff),
+        arizona_view:new(Mod, ExpectAssigns, ChangedAssigns, [], Diff),
         arizona_socket:new(diff, #{
-            ViewId => arizona_view:new(Mod, ExpectAssigns, ChangedAssigns, Diff),
+            ViewId => arizona_view:new(Mod, ExpectAssigns, ChangedAssigns, [], Diff),
             CounterViewId => arizona_view:new(
-                CounterMod, ExpectAssigns#{id => CounterViewId}, #{}, []
+                CounterMod, ExpectAssigns#{id => CounterViewId}, #{}, [], []
             )
         })
     },
@@ -203,17 +203,17 @@ diff_view_new_id(Config) when is_list(Config) ->
         ]}
     ],
     Expect = {
-        arizona_view:new(RootMod, ExpectAssigns, ChangedAssigns, Diff),
+        arizona_view:new(RootMod, ExpectAssigns, ChangedAssigns, [], Diff),
         arizona_socket:new(diff, #{
             ~"baz" => arizona_view:new(
-                Mod, #{id => ~"baz", ignore => false, name => ~"Arizona"}, #{}, []
+                Mod, #{id => ~"baz", ignore => false, name => ~"Arizona"}, #{}, [], []
             ),
             % FIXME: The 'ViewId' should be removed from the socket views.
             % The question is: How to know the previous id?
             ViewId => arizona_view:new(
-                Mod, #{id => ~"bar", ignore => false, name => ~"World"}, #{}, []
+                Mod, #{id => ~"bar", ignore => false, name => ~"World"}, #{}, [], []
             ),
-            RootViewId => arizona_view:new(RootMod, ExpectAssigns, ChangedAssigns, Diff)
+            RootViewId => arizona_view:new(RootMod, ExpectAssigns, ChangedAssigns, [], Diff)
         })
     },
     RenderSocket = arizona_socket:new(render),
@@ -242,14 +242,14 @@ diff_view_ignore(Config) when is_list(Config) ->
     ChangedAssigns = #{view_id => ~"baz", name => ~"Arizona", ignore => true},
     ExpectAssigns = maps:merge(Assigns, ChangedAssigns),
     Expect = {
-        arizona_view:new(RootMod, ExpectAssigns, ChangedAssigns, []),
+        arizona_view:new(RootMod, ExpectAssigns, ChangedAssigns, [], []),
         arizona_socket:new(diff, #{
             % FIXME: The 'ViewId' should be removed from the socket views.
             % The question is: How to know the previous id?
             ViewId => arizona_view:new(
-                Mod, #{id => ~"bar", ignore => false, name => ~"World"}, #{}, []
+                Mod, #{id => ~"bar", ignore => false, name => ~"World"}, #{}, [], []
             ),
-            RootViewId => arizona_view:new(RootMod, ExpectAssigns, ChangedAssigns, [])
+            RootViewId => arizona_view:new(RootMod, ExpectAssigns, ChangedAssigns, [], [])
         })
     },
     RenderSocket = arizona_socket:new(render),
@@ -276,11 +276,11 @@ diff_component(Config) when is_list(Config) ->
     ChangedAssigns = #{text => ~"+1"},
     Diff = [{0, ~"+1"}],
     Expect = {
-        arizona_view:new(Mod, Assigns, ChangedAssigns, Diff),
+        arizona_view:new(Mod, Assigns, ChangedAssigns, [], Diff),
         arizona_socket:new(diff)
     },
     RenderSocket = arizona_socket:new(render),
-    View0 = arizona_view:new(Mod, Assigns, ChangedAssigns, []),
+    View0 = arizona_view:new(Mod, Assigns, ChangedAssigns, [], []),
     RenderToken = arizona_component:render(Mod, Fun, View0),
     ParentView = arizona_view:new(#{}),
     {RenderedView, Socket0} = arizona_render:render(
@@ -302,10 +302,10 @@ diff_list(Config) when is_list(Config) ->
     ChangedAssigns = #{bar => ~"baz"},
     Diff = [{0, [{0, [~"foo", ~"baz"]}]}],
     Expect = {
-        arizona_view:new(Mod, Assigns, ChangedAssigns, Diff),
+        arizona_view:new(Mod, Assigns, ChangedAssigns, [], Diff),
         arizona_socket:new(diff)
     },
-    View = arizona_view:new(Mod, Assigns, ChangedAssigns, []),
+    View = arizona_view:new(Mod, Assigns, ChangedAssigns, [], []),
     Token = arizona_render:nested_template(View, ~"""
     <div>
         {[

--- a/test/arizona_view_SUITE.erl
+++ b/test/arizona_view_SUITE.erl
@@ -54,30 +54,36 @@ mount_ignore(Config) when is_list(Config) ->
 render(Config) when is_list(Config) ->
     Mod = arizona_example_template,
     Assigns = #{id => ~"app", count => 0},
-    RenderedView = arizona_view:new(Mod, Assigns, #{}, [
-        template,
+    RenderedView = arizona_view:new(
+        Mod,
+        Assigns,
+        #{},
         [
-            ~"<html>\n    <head></head>\n    <body id=\"",
-            ~"\"> ",
-            ~"</body>\n</html>"
-        ],
-        [
-            ~"app",
+            template,
             [
-                template,
-                [~"<div id=\"", ~"\"> ", ~"", ~"</div>"],
+                ~"<html>\n    <head></head>\n    <body id=\"",
+                ~"\"> ",
+                ~"</body>\n</html>"
+            ],
+            [
+                ~"app",
                 [
-                    ~"counter",
-                    ~"0",
+                    template,
+                    [~"<div id=\"", ~"\"> ", ~"", ~"</div>"],
                     [
-                        template,
-                        [~"<button> ", ~"</button>"],
-                        [~"Increment"]
+                        ~"counter",
+                        ~"0",
+                        [
+                            template,
+                            [~"<button> ", ~"</button>"],
+                            [~"Increment"]
+                        ]
                     ]
                 ]
             ]
-        ]
-    ]),
+        ],
+        []
+    ),
     Expect = {
         RenderedView,
         arizona_socket:new(render, #{
@@ -86,6 +92,7 @@ render(Config) when is_list(Config) ->
                 arizona_example_counter,
                 #{id => ~"counter", count => 0, btn_text => ~"Increment"},
                 #{},
+                [],
                 []
             )
         })
@@ -283,11 +290,11 @@ diff(Config) when is_list(Config) ->
     ExpectAssigns = maps:merge(Assigns, ChangedAssigns),
     Diff = [{1, [{2, [{0, ~"+1"}]}, {1, ~"1"}]}],
     Expect = {
-        arizona_view:new(Mod, ExpectAssigns, ChangedAssigns, Diff),
+        arizona_view:new(Mod, ExpectAssigns, ChangedAssigns, [], Diff),
         arizona_socket:new(diff, #{
-            ViewId => arizona_view:new(Mod, ExpectAssigns, ChangedAssigns, Diff),
+            ViewId => arizona_view:new(Mod, ExpectAssigns, ChangedAssigns, [], Diff),
             CounterViewId => arizona_view:new(
-                CounterMod, ExpectAssigns#{id => CounterViewId}, ChangedAssigns, []
+                CounterMod, ExpectAssigns#{id => CounterViewId}, ChangedAssigns, [], []
             )
         })
     },


### PR DESCRIPTION
# Description

Those changes help in the separation of concerns and to keep the rendered in the view for easier diff.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
