### PR TITLE
Introduce file rendering

### DIFF
--- a/test/arizona_view_handler_SUITE.erl
+++ b/test/arizona_view_handler_SUITE.erl
@@ -19,6 +19,7 @@ init_per_suite(Config) ->
                     {"/hello-world", arizona_view_handler,
                         {?MODULE,
                             #{
+                                data_dir => proplists:get_value(data_dir, Config),
                                 title => ~"Arizona",
                                 id => ~"helloWorld",
                                 name => ~"World"

--- a/test/arizona_view_handler_SUITE_data/layout.herl
+++ b/test/arizona_view_handler_SUITE_data/layout.herl
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{arizona_view:get_assign(title, View)}</title>
+    {arizona_html:scripts()}
+</head>
+<body>
+    {arizona_view:get_assign(inner_content, View)}
+</body>
+</html>

--- a/test/support/arizona_example_layout.erl
+++ b/test/support/arizona_example_layout.erl
@@ -3,18 +3,7 @@
 -export([render/1]).
 
 render(View) ->
-    arizona_render:component_template(View, ~"""
-    <!DOCTYPE html>
-    <html lang="en">
-    <head>
-        <meta charset="UTF-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>{arizona_view:get_assign(title, View)}</title>
-        {arizona_html:scripts()}
-    </head>
-    <body>
-        {arizona_view:get_assign(inner_content, View)}
-    </body>
-    </html>
-    """).
+    arizona_render:component_template(View, {file, template_file(View)}).
+
+template_file(View) ->
+    filename:join(arizona_view:get_assign(data_dir, View), "layout.herl").


### PR DESCRIPTION
# Description

This PR introduces file rendering.

Since we have HTML and Erlang in Arizona templates, I named the file extension as `.herl`.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
