### PR TITLE
Rename assign to bind to align with Erlang conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ functions directly within the HTML structure. For example:
         arizona:render_nested_template(~"""
         <li>{Item}</li>
         """)
-     end, arizona:get_assign(list, View))}
+     end, arizona:get_binding(list, View))}
 </ul>
 ```
 
@@ -96,7 +96,7 @@ Create a `config/sys.config` file:
                 {"/assets/[...]", cowboy_static, {priv_dir, arizona_example, "assets"}},
                 % Views are stateful and keep their state in memory.
                 % Use the 'arizona_view_handler' to render Arizona views.
-                % The 'arizona_example_page' will be mounted with the assigns 'title' and 'id'.
+                % The 'arizona_example_page' will be mounted with the bindings 'title' and 'id'.
                 % The layout is optional and wraps the view. It does not have a state; 
                 % it simply places the view within its structure.
                 {"/", arizona_view_handler,
@@ -129,13 +129,13 @@ Create the `src/arizona_example_page.erl` file:
 -export([render/1]).
 -export([handle_event/3]).
 
-mount(Assigns, _Socket) ->
-    View = arizona:new_view(?MODULE, Assigns),
+mount(Bindings, _Socket) ->
+    View = arizona:new_view(?MODULE, Bindings),
     {ok, View}.
 
 render(View) ->
     arizona:render_view_template(View, ~"""
-    <div id="{arizona:get_assign(id, View)}">
+    <div id="{arizona:get_binding(id, View)}">
         {arizona:render_view(arizona_example_counter, #{
             id => ~"counter",
             count => 0
@@ -158,16 +158,16 @@ Create the `src/arizona_example_counter.erl` view, which is defined in the rende
 -export([render/1]).
 -export([handle_event/3]).
 
-mount(Assigns, _Socket) ->
-    View = arizona:new_view(?MODULE, Assigns),
+mount(Bindings, _Socket) ->
+    View = arizona:new_view(?MODULE, Bindings),
     {ok, View}.
 
 render(View) ->
     arizona:render_view_template(View, ~"""
-    <div id="{arizona:get_assign(id, View)}">
-        <span>{integer_to_binary(arizona:get_assign(count, View))}</span>
+    <div id="{arizona:get_binding(id, View)}">
+        <span>{integer_to_binary(arizona:get_binding(count, View))}</span>
         {arizona:render_component(arizona_example_components, button, #{
-            handler => arizona:get_assign(id, View),
+            handler => arizona:get_binding(id, View),
             event => ~"incr",
             payload => 1,
             text => ~"Increment"
@@ -176,8 +176,8 @@ render(View) ->
     """).
 
 handle_event(~"incr", Incr, View) ->
-    Count = arizona:get_assign(count, View),
-    arizona:put_assign(count, Count + Incr, View).
+    Count = arizona:get_binding(count, View),
+    arizona:put_binding(count, Count + Incr, View).
 ```
 
 Create the button in `src/arizona_example_components.erl`, which is defined in the render
@@ -190,14 +190,14 @@ function of the view:
 button(View) ->
     arizona:render_component_template(View, ~"""
     <button
-        type="{arizona:get_assign(type, View, ~"button")}"
+        type="{arizona:get_binding(type, View, ~"button")}"
         onclick="{arizona:render_js_event(
-            arizona:get_assign(handler, View),
-            arizona:get_assign(event, View),
-            arizona:get_assign(payload, View)
+            arizona:get_binding(handler, View),
+            arizona:get_binding(event, View),
+            arizona:get_binding(payload, View)
         )}"
     >
-        {arizona:get_assign(text, View)}
+        {arizona:get_binding(text, View)}
     </button>
     """).
 ```
@@ -212,8 +212,8 @@ Create the optional layout `src/arizona_example_layout.erl`, which is defined in
 -export([mount/2]).
 -export([render/1]).
 
-mount(Assigns, _Socket) ->
-    arizona:new_view(?MODULE, Assigns).
+mount(Bindings, _Socket) ->
+    arizona:new_view(?MODULE, Bindings).
 
 render(View) ->
     arizona:render_layout_template(View, ~""""
@@ -223,13 +223,13 @@ render(View) ->
         <meta charset="UTF-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>{arizona:get_assign(title, View)}</title>
+        <title>{arizona:get_binding(title, View)}</title>
         {arizona:render_html_scripts()}
         <script src="assets/main.js"></script>
     </head>
     <body>
-        {% The 'inner_content' assign is auto-assigned by Arizona in the view. }
-        {arizona:get_assign(inner_content, View)}
+        {% The 'inner_content' binding is auto-bindinged by Arizona in the view. }
+        {arizona:get_binding(inner_content, View)}
     </body>
     </html>
     """").

--- a/src/arizona.erl
+++ b/src/arizona.erl
@@ -8,14 +8,14 @@ reusable components, application layouts, and dynamic template fragments.
 
 Arizona follows a component-based architecture where:
 
-- `Views`: are stateful entities that manage dynamic data through assigns
+- `Views`: are stateful entities that manage dynamic data through bindings
 - `Components`: are stateless UI elements that inherit parent view state
 - `Nested Templates`: handle conditional blocks and reusable fragments
 - `Layout`: define static application structure (rendered once on mount)
 
 ## Key Functions
 
-- `render_view_template/2`: Main view renderer with stateful assigns (DOM-patched)
+- `render_view_template/2`: Main view renderer with stateful bindings (DOM-patched)
 - `render_component_template/2`: Stateless component renderer for UI composition
 - `render_nested_template/1`: Dynamic fragment renderer for conditional content
 - `render_layout_template/2`: Structural wrapper for views (initial render only)
@@ -36,10 +36,10 @@ Arizona follows a component-based architecture where:
 -export([render_html_scripts/0]).
 -export([render_js_event/3]).
 -export([new_view/2]).
--export([put_assign/3]).
--export([put_assigns/2]).
--export([get_assign/2]).
--export([get_assign/3]).
+-export([put_binding/3]).
+-export([put_bindings/2]).
+-export([get_binding/2]).
+-export([get_binding/3]).
 -export([generate_static/0]).
 
 %
@@ -55,10 +55,10 @@ Arizona follows a component-based architecture where:
 -ignore_xref([render_html_scripts/0]).
 -ignore_xref([render_js_event/3]).
 -ignore_xref([new_view/2]).
--ignore_xref([put_assign/3]).
--ignore_xref([put_assigns/2]).
--ignore_xref([get_assign/2]).
--ignore_xref([get_assign/3]).
+-ignore_xref([put_binding/3]).
+-ignore_xref([put_bindings/2]).
+-ignore_xref([get_binding/2]).
+-ignore_xref([get_binding/3]).
 -ignore_xref([generate_static/0]).
 
 %% --------------------------------------------------------------------
@@ -68,8 +68,8 @@ Arizona follows a component-based architecture where:
 -type view() :: arizona_view:view().
 -export_type([view/0]).
 
--type assigns() :: arizona_view:assigns().
--export_type([assigns/0]).
+-type bindings() :: arizona_view:bindings().
+-export_type([bindings/0]).
 
 -type socket() :: arizona_socket:socket().
 -export_type([socket/0]).
@@ -90,10 +90,10 @@ Arizona follows a component-based architecture where:
 -type rendered_layout_template() :: rendered_view_template().
 -export_type([rendered_layout_template/0]).
 
--type rendered_view() :: {view, Mod :: module(), Assigns :: assigns()}.
+-type rendered_view() :: {view, Mod :: module(), Bindings :: bindings()}.
 -export_type([rendered_view/0]).
 
--type rendered_component() :: {component, Mod :: module(), Fun :: atom(), Assigns :: assigns()}.
+-type rendered_component() :: {component, Mod :: module(), Fun :: atom(), Bindings :: bindings()}.
 -export_type([rendered_component/0]).
 
 -type rendered_value() :: arizona_renderer:rendered_value().
@@ -135,7 +135,7 @@ to render the view's template.
 
 ## Parameters
 
-- `View`: The current view state (`t:view/0`), which contains the assigns and other
+- `View`: The current view state (`t:view/0`), which contains the bindings and other
   metadata used to populate the template.
 - `Template`: The template to render. This can be either:
 
@@ -148,17 +148,17 @@ The rendered template as `t:rendered_view_template/0`.
 
 ## Usage Notes
 
-- The template can include placeholders (e.g., `{arizona:get_assign(id, View)}`) to
-  dynamically insert data from the view's assigns.
-- **Important**: The `id` assign is **required** and must be set by the consumer.
-  The `id` should be unique and assigned to a top-level HTML element (e.g., a `div`)
+- The template can include placeholders (e.g., `{arizona:get_binding(id, View)}`) to
+  dynamically insert data from the view's bindings.
+- **Important**: The `id` binding is **required** and must be set by the consumer.
+  The `id` should be unique and bindinged to a top-level HTML element (e.g., a `div`)
   in the template. This ensures proper DOM patching and state management. For example:
 
   ```erlang
   render(View) ->
       arizona:render_view_template(View, ~"""
-      <div id="{arizona:get_assign(id, View)}">
-          Hello, {arizona:get_assign(name, View, ~"World")}!
+      <div id="{arizona:get_binding(id, View)}">
+          Hello, {arizona:get_binding(name, View, ~"World")}!
       </div>
       """).
   ```
@@ -179,7 +179,7 @@ elements.
 
 ## Parameters
 
-- `View`: The current view state (`t:arizona_view:view/0`), which contains the assigns
+- `View`: The current view state (`t:arizona_view:view/0`), which contains the bindings
   and other metadata used to populate the template. Components inherit their state from
   the parent view that calls them.
 - `Template`: The template to render. This can be either:
@@ -199,14 +199,14 @@ The rendered template as `t:rendered_component_template/0`.
   ```erlang
   button(View) ->
       arizona:render_component_template(View, ~"""
-      <button type="{arizona:get_assign(type, View, ~"button")}">
-          {arizona:get_assign(text, View)}
+      <button type="{arizona:get_binding(type, View, ~"button")}">
+          {arizona:get_binding(text, View)}
       </button>
       """).
   ```
 
-- The template can include placeholders (e.g., `{arizona:get_assign(type, View, ~"button")}`)
-  to dynamically insert data from the view's assigns.
+- The template can include placeholders (e.g., `{arizona:get_binding(type, View, ~"button")}`)
+  to dynamically insert data from the view's bindings.
 - Components are **stateless** and rely on the state of the parent view. They are
   designed to be reusable and lightweight.
 """".
@@ -240,7 +240,7 @@ The rendered template as `t:rendered_nested_template/0`.
       arizona:render_component_template(View, ~""""
       <div class="profile">
           <h1>User Profile</h1>
-          {case arizona:get_assign(user_role, View) of
+          {case arizona:get_binding(user_role, View) of
               admin ->
                   arizona:render_nested_template(~"""
                   <div class="admin-badge">
@@ -262,7 +262,7 @@ The rendered template as `t:rendered_nested_template/0`.
                   </div>
                   """)
           end}
-          <p>Welcome, {arizona:get_assign(username, View)}!</p>
+          <p>Welcome, {arizona:get_binding(username, View)}!</p>
       </div>
       """").
   ```
@@ -283,12 +283,12 @@ Renders a layout template, which provides a consistent structure (e.g., HTML
 wrappers, headers, footers) for views. Layouts are **stateless** and are rendered
 **only once** when the view is first mounted.
 
-They receive a special assign called `inner_content`, which represents the rendered
+They receive a special binding called `inner_content`, which represents the rendered
 content of the view being wrapped.
 
 ## Parameters
 
-- `View`: The current view state (`t:view/0`), which contains the assigns and other
+- `View`: The current view state (`t:view/0`), which contains the bindings and other
   metadata used to populate the template.
 - `Template`: The template to render. This can be either:
 
@@ -313,17 +313,17 @@ The rendered template as `t:rendered_layout_template/0`.
           <meta charset="UTF-8">
           <meta http-equiv="X-UA-Compatible" content="IE=edge">
           <meta name="viewport" content="width=device-width, initial-scale=1.0">
-          <title>{arizona:get_assign(title, View)}</title>
+          <title>{arizona:get_binding(title, View)}</title>
           {arizona:render_html_scripts()}
       </head>
       <body>
-          {arizona:get_assign(inner_content, View)}
+          {arizona:get_binding(inner_content, View)}
       </body>
       </html>
       """).
   ```
 
-- The inner_content assign is automatically provided by Arizona and represents the
+- The inner_content binding is automatically provided by Arizona and represents the
   rendered content of the view being wrapped. It should be placed in the layout
   template where the view's content should appear.
 - Layouts are rendered only once and do not re-renders after their initial render.
@@ -335,20 +335,20 @@ The rendered template as `t:rendered_layout_template/0`.
 render_layout_template(Payload, Template) ->
     arizona_renderer:render_view_template(Payload, Template).
 
--spec render_view(Mod, Assigns) -> Rendered when
+-spec render_view(Mod, Bindings) -> Rendered when
     Mod :: module(),
-    Assigns :: assigns(),
+    Bindings :: bindings(),
     Rendered :: rendered_view().
-render_view(Mod, Assigns) ->
-    arizona_renderer:render_view(Mod, Assigns).
+render_view(Mod, Bindings) ->
+    arizona_renderer:render_view(Mod, Bindings).
 
--spec render_component(Mod, Fun, Assigns) -> Rendered when
+-spec render_component(Mod, Fun, Bindings) -> Rendered when
     Mod :: module(),
     Fun :: atom(),
-    Assigns :: assigns(),
+    Bindings :: bindings(),
     Rendered :: rendered_component().
-render_component(Mod, Fun, Assigns) ->
-    arizona_renderer:render_component(Mod, Fun, Assigns).
+render_component(Mod, Fun, Bindings) ->
+    arizona_renderer:render_component(Mod, Fun, Bindings).
 
 -spec render_if_true(Cond, Callback) -> Rendered when
     Cond :: boolean(),
@@ -378,41 +378,41 @@ render_html_scripts() ->
 render_js_event(ViewId, EventName, Payload) ->
     arizona_js:send_event(ViewId, EventName, Payload).
 
--spec new_view(Mod, Assigns) -> View when
+-spec new_view(Mod, Bindings) -> View when
     Mod :: module(),
-    Assigns :: assigns(),
+    Bindings :: bindings(),
     View :: view().
-new_view(Mod, Assigns) ->
-    arizona_view:new(Mod, Assigns).
+new_view(Mod, Bindings) ->
+    arizona_view:new(Mod, Bindings).
 
--spec put_assign(Key, Value, View0) -> View1 when
+-spec put_binding(Key, Value, View0) -> View1 when
     Key :: atom(),
     Value :: dynamic(),
     View0 :: view(),
     View1 :: view().
-put_assign(Key, Value, View) ->
-    arizona_view:put_assign(Key, Value, View).
+put_binding(Key, Value, View) ->
+    arizona_view:put_binding(Key, Value, View).
 
--spec put_assigns(Assigns, View0) -> View1 when
-    Assigns :: assigns(),
+-spec put_bindings(Bindings, View0) -> View1 when
+    Bindings :: bindings(),
     View0 :: view(),
     View1 :: view().
-put_assigns(Assigns, View) ->
-    arizona_view:put_assigns(Assigns, View).
+put_bindings(Bindings, View) ->
+    arizona_view:put_bindings(Bindings, View).
 
--spec get_assign(Key, View) -> Value when
+-spec get_binding(Key, View) -> Value when
     Key :: atom(),
     View :: view(),
     Value :: dynamic().
-get_assign(Key, View) ->
-    arizona_view:get_assign(Key, View).
+get_binding(Key, View) ->
+    arizona_view:get_binding(Key, View).
 
--spec get_assign(Key, View, Default) -> Value when
+-spec get_binding(Key, View, Default) -> Value when
     Key :: atom(),
     View :: view(),
     Value :: Default | dynamic().
-get_assign(Key, View, Default) ->
-    arizona_view:get_assign(Key, View, Default).
+get_binding(Key, View, Default) ->
+    arizona_view:get_binding(Key, View, Default).
 
 -spec generate_static() -> ok.
 generate_static() ->

--- a/src/arizona_component.erl
+++ b/src/arizona_component.erl
@@ -47,7 +47,7 @@ it stateless and reusable.
 - `Fun`: The function name (`t:atom/0`) within the component module that handles
   rendering.
 - `View`: The current view state (`t:arizona:view/0`) of the parent view. This is
-  passed to the component to access assigns or other data.
+  passed to the component to access bindings or other data.
 
 ## Returns
 

--- a/src/arizona_layout.erl
+++ b/src/arizona_layout.erl
@@ -11,7 +11,7 @@ not the layout.
 
 To implement a layout in Arizona, a module must define the following callbacks:
 
-- `c:mount/2`: Initializes the layout with assigns and a WebSocket connection.
+- `c:mount/2`: Initializes the layout with bindings and a WebSocket connection.
 - `c:render/1`: Renders the layout's template **once**, wrapping the view's content.
 
 Layouts provide a way to create consistent UI structures across multiple views,
@@ -32,21 +32,21 @@ such as headers, footers, or navigation bars.
 -doc ~"""
 Initializes the layout when it is first rendered.
 
-This callback sets up the layout's assigns and prepares it to wrap the view's
+This callback sets up the layout's bindings and prepares it to wrap the view's
 content. The layout is rendered only once, and its state remains static throughout
 the lifecycle of the view.
 
 ## Parameters
 
-- `Assigns`: A map (`t:arizona:assigns/0`) containing the initial data for the layout.
+- `Bindings`: A map (`t:arizona:bindings/0`) containing the initial data for the layout.
 - `Socket`: The WebSocket connection (`t:arizona:socket/0`) associated with the layout.
 
 ## Returns
 
 The initialized view state (`t:arizona:view/0`) for the layout.
 """.
--callback mount(Assigns, Socket) -> View when
-    Assigns :: arizona:assigns(),
+-callback mount(Bindings, Socket) -> View when
+    Bindings :: arizona:bindings(),
     Socket :: arizona:socket(),
     View :: arizona:view().
 
@@ -59,7 +59,7 @@ Subsequent updates and re-renders only affect the wrapped view, not the layout.
 ## Parameters
 
 - `View`: The current view state (`t:arizona:view/0`), which includes the layout's
-  assigns and the view's content.
+  bindings and the view's content.
 
 ## Returns
 
@@ -81,20 +81,20 @@ This function is used internally by Arizona to initialize the layout.
 ## Parameters
 
 - `Mod`: The module name of the layout being mounted. This must be a valid atom.
-- `Assigns`: A map (`t:arizona:assigns/0`) containing the initial data for the layout.
+- `Bindings`: A map (`t:arizona:bindings/0`) containing the initial data for the layout.
 - `Socket`: The WebSocket connection (`t:arizona:socket/0`) associated with the layout.
 
 ## Returns
 
 The initialized view state (`t:arizona:view/0`) for the layout.
 """.
--spec mount(Mod, Assigns, Socket) -> View when
+-spec mount(Mod, Bindings, Socket) -> View when
     Mod :: module(),
-    Assigns :: arizona:assigns(),
+    Bindings :: arizona:bindings(),
     Socket :: arizona:socket(),
     View :: arizona:view().
-mount(Mod, Assigns, Socket) when is_atom(Mod), is_map(Assigns) ->
-    erlang:apply(Mod, mount, [Assigns, Socket]).
+mount(Mod, Bindings, Socket) when is_atom(Mod), is_map(Bindings) ->
+    erlang:apply(Mod, mount, [Bindings, Socket]).
 
 -doc ~"""
 Delegates to the `c:render/1` callback defined in the layout module (`Mod`).
@@ -105,7 +105,7 @@ when the view is first mounted.
 ## Parameters
 
 - `View`: The current view state (`t:arizona:view/0`), which includes the layout's
-  assigns and the view's content.
+  bindings and the view's content.
 
 ## Returns
 

--- a/src/arizona_parser.erl
+++ b/src/arizona_parser.erl
@@ -141,7 +141,7 @@ expr_vars(Expr) ->
     case
         re:run(
             Expr,
-            "arizona:get_assign\\(([a-z][a-zA-Z_@]*|'(.*?)')",
+            "arizona:get_binding\\(([a-z][a-zA-Z_@]*|'(.*?)')",
             [global, {capture, all_but_first, binary}]
         )
     of

--- a/src/arizona_socket.erl
+++ b/src/arizona_socket.erl
@@ -81,7 +81,7 @@ views(#socket{} = Socket) ->
     Socket0 :: socket(),
     Socket1 :: socket().
 put_view(View, Socket) ->
-    ViewId = arizona_view:get_assign(id, View),
+    ViewId = arizona_view:get_binding(id, View),
     put_view(ViewId, View, Socket).
 
 -spec get_view(ViewId, Socket) -> {ok, View} | error when

--- a/src/arizona_static.erl
+++ b/src/arizona_static.erl
@@ -46,8 +46,8 @@ process_route({Path, cowboy_static, {priv_file, App, Filename}}, StaticDir) ->
     write_priv_file(Path, App, Filename, StaticDir);
 process_route({Path, cowboy_static, {priv_dir, App, Dir}}, StaticDir) ->
     write_priv_dir_files(Path, App, Dir, StaticDir);
-process_route({Path, arizona_view_handler, {Mod, Assigns}}, StaticDir) ->
-    write_view_as_html(Path, Mod, Assigns, StaticDir);
+process_route({Path, arizona_view_handler, {Mod, Bindings}}, StaticDir) ->
+    write_view_as_html(Path, Mod, Bindings, StaticDir);
 process_route(Route, StaticDir) when is_tuple(Route) ->
     error(invalid_route, [Route, StaticDir], [
         {error_info, #{cause => ~"only static route is allowed"}}
@@ -79,10 +79,10 @@ write_priv_dir_files(Path0, App, Dir, StaticDir) ->
         Files
     ).
 
-write_view_as_html(Path, Mod, Assigns, StaticDir) ->
+write_view_as_html(Path, Mod, Bindings, StaticDir) ->
     ok = check_path_segments(Path),
     Socket0 = arizona_socket:new(render),
-    {ok, View0} = arizona_view:mount(Mod, Assigns, Socket0),
+    {ok, View0} = arizona_view:mount(Mod, Bindings, Socket0),
     Token = arizona_view:render(View0),
     {View, _Socket} = arizona_renderer:render(Token, View0, View0, Socket0),
     Html = arizona_view:rendered_to_iolist(View),

--- a/src/arizona_view_handler.erl
+++ b/src/arizona_view_handler.erl
@@ -13,7 +13,7 @@
 
 -type state() :: {
     Mod :: module(),
-    Assigns :: arizona_view:assigns(),
+    Bindings :: arizona_view:bindings(),
     Opts :: opts()
 }.
 -export_type([state/0]).
@@ -31,12 +31,12 @@
     Req0 :: cowboy_req:req(),
     State :: state(),
     Req1 :: cowboy_req:req().
-init(Req0, {Mod, Assigns, Opts} = State) when is_atom(Mod), is_map(Assigns), is_map(Opts) ->
+init(Req0, {Mod, Bindings, Opts} = State) when is_atom(Mod), is_map(Bindings), is_map(Opts) ->
     Socket = arizona_socket:new(render),
-    {ok, View0} = arizona_view:mount(Mod, Assigns, Socket),
+    {ok, View0} = arizona_view:mount(Mod, Bindings, Socket),
     Token = arizona_view:render(View0),
     {View1, _Socket} = arizona_renderer:render(Token, View0, View0, Socket),
-    View = maybe_render_layout(View1, Socket, Token, Assigns, Opts),
+    View = maybe_render_layout(View1, Socket, Token, Bindings, Opts),
     Html = arizona_view:rendered_to_iolist(View),
     Headers = #{~"content-type" => ~"text/html"},
     Req = cowboy_req:reply(200, Headers, Html, Req0),
@@ -46,11 +46,11 @@ init(Req0, {Mod, Assigns, Opts} = State) when is_atom(Mod), is_map(Assigns), is_
 %% Private functions
 %% --------------------------------------------------------------------
 
-maybe_render_layout(View, Socket, ViewToken, Assigns, Opts) ->
+maybe_render_layout(View, Socket, ViewToken, Bindings, Opts) ->
     case Opts of
         #{layout := LayoutMod} ->
             {LayoutView, _Socket} = arizona_renderer:render_layout(
-                LayoutMod, Assigns, ViewToken, Socket
+                LayoutMod, Bindings, ViewToken, Socket
             ),
             LayoutView;
         #{} ->

--- a/src/arizona_websocket.erl
+++ b/src/arizona_websocket.erl
@@ -45,16 +45,16 @@ init(Req0, []) ->
     InitState :: init_state(),
     Events :: cowboy_websocket:commands(),
     Socket :: arizona_socket:socket().
-websocket_init({{Mod, Assigns, _Opts}, Params}) ->
+websocket_init({{Mod, Bindings, _Opts}, Params}) ->
     ?LOG_INFO(#{
         text => ~"init",
         in => ?MODULE,
         view_module => Mod,
-        assigns => Assigns,
+        bindings => Bindings,
         params => Params
     }),
     Socket0 = arizona_socket:new(render),
-    {ok, View0} = arizona_view:mount(Mod, Assigns, Socket0),
+    {ok, View0} = arizona_view:mount(Mod, Bindings, Socket0),
     Token = arizona_view:render(View0),
     {_View, Socket1} = arizona_renderer:render(Token, View0, View0, Socket0),
     Socket = arizona_socket:set_render_context(diff, Socket1),
@@ -86,7 +86,7 @@ websocket_handle({text, Msg}, Socket0) ->
     {View2, Socket1} = arizona_diff:diff(Token, 0, View1, Socket0),
     Diff = arizona_view:diff(View2),
     Events = put_diff_event(Diff, ViewId, []),
-    View = arizona_view:merge_changed_assigns(View2),
+    View = arizona_view:merge_changed_bindings(View2),
     Socket = arizona_socket:put_view(View, Socket1),
     {Events, Socket}.
 

--- a/test/arizona_diff_SUITE.erl
+++ b/test/arizona_diff_SUITE.erl
@@ -34,21 +34,21 @@ diff_view_template(Config) when is_list(Config) ->
     Vars = [id, foo, bar],
     Mod = undefined,
     ViewId = ~"foo",
-    Assigns = #{id => ViewId, foo => ~"foo", bar => ~"bar"},
-    ChangedAssigns = #{bar => ~"baz"},
-    ExpectAssigns = maps:merge(Assigns, ChangedAssigns),
+    Bindings = #{id => ViewId, foo => ~"foo", bar => ~"bar"},
+    ChangedBindings = #{bar => ~"baz"},
+    ExpectBindings = maps:merge(Bindings, ChangedBindings),
     Diff = [{2, ~"baz"}],
     Expect = {
-        arizona_view:new(Mod, ExpectAssigns, #{}, [], [], Diff),
+        arizona_view:new(Mod, ExpectBindings, #{}, [], [], Diff),
         arizona_socket:new(diff, #{
-            ViewId => arizona_view:new(Mod, ExpectAssigns, #{}, [], [], [])
+            ViewId => arizona_view:new(Mod, ExpectBindings, #{}, [], [], [])
         })
     },
-    View = arizona_view:new(Mod, Assigns, ChangedAssigns, [], [], []),
+    View = arizona_view:new(Mod, Bindings, ChangedBindings, [], [], []),
     Token = arizona_renderer:render_view_template(View, ~"""
-    <div id={arizona:get_assign(id, View)}>
-    {arizona:get_assign(foo, View)}
-    {arizona:get_assign(bar, View)}
+    <div id={arizona:get_binding(id, View)}>
+    {arizona:get_binding(foo, View)}
+    {arizona:get_binding(bar, View)}
     </div>
     """),
     TokenCallback = fun() -> Token end,
@@ -60,18 +60,18 @@ diff_component_template(Config) when is_list(Config) ->
     Index = 0,
     Vars = [foo, bar],
     Mod = undefined,
-    Assigns = #{foo => ~"foo", bar => ~"bar"},
-    ChangedAssigns = #{bar => ~"baz"},
+    Bindings = #{foo => ~"foo", bar => ~"bar"},
+    ChangedBindings = #{bar => ~"baz"},
     Diff = [{1, ~"baz"}],
     Expect = {
-        arizona_view:new(Mod, Assigns, ChangedAssigns, [], [], Diff),
+        arizona_view:new(Mod, Bindings, ChangedBindings, [], [], Diff),
         arizona_socket:new(diff)
     },
-    View = arizona_view:new(Mod, Assigns, ChangedAssigns, [], [], []),
+    View = arizona_view:new(Mod, Bindings, ChangedBindings, [], [], []),
     Token = arizona_renderer:render_component_template(View, ~"""
     <div>
-        {arizona:get_assign(foo, View)}
-        {arizona:get_assign(bar, View)}
+        {arizona:get_binding(foo, View)}
+        {arizona:get_binding(bar, View)}
     </div>
     """),
     TokenCallback = fun() -> Token end,
@@ -83,18 +83,18 @@ diff_nested_template(Config) when is_list(Config) ->
     Index = 0,
     Vars = [foo, bar],
     Mod = undefined,
-    Assigns = #{foo => ~"foo", bar => ~"bar"},
-    ChangedAssigns = #{bar => ~"baz"},
+    Bindings = #{foo => ~"foo", bar => ~"bar"},
+    ChangedBindings = #{bar => ~"baz"},
     Diff = [{0, [{1, ~"baz"}]}],
     Expect = {
-        arizona_view:new(Mod, Assigns, ChangedAssigns, [], [], Diff),
+        arizona_view:new(Mod, Bindings, ChangedBindings, [], [], Diff),
         arizona_socket:new(diff)
     },
-    View = arizona_view:new(Mod, Assigns, ChangedAssigns, [], [], []),
+    View = arizona_view:new(Mod, Bindings, ChangedBindings, [], [], []),
     Token = arizona_renderer:render_nested_template(View, ~"""
     <div>
-        {arizona:get_assign(foo, View)}
-        {arizona:get_assign(bar, View)}
+        {arizona:get_binding(foo, View)}
+        {arizona:get_binding(bar, View)}
     </div>
     """),
     TokenCallback = fun() -> Token end,
@@ -106,8 +106,8 @@ diff_list_template(Config) when is_list(Config) ->
     Index = 0,
     Vars = [foo, bar],
     Mod = undefined,
-    Assigns = #{foo => ~"foo", bar => ~"bar"},
-    ChangedAssigns = #{bar => ~"baz"},
+    Bindings = #{foo => ~"foo", bar => ~"bar"},
+    ChangedBindings = #{bar => ~"baz"},
     Diff = [
         {0, [
             [{1, ~"baz"}, {0, ~"foo"}],
@@ -115,16 +115,16 @@ diff_list_template(Config) when is_list(Config) ->
         ]}
     ],
     Expect = {
-        arizona_view:new(Mod, Assigns, ChangedAssigns, [], [], Diff),
+        arizona_view:new(Mod, Bindings, ChangedBindings, [], [], Diff),
         arizona_socket:new(diff)
     },
-    View = arizona_view:new(Mod, Assigns, ChangedAssigns, [], [], []),
+    View = arizona_view:new(Mod, Bindings, ChangedBindings, [], [], []),
     Token = arizona_renderer:render_list(
         fun(Item) ->
             arizona_renderer:render_nested_template(#{'View' => View, 'Item' => Item}, ~"""
             <div>
-                {arizona:get_assign(foo, View)}
-                {arizona:get_assign(bar, View, Item)}
+                {arizona:get_binding(foo, View)}
+                {arizona:get_binding(bar, View, Item)}
             </div>
             """)
         end,
@@ -142,9 +142,9 @@ diff_view(Config) when is_list(Config) ->
     CounterMod = arizona_example_counter,
     ViewId = ~"app",
     CounterViewId = ~"counter",
-    Assigns = #{id => ViewId, count => 0, btn_text => ~"Increment"},
-    ChangedAssigns = #{count => 1, btn_text => ~"+1"},
-    ExpectAssigns = maps:merge(Assigns, ChangedAssigns),
+    Bindings = #{id => ViewId, count => 0, btn_text => ~"Increment"},
+    ChangedBindings = #{count => 1, btn_text => ~"+1"},
+    ExpectBindings = maps:merge(Bindings, ChangedBindings),
     Rendered = [
         template,
         [
@@ -190,12 +190,12 @@ diff_view(Config) when is_list(Config) ->
         ]}
     ],
     Expect = {
-        arizona_view:new(Mod, ExpectAssigns, #{}, Rendered, [], Diff),
+        arizona_view:new(Mod, ExpectBindings, #{}, Rendered, [], Diff),
         arizona_socket:new(diff, #{
-            ViewId => arizona_view:new(Mod, ExpectAssigns, #{}, Rendered, [], []),
+            ViewId => arizona_view:new(Mod, ExpectBindings, #{}, Rendered, [], []),
             CounterViewId => arizona_view:new(
                 CounterMod,
-                ExpectAssigns#{id => CounterViewId},
+                ExpectBindings#{id => CounterViewId},
                 #{},
                 [
                     template,
@@ -221,14 +221,14 @@ diff_view(Config) when is_list(Config) ->
         })
     },
     RenderSocket = arizona_socket:new(render),
-    {ok, MountedView} = arizona_view:mount(Mod, Assigns, RenderSocket),
+    {ok, MountedView} = arizona_view:mount(Mod, Bindings, RenderSocket),
     RenderToken = arizona_view:render(MountedView),
     ParentView = arizona_view:new(#{}),
     {RenderedView, Socket0} = arizona_renderer:render(
         RenderToken, MountedView, ParentView, RenderSocket
     ),
     View0 = arizona_view:set_tmp_rendered([], RenderedView),
-    View = arizona_view:put_assigns(ChangedAssigns, View0),
+    View = arizona_view:put_bindings(ChangedBindings, View0),
     Token = arizona_view:render(View),
     TokenCallback = fun() -> Token end,
     Socket1 = arizona_socket:set_render_context(diff, Socket0),
@@ -243,9 +243,9 @@ diff_view_new_id(Config) when is_list(Config) ->
     Mod = arizona_example_new_id,
     RootViewId = ~"foo",
     ViewId = ~"bar",
-    Assigns = #{id => RootViewId, view_id => ViewId, name => ~"World", ignore => false},
-    ChangedAssigns = #{view_id => ~"baz", name => ~"Arizona"},
-    ExpectAssigns = maps:merge(Assigns, ChangedAssigns),
+    Bindings = #{id => RootViewId, view_id => ViewId, name => ~"World", ignore => false},
+    ChangedBindings = #{view_id => ~"baz", name => ~"Arizona"},
+    ExpectBindings = maps:merge(Bindings, ChangedBindings),
     Rendered = [
         template,
         [~"<div id=\"", ~"\"> ", ~"</div>"],
@@ -270,7 +270,7 @@ diff_view_new_id(Config) when is_list(Config) ->
         ]}
     ],
     Expect = {
-        arizona_view:new(RootMod, ExpectAssigns, #{}, Rendered, [], Diff),
+        arizona_view:new(RootMod, ExpectBindings, #{}, Rendered, [], Diff),
         arizona_socket:new(diff, #{
             ~"baz" => arizona_view:new(
                 Mod,
@@ -306,18 +306,18 @@ diff_view_new_id(Config) when is_list(Config) ->
                 [],
                 []
             ),
-            RootViewId => arizona_view:new(RootMod, ExpectAssigns, #{}, Rendered, [], [])
+            RootViewId => arizona_view:new(RootMod, ExpectBindings, #{}, Rendered, [], [])
         })
     },
     RenderSocket = arizona_socket:new(render),
-    {ok, MountedView} = arizona_view:mount(RootMod, Assigns, RenderSocket),
+    {ok, MountedView} = arizona_view:mount(RootMod, Bindings, RenderSocket),
     RenderToken = arizona_view:render(MountedView),
     ParentView = arizona_view:new(#{}),
     {RenderedView, Socket0} = arizona_renderer:render(
         RenderToken, MountedView, ParentView, RenderSocket
     ),
     View0 = arizona_view:set_tmp_rendered([], RenderedView),
-    View = arizona_view:put_assigns(ChangedAssigns, View0),
+    View = arizona_view:put_bindings(ChangedBindings, View0),
     Token = arizona_view:render(View),
     TokenCallback = fun() -> Token end,
     Socket = arizona_socket:set_render_context(diff, Socket0),
@@ -331,9 +331,9 @@ diff_view_ignore(Config) when is_list(Config) ->
     Mod = arizona_example_new_id,
     RootViewId = ~"foo",
     ViewId = ~"bar",
-    Assigns = #{id => RootViewId, view_id => ViewId, name => ~"World", ignore => false},
-    ChangedAssigns = #{view_id => ~"baz", name => ~"Arizona", ignore => true},
-    ExpectAssigns = maps:merge(Assigns, ChangedAssigns),
+    Bindings = #{id => RootViewId, view_id => ViewId, name => ~"World", ignore => false},
+    ChangedBindings = #{view_id => ~"baz", name => ~"Arizona", ignore => true},
+    ExpectBindings = maps:merge(Bindings, ChangedBindings),
     Rendered = [
         template,
         [~"<div id=\"", ~"\"> ", ~"</div>"],
@@ -351,7 +351,7 @@ diff_view_ignore(Config) when is_list(Config) ->
         ]
     ],
     Expect = {
-        arizona_view:new(RootMod, ExpectAssigns, #{}, Rendered, [], []),
+        arizona_view:new(RootMod, ExpectBindings, #{}, Rendered, [], []),
         arizona_socket:new(diff, #{
             % FIXME: The 'ViewId' should be removed from the socket views.
             % The question is: How to know the previous id?
@@ -373,7 +373,7 @@ diff_view_ignore(Config) when is_list(Config) ->
             ),
             RootViewId => arizona_view:new(
                 RootMod,
-                ExpectAssigns,
+                ExpectBindings,
                 #{},
                 [
                     template,
@@ -397,14 +397,14 @@ diff_view_ignore(Config) when is_list(Config) ->
         })
     },
     RenderSocket = arizona_socket:new(render),
-    {ok, MountedView} = arizona_view:mount(RootMod, Assigns, RenderSocket),
+    {ok, MountedView} = arizona_view:mount(RootMod, Bindings, RenderSocket),
     RenderToken = arizona_view:render(MountedView),
     ParentView = arizona_view:new(#{}),
     {RenderedView, Socket0} = arizona_renderer:render(
         RenderToken, MountedView, ParentView, RenderSocket
     ),
     View0 = arizona_view:set_tmp_rendered([], RenderedView),
-    View = arizona_view:put_assigns(ChangedAssigns, View0),
+    View = arizona_view:put_bindings(ChangedBindings, View0),
     Token = arizona_view:render(View),
     TokenCallback = fun() -> Token end,
     Socket = arizona_socket:set_render_context(diff, Socket0),
@@ -416,23 +416,23 @@ diff_component(Config) when is_list(Config) ->
     Vars = [text],
     Mod = arizona_example_components,
     Fun = button,
-    Assigns = #{text => ~"Increment"},
-    ChangedAssigns = #{text => ~"+1"},
+    Bindings = #{text => ~"Increment"},
+    ChangedBindings = #{text => ~"+1"},
     Rendered = [template, [~"<button> ", ~"</button>"], [~"+1"]],
     Diff = [{0, ~"+1"}],
     Expect = {
-        arizona_view:new(Mod, Assigns, ChangedAssigns, Rendered, [], Diff),
+        arizona_view:new(Mod, Bindings, ChangedBindings, Rendered, [], Diff),
         arizona_socket:new(diff)
     },
     RenderSocket = arizona_socket:new(render),
-    View0 = arizona_view:new(Mod, Assigns, ChangedAssigns, [], [], []),
+    View0 = arizona_view:new(Mod, Bindings, ChangedBindings, [], [], []),
     RenderToken = arizona_component:render(Mod, Fun, View0),
     ParentView = arizona_view:new(#{}),
     {RenderedView, Socket0} = arizona_renderer:render(
         RenderToken, View0, ParentView, RenderSocket
     ),
     View1 = arizona_view:set_tmp_rendered([], RenderedView),
-    View = arizona_view:put_assigns(ChangedAssigns, View1),
+    View = arizona_view:put_bindings(ChangedBindings, View1),
     Token = arizona_component:render(Mod, Fun, View),
     Socket = arizona_socket:set_render_context(diff, Socket0),
     TokenCallback = fun() -> Token end,
@@ -443,19 +443,19 @@ diff_list(Config) when is_list(Config) ->
     Index = 0,
     Vars = [foo, bar],
     Mod = undefined,
-    Assigns = #{foo => ~"foo", bar => ~"bar"},
-    ChangedAssigns = #{bar => ~"baz"},
+    Bindings = #{foo => ~"foo", bar => ~"bar"},
+    ChangedBindings = #{bar => ~"baz"},
     Diff = [{0, [{0, [~"foo", ~"baz"]}]}],
     Expect = {
-        arizona_view:new(Mod, Assigns, ChangedAssigns, [], [], Diff),
+        arizona_view:new(Mod, Bindings, ChangedBindings, [], [], Diff),
         arizona_socket:new(diff)
     },
-    View = arizona_view:new(Mod, Assigns, ChangedAssigns, [], [], []),
+    View = arizona_view:new(Mod, Bindings, ChangedBindings, [], [], []),
     Token = arizona_renderer:render_nested_template(View, ~"""
     <div>
         {[
-            arizona:get_assign(foo, View),
-            arizona:get_assign(bar, View)
+            arizona:get_binding(foo, View),
+            arizona:get_binding(bar, View)
          ]}
     </div>
     """),

--- a/test/arizona_parser_SUITE.erl
+++ b/test/arizona_parser_SUITE.erl
@@ -257,7 +257,7 @@ parse_transform_render_list(Config) when is_list(Config) ->
                                                     {nil, 5}}}
                                         ]}
                                     ]}},
-                                {call, 7, {remote, 7, {atom, 7, arizona}, {atom, 7, get_assign}}, [
+                                {call, 7, {remote, 7, {atom, 7, arizona}, {atom, 7, get_binding}}, [
                                     {atom, 7, list}, {var, 7, 'View'}
                                 ]}
                             ]},
@@ -280,7 +280,7 @@ parse_transform_render_list(Config) when is_list(Config) ->
             {integer_to_binary(Item)}
         </li>
         """)
-     end, arizona:get_assign(list, View))}
+     end, arizona:get_binding(list, View))}
     </ul>
     """"),
     View = arizona_view:new(#{list => [1, 2, 3]}),

--- a/test/arizona_renderer_SUITE.erl
+++ b/test/arizona_renderer_SUITE.erl
@@ -28,9 +28,9 @@ groups() ->
 render_view_template(Config) when is_list(Config) ->
     View = arizona_view:new(#{id => ~"foo", foo => ~"foo", bar => ~"bar"}),
     Got = arizona_renderer:render_view_template(View, ~"""
-    <div id="{arizona:get_assign(id, View)}">
-      {arizona:get_assign(foo, View)}
-      {arizona:get_assign(bar, View)}
+    <div id="{arizona:get_binding(id, View)}">
+      {arizona:get_binding(foo, View)}
+      {arizona:get_binding(bar, View)}
     </div>
     """),
     ?assertMatch(
@@ -43,8 +43,8 @@ render_component_template(Config) when is_list(Config) ->
     View = arizona_view:new(#{foo => ~"foo", bar => ~"bar"}),
     Got = arizona_renderer:render_component_template(View, ~"""
     <div>
-      {arizona:get_assign(foo, View)}
-      {arizona:get_assign(bar, View)}
+      {arizona:get_binding(foo, View)}
+      {arizona:get_binding(bar, View)}
     </div>
     """),
     ?assertMatch(
@@ -57,8 +57,8 @@ render_nested_template(Config) when is_list(Config) ->
     View = arizona_view:new(#{foo => ~"foo", bar => ~"bar"}),
     Got = arizona_renderer:render_nested_template(View, ~"""
     <div>
-      {arizona:get_assign(foo, View)}
-      {arizona:get_assign(bar, View)}
+      {arizona:get_binding(foo, View)}
+      {arizona:get_binding(bar, View)}
     </div>
     """),
     ?assertMatch(
@@ -68,15 +68,15 @@ render_nested_template(Config) when is_list(Config) ->
 
 render_view(Config) when is_list(Config) ->
     Mod = foo,
-    Assigns = #{id => ~"foo"},
-    Expect = {view, Mod, Assigns},
-    Got = arizona_renderer:render_view(Mod, Assigns),
+    Bindings = #{id => ~"foo"},
+    Expect = {view, Mod, Bindings},
+    Got = arizona_renderer:render_view(Mod, Bindings),
     ?assertEqual(Expect, Got).
 
 render_component(Config) when is_list(Config) ->
     Mod = foo,
     Fun = bar,
-    Assigns = #{},
-    Expect = {component, Mod, Fun, Assigns},
-    Got = arizona_renderer:render_component(Mod, Fun, Assigns),
+    Bindings = #{},
+    Expect = {component, Mod, Fun, Bindings},
+    Got = arizona_renderer:render_component(Mod, Fun, Bindings),
     ?assertEqual(Expect, Got).

--- a/test/arizona_transform_SUITE.erl
+++ b/test/arizona_transform_SUITE.erl
@@ -34,7 +34,7 @@ render_view_template(Config) when is_list(Config) ->
     -module(arizona_renderer_view_template).
     render(View) ->
         arizona:render_view_template(View, ~"""
-        Hello, {arizona:get_assign(name, View)}!
+        Hello, {arizona:get_binding(name, View)}!
         """).
     """"),
     Got = arizona_transform:parse_transform(Forms, []),
@@ -55,7 +55,7 @@ render_component_template(Config) when is_list(Config) ->
     -module(arizona_renderer_component_template).
     render(View) ->
         arizona:render_component_template(View, ~"""
-        Hello, {arizona:get_assign(name, View)}!
+        Hello, {arizona:get_binding(name, View)}!
         """).
     """"),
     Got = arizona_transform:parse_transform(Forms, []),
@@ -76,7 +76,7 @@ render_nested_template(Config) when is_list(Config) ->
     -module(arizona_renderer_nested_template).
     render(View) ->
         arizona:render_nested_template(View, ~"""
-        Hello, {arizona:get_assign(name, View)}!
+        Hello, {arizona:get_binding(name, View)}!
         """).
     """"),
     Got = arizona_transform:parse_transform(Forms, []),

--- a/test/arizona_view_SUITE.erl
+++ b/test/arizona_view_SUITE.erl
@@ -42,10 +42,10 @@ groups() ->
 
 mount(Config) when is_list(Config) ->
     Mod = arizona_example_template,
-    Assigns = #{id => ~"app", count => 0},
-    Expect = {ok, arizona_view:new(Mod, Assigns)},
+    Bindings = #{id => ~"app", count => 0},
+    Expect = {ok, arizona_view:new(Mod, Bindings)},
     Socket = arizona_socket:new(render),
-    Got = arizona_view:mount(Mod, Assigns, Socket),
+    Got = arizona_view:mount(Mod, Bindings, Socket),
     ?assertEqual(Expect, Got).
 
 mount_ignore(Config) when is_list(Config) ->
@@ -56,7 +56,7 @@ mount_ignore(Config) when is_list(Config) ->
 
 render(Config) when is_list(Config) ->
     Mod = arizona_example_template,
-    Assigns = #{id => ~"app", count => 0},
+    Bindings = #{id => ~"app", count => 0},
     Rendered = [
         template,
         [
@@ -82,9 +82,9 @@ render(Config) when is_list(Config) ->
         ]
     ],
     Expect = {
-        arizona_view:new(Mod, Assigns, #{}, Rendered, Rendered, []),
+        arizona_view:new(Mod, Bindings, #{}, Rendered, Rendered, []),
         arizona_socket:new(render, #{
-            ~"app" => arizona_view:new(Mod, Assigns, #{}, Rendered, [], []),
+            ~"app" => arizona_view:new(Mod, Bindings, #{}, Rendered, [], []),
             ~"counter" => arizona_view:new(
                 arizona_example_counter,
                 #{id => ~"counter", count => 0, btn_text => ~"Increment"},
@@ -114,7 +114,7 @@ render(Config) when is_list(Config) ->
     },
     ParentView = arizona_view:new(#{}),
     Socket = arizona_socket:new(render),
-    {ok, View} = arizona_view:mount(Mod, Assigns, Socket),
+    {ok, View} = arizona_view:mount(Mod, Bindings, Socket),
     Token = arizona_view:render(View),
     Got = arizona_renderer:render(Token, View, ParentView, Socket),
     ?assertEqual(Expect, Got).
@@ -138,8 +138,8 @@ rendered_to_iolist(Config) when is_list(Config) ->
     ParentView = arizona_view:new(#{}),
     Socket = arizona_socket:new(render),
     Mod = arizona_example_template,
-    Assigns = #{id => ~"app", count => 0},
-    {ok, View0} = arizona_view:mount(Mod, Assigns, Socket),
+    Bindings = #{id => ~"app", count => 0},
+    {ok, View0} = arizona_view:mount(Mod, Bindings, Socket),
     Token = arizona_view:render(View0),
     {View, _Socket} = arizona_renderer:render(Token, View0, ParentView, Socket),
     Got = arizona_view:rendered_to_iolist(View),
@@ -156,10 +156,10 @@ render_nested_template_to_iolist(Config) when is_list(Config) ->
     ParentView0 = arizona_view:new(#{show_dialog => true, message => ~"Hello, World!"}),
     Token = arizona_renderer:render_nested_template(ParentView0, ~""""
     <div>
-        {arizona_renderer:render_if_true(arizona:get_assign(show_dialog, View), fun() ->
+        {arizona_renderer:render_if_true(arizona:get_binding(show_dialog, View), fun() ->
              arizona_renderer:render_nested_template(View, ~"""
              <dialog open>
-                 {arizona_view:get_assign(message, View)}
+                 {arizona_view:get_binding(message, View)}
              </dialog>
              """)
          end)}
@@ -173,7 +173,7 @@ render_nested_template_to_iolist(Config) when is_list(Config) ->
 render_table_component(Config) when is_list(Config) ->
     Mod = arizona_example_components,
     Fun = table,
-    Assigns = #{
+    Bindings = #{
         columns => [
             #{
                 label => ~"Name",
@@ -226,10 +226,10 @@ render_table_component(Config) when is_list(Config) ->
     ],
     Socket = arizona_socket:new(render),
     Expect = {
-        arizona_view:new(undefined, Assigns, #{}, Rendered, Rendered, []),
+        arizona_view:new(undefined, Bindings, #{}, Rendered, Rendered, []),
         Socket
     },
-    View = arizona_view:new(Assigns),
+    View = arizona_view:new(Bindings),
     Token = arizona_component:render(Mod, Fun, View),
     Got = arizona_renderer:render(Token, View, View, Socket),
     ?assertEqual(Expect, Got).
@@ -237,7 +237,7 @@ render_table_component(Config) when is_list(Config) ->
 render_table_component_to_iolist(Config) when is_list(Config) ->
     Mod = arizona_example_components,
     Fun = table,
-    Assigns = #{
+    Bindings = #{
         columns => [
             #{
                 label => ~"Name",
@@ -253,7 +253,7 @@ render_table_component_to_iolist(Config) when is_list(Config) ->
             #{name => ~"Bob", age => ~"51"}
         ]
     },
-    View0 = arizona_view:new(Assigns),
+    View0 = arizona_view:new(Bindings),
     Socket = arizona_socket:new(render),
     Expect = [
         ~"<table>\n    <tr> ",
@@ -298,9 +298,9 @@ diff(Config) when is_list(Config) ->
     CounterMod = arizona_example_counter,
     ViewId = ~"app",
     CounterViewId = ~"counter",
-    Assigns = #{id => ViewId, count => 0, btn_text => ~"Increment"},
-    ChangedAssigns = #{count => 1, btn_text => ~"+1"},
-    ExpectAssigns = maps:merge(Assigns, ChangedAssigns),
+    Bindings = #{id => ViewId, count => 0, btn_text => ~"Increment"},
+    ChangedBindings = #{count => 1, btn_text => ~"+1"},
+    ExpectBindings = maps:merge(Bindings, ChangedBindings),
     Rendered = [
         template,
         [
@@ -327,12 +327,12 @@ diff(Config) when is_list(Config) ->
     ],
     Diff = [{1, [{2, [{0, ~"+1"}]}, {1, ~"1"}]}],
     Expect = {
-        arizona_view:new(Mod, ExpectAssigns, #{}, Rendered, [], Diff),
+        arizona_view:new(Mod, ExpectBindings, #{}, Rendered, [], Diff),
         arizona_socket:new(diff, #{
-            ViewId => arizona_view:new(Mod, ExpectAssigns, #{}, Rendered, [], []),
+            ViewId => arizona_view:new(Mod, ExpectBindings, #{}, Rendered, [], []),
             CounterViewId => arizona_view:new(
                 CounterMod,
-                ExpectAssigns#{id => CounterViewId},
+                ExpectBindings#{id => CounterViewId},
                 #{},
                 [
                     template,
@@ -358,14 +358,14 @@ diff(Config) when is_list(Config) ->
         })
     },
     RenderSocket = arizona_socket:new(render),
-    {ok, MountedView} = arizona_view:mount(Mod, Assigns, RenderSocket),
+    {ok, MountedView} = arizona_view:mount(Mod, Bindings, RenderSocket),
     RenderToken = arizona_view:render(MountedView),
     ParentView = arizona_view:new(#{}),
     {RenderedView, Socket0} = arizona_renderer:render(
         RenderToken, MountedView, ParentView, RenderSocket
     ),
     View0 = arizona_view:set_tmp_rendered([], RenderedView),
-    View = arizona_view:put_assigns(ChangedAssigns, View0),
+    View = arizona_view:put_bindings(ChangedBindings, View0),
     Token = arizona_view:render(View),
     TokenCallback = fun() -> Token end,
     Socket = arizona_socket:set_render_context(diff, Socket0),
@@ -377,8 +377,8 @@ diff_to_iolist(Config) when is_list(Config) ->
     Vars = [id, count, btn_text],
     Mod = arizona_example_template,
     ViewId = ~"app",
-    Assigns = #{id => ViewId, count => 0, btn_text => ~"Increment"},
-    ChangedAssigns = #{count => 1, btn_text => ~"+1"},
+    Bindings = #{id => ViewId, count => 0, btn_text => ~"Increment"},
+    ChangedBindings = #{count => 1, btn_text => ~"+1"},
     Expect = [
         ~"<html>\n    <head></head>\n    <body id=\"",
         ~"app",
@@ -395,14 +395,14 @@ diff_to_iolist(Config) when is_list(Config) ->
         ~"</body>\n</html>"
     ],
     RenderSocket = arizona_socket:new(render),
-    {ok, MountedView} = arizona_view:mount(Mod, Assigns, RenderSocket),
+    {ok, MountedView} = arizona_view:mount(Mod, Bindings, RenderSocket),
     RenderToken = arizona_view:render(MountedView),
     ParentView = arizona_view:new(#{}),
     {RenderedView, Socket0} = arizona_renderer:render(
         RenderToken, MountedView, ParentView, RenderSocket
     ),
     View0 = arizona_view:set_tmp_rendered([], RenderedView),
-    View = arizona_view:put_assigns(ChangedAssigns, View0),
+    View = arizona_view:put_bindings(ChangedBindings, View0),
     Token = arizona_view:render(View),
     TokenCallback = fun() -> Token end,
     Socket = arizona_socket:set_render_context(diff, Socket0),

--- a/test/arizona_view_handler_SUITE.erl
+++ b/test/arizona_view_handler_SUITE.erl
@@ -39,12 +39,12 @@ end_per_suite(Config) ->
 %% Behaviour (arizona_live_view) callbacks
 %% --------------------------------------------------------------------
 
--spec mount(Assigns, Socket) -> Return when
-    Assigns :: arizona:assigns(),
+-spec mount(Bindings, Socket) -> Return when
+    Bindings :: arizona:bindings(),
     Socket :: arizona:socket(),
     Return :: arizona:mount_ret().
-mount(Assigns, _Socket) ->
-    View = arizona_view:new(?MODULE, Assigns),
+mount(Bindings, _Socket) ->
+    View = arizona_view:new(?MODULE, Bindings),
     {ok, View}.
 
 -spec render(View) -> Token when
@@ -52,8 +52,8 @@ mount(Assigns, _Socket) ->
     Token :: arizona:rendered_view_template().
 render(View) ->
     arizona:render_view_template(View, ~""""
-    <main id="{arizona:get_assign(id, View)}">
-        Hello, {arizona:get_assign(name, View)}!
+    <main id="{arizona:get_binding(id, View)}">
+        Hello, {arizona:get_binding(name, View)}!
     </main>
     """").
 

--- a/test/arizona_view_handler_SUITE_data/layout.herl
+++ b/test/arizona_view_handler_SUITE_data/layout.herl
@@ -4,10 +4,10 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{arizona:get_assign(title, View)}</title>
+    <title>{arizona:get_binding(title, View)}</title>
     {arizona:render_html_scripts()}
 </head>
 <body>
-    {arizona:get_assign(inner_content, View)}
+    {arizona:get_binding(inner_content, View)}
 </body>
 </html>

--- a/test/support/arizona_example_components.erl
+++ b/test/support/arizona_example_components.erl
@@ -7,7 +7,7 @@
 button(View) ->
     arizona:render_component_template(View, ~"""
     <button>
-        {arizona:get_assign(text, View)}
+        {arizona:get_binding(text, View)}
     </button>
     """).
 
@@ -18,7 +18,7 @@ list(View) ->
             arizona:render_nested_template(~"""
             <li>{Item}</li>
             """)
-         end, arizona:get_assign(list, View))}
+         end, arizona:get_binding(list, View))}
     </ul>
     """").
 
@@ -30,7 +30,7 @@ table(View) ->
                 arizona:render_nested_template(~"""
                 <th>{maps:get(label, Col)}</th>
                 """)
-             end, arizona:get_assign(columns, View))}
+             end, arizona:get_binding(columns, View))}
         </tr>
         {arizona:render_list(fun(Row) ->
             arizona:render_nested_template(~""""
@@ -41,9 +41,9 @@ table(View) ->
                         {erlang:apply(maps:get(callback, Col), [Row])}
                     </td>
                     """)
-                 end, arizona:get_assign(columns, View))}
+                 end, arizona:get_binding(columns, View))}
             </tr>
             """")
-         end, arizona:get_assign(rows, View))}
+         end, arizona:get_binding(rows, View))}
     </table>
     """"").

--- a/test/support/arizona_example_counter.erl
+++ b/test/support/arizona_example_counter.erl
@@ -6,18 +6,18 @@
 -export([render/1]).
 -export([handle_event/3]).
 
-mount(Assigns, _Socket) ->
-    View = arizona_view:new(?MODULE, Assigns#{
-        id => maps:get(id, Assigns, ~"counter")
+mount(Bindings, _Socket) ->
+    View = arizona_view:new(?MODULE, Bindings#{
+        id => maps:get(id, Bindings, ~"counter")
     }),
     {ok, View}.
 
 render(View) ->
     arizona:render_view_template(View, ~""""
-    <div id="{arizona:get_assign(id, View)}">
-        {integer_to_binary(arizona:get_assign(count, View))}
+    <div id="{arizona:get_binding(id, View)}">
+        {integer_to_binary(arizona:get_binding(count, View))}
         {arizona:render_component(arizona_example_components, button, #{
-            text => arizona:get_assign(btn_text, View, ~"Increment")
+            text => arizona:get_binding(btn_text, View, ~"Increment")
         })}
     </div>
     """").

--- a/test/support/arizona_example_ignore.erl
+++ b/test/support/arizona_example_ignore.erl
@@ -5,7 +5,7 @@
 -export([render/1]).
 -export([handle_event/3]).
 
-mount(_Assigns, _Socket) ->
+mount(_Bindings, _Socket) ->
     ignore.
 
 render(View) ->

--- a/test/support/arizona_example_layout.erl
+++ b/test/support/arizona_example_layout.erl
@@ -4,11 +4,11 @@
 -export([mount/2]).
 -export([render/1]).
 
-mount(Assigns, _Socket) ->
-    arizona:new_view(?MODULE, Assigns).
+mount(Bindings, _Socket) ->
+    arizona:new_view(?MODULE, Bindings).
 
 render(View) ->
     arizona:render_layout_template(View, {file, template_file(View)}).
 
 template_file(View) ->
-    filename:join(arizona:get_assign(data_dir, View), "layout.herl").
+    filename:join(arizona:get_binding(data_dir, View), "layout.herl").

--- a/test/support/arizona_example_new_id.erl
+++ b/test/support/arizona_example_new_id.erl
@@ -7,14 +7,14 @@
 
 mount(#{ignore := true}, _Socket) ->
     ignore;
-mount(Assigns, _Socket) ->
-    View = arizona_view:new(?MODULE, Assigns),
+mount(Bindings, _Socket) ->
+    View = arizona_view:new(?MODULE, Bindings),
     {ok, View}.
 
 render(View) ->
     arizona:render_view_template(View, ~""""
-    <div id="{arizona:get_assign(id, View)}">
-        Hello, {arizona:get_assign(name, View)}!
+    <div id="{arizona:get_binding(id, View)}">
+        Hello, {arizona:get_binding(name, View)}!
     </div>
     """").
 

--- a/test/support/arizona_example_template.erl
+++ b/test/support/arizona_example_template.erl
@@ -6,19 +6,19 @@
 -export([render/1]).
 -export([handle_event/3]).
 
-mount(Assigns, _Socket) ->
-    View = arizona_view:new(?MODULE, Assigns),
+mount(Bindings, _Socket) ->
+    View = arizona_view:new(?MODULE, Bindings),
     {ok, View}.
 
 render(View) ->
     arizona:render_view_template(View, ~""""
     <html>
         <head></head>
-        <body id="{arizona:get_assign(id, View)}">
+        <body id="{arizona:get_binding(id, View)}">
             {arizona:render_view(arizona_example_counter, #{
                 id => ~"counter",
-                count => arizona:get_assign(count, View),
-                btn_text => arizona:get_assign(btn_text, View, ~"Increment")
+                count => arizona:get_binding(count, View),
+                btn_text => arizona:get_binding(btn_text, View, ~"Increment")
             })}
         </body>
     </html>

--- a/test/support/arizona_example_template_new_id.erl
+++ b/test/support/arizona_example_template_new_id.erl
@@ -7,17 +7,17 @@
 
 mount(#{ignore := true}, _Socket) ->
     ignore;
-mount(Assigns, _Socket) ->
-    View = arizona_view:new(?MODULE, Assigns),
+mount(Bindings, _Socket) ->
+    View = arizona_view:new(?MODULE, Bindings),
     {ok, View}.
 
 render(View) ->
     arizona:render_view_template(View, ~"""
-    <div id="{arizona:get_assign(id, View)}">
+    <div id="{arizona:get_binding(id, View)}">
         {arizona:render_view(arizona_example_new_id, #{
-            id => arizona:get_assign(view_id, View),
-            name =>  arizona:get_assign(name, View),
-            ignore => arizona:get_assign(ignore, View)
+            id => arizona:get_binding(view_id, View),
+            name =>  arizona:get_binding(name, View),
+            ignore => arizona:get_binding(ignore, View)
         })}
     </div>
     """).


### PR DESCRIPTION
# Description

I was thinking about this for a time, and this comment in the Erlang Forums was the key to this breaking change.
The `bindings` word is more consistent with the Erlang conventions.
See [this](https://www.erlang.org/doc/apps/stdlib/erl_eval.html#t:bindings/0) in the `erl_syntax` module for an example.

- [ ] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
