### PR TITLE
Fix layout rendering and lazy `inner_content` handling

### DIFF
--- a/src/arizona.erl
+++ b/src/arizona.erl
@@ -87,7 +87,7 @@ Arizona follows a component-based architecture where:
 -type rendered_nested_template() :: no_return().
 -export_type([rendered_nested_template/0]).
 
--type rendered_layout_template() :: rendered_view_template().
+-type rendered_layout_template() :: rendered_component_template().
 -export_type([rendered_layout_template/0]).
 
 -type rendered_view() :: {view, Mod :: module(), Bindings :: bindings()}.
@@ -333,7 +333,7 @@ The rendered template as `t:rendered_layout_template/0`.
     Template :: binary() | {file, file:filename_all()},
     Rendered :: rendered_layout_template().
 render_layout_template(Payload, Template) ->
-    arizona_renderer:render_view_template(Payload, Template).
+    arizona_renderer:render_component_template(Payload, Template).
 
 -spec render_view(Mod, Bindings) -> Rendered when
     Mod :: module(),

--- a/test/arizona_view_handler_SUITE.erl
+++ b/test/arizona_view_handler_SUITE.erl
@@ -21,7 +21,6 @@ init_per_suite(Config) ->
                             #{
                                 data_dir => proplists:get_value(data_dir, Config),
                                 title => ~"Arizona",
-                                id => ~"helloWorld",
                                 name => ~"World"
                             },
                             #{layout => arizona_example_layout}}}
@@ -44,7 +43,9 @@ end_per_suite(Config) ->
     Socket :: arizona:socket(),
     Return :: arizona:mount_ret().
 mount(Bindings, _Socket) ->
-    View = arizona_view:new(?MODULE, Bindings),
+    View = arizona_view:new(?MODULE, Bindings#{
+        id => ~"helloWorld"
+    }),
     {ok, View}.
 
 -spec render(View) -> Token when


### PR DESCRIPTION
# Description

Layouts were incorrectly being rendered as stateful views. Since layouts are stateless, they should be rendered in the same manner as components. Also, the `inner_content` must be rendered lazily to properly inherit the layout’s bindings, ensuring context is preserved.

This PR addresses those issues and syncs the `arizona_view_handler_SUITE` tests with the above description.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
