### PR TITLE
Fix parsing multiple forms in the same Erlang expression

### DIFF
--- a/src/arizona_parser.erl
+++ b/src/arizona_parser.erl
@@ -86,11 +86,14 @@ scan_and_parse_html_token_to_ast({html, _Loc, Text0}) ->
 scan_and_parse_erlang_token_to_ast({erlang, _Loc, Expr0}, Index0, RenderContext, Bindings) ->
     Index = integer_to_binary(Index0),
     Vars = vars_to_binary(expr_vars(Expr0)),
-    Form0 = merl:quote(Expr0),
-    Form = arizona_transform:transform(Form0, Bindings),
-    Expr1 = erl_pp:expr(Form),
-    Expr = norm_expr(RenderContext, Expr1, Index, Vars),
+    Form = arizona_transform:transform(merl:quote(Expr0), Bindings),
+    Expr = norm_expr(RenderContext, form_to_iolist(Form), Index, Vars),
     scan_and_parse_to_ast(iolist_to_binary(Expr)).
+
+form_to_iolist(Forms) when is_list(Forms) ->
+    erl_pp:exprs(Forms);
+form_to_iolist(Form) when is_tuple(Form) ->
+    erl_pp:expr(Form).
 
 norm_expr(from_socket, Expr, Index, Vars) ->
     [

--- a/src/arizona_parser.erl
+++ b/src/arizona_parser.erl
@@ -41,9 +41,8 @@ binaries and the Dynamic is an AST list of Erlang terms.
     Tokens :: [Token],
     Opts :: options(),
     Token :: arizona_scanner:token(),
-    Static :: [Ast],
-    Dynamic :: [Ast],
-    Ast :: tuple().
+    Static :: [tuple()],
+    Dynamic :: [tuple() | [tuple()]].
 parse(Tokens0, Opts) when is_list(Tokens0), is_map(Opts) ->
     Tokens1 = drop_comments(Tokens0),
     Tokens = add_empty_text_tokens(Tokens1),

--- a/src/arizona_transform.erl
+++ b/src/arizona_transform.erl
@@ -25,10 +25,11 @@ parse_transform(Forms0, _Opts) ->
     % debug(Forms0, Forms),
     Forms.
 
--spec transform(Form0, Bindings) -> Form1 when
-    Form0 :: erl_syntax:syntaxTree(),
+-spec transform(Form, Bindings) -> Transformed when
+    Form :: erl_syntax:syntaxTree(),
     Bindings :: erl_eval:binding_struct(),
-    Form1 :: erl_syntax:syntaxTree().
+    Transformed :: Ast | [Ast],
+    Ast :: erl_syntax:syntaxTree().
 transform(
     {call, _Pos1, {remote, _Pos2, {atom, _Pos3, Mod}, {atom, _Pos4, Fun}}, Body} = Form,
     Bindings
@@ -92,19 +93,19 @@ transform_function(Form) ->
 transform_fun_body(arizona, render_view_template, Body, Bindings) ->
     [_View, TemplateAst] = Body,
     ParseOpts = #{},
-    {Static, Dynamic} = template_to_static_dynamic(TemplateAst, Bindings, ParseOpts),
+    {Static, Dynamic} = eval_template(TemplateAst, Bindings, ParseOpts),
     Token = token(view_template, [Static, Dynamic]),
     {true, Token};
 transform_fun_body(arizona, render_component_template, Body, Bindings) ->
     [_View, TemplateAst] = Body,
     ParseOpts = #{},
-    {Static, Dynamic} = template_to_static_dynamic(TemplateAst, Bindings, ParseOpts),
+    {Static, Dynamic} = eval_template(TemplateAst, Bindings, ParseOpts),
     Token = token(component_template, [Static, Dynamic]),
     {true, Token};
 transform_fun_body(arizona, render_nested_template, Body, Bindings) ->
     TemplateAst = nested_template_ast(Body),
     ParseOpts = #{render_context => render},
-    {Static, Dynamic} = template_to_static_dynamic(TemplateAst, Bindings, ParseOpts),
+    {Static, Dynamic} = eval_template(TemplateAst, Bindings, ParseOpts),
     Token = token(nested_template, [Static, Dynamic]),
     {true, Token};
 transform_fun_body(arizona, render_list, Body, Bindings) ->
@@ -125,7 +126,7 @@ callback_to_static_dynamic(Callback0, Bindings) ->
         ]}} = Callback0,
     TemplateAst = nested_template_ast(Body),
     ParseOpts = #{render_context => none},
-    {Static, DynamicList0} = template_to_static_dynamic(TemplateAst, Bindings, ParseOpts),
+    {Static, DynamicList0} = eval_template(TemplateAst, Bindings, ParseOpts),
     DynamicList = erl_syntax:set_pos(DynamicList0, Pos3),
     Callback =
         {'fun', Pos1,
@@ -139,7 +140,7 @@ nested_template_ast([TemplateAst]) ->
 nested_template_ast([_Payload, TemplateAst]) ->
     TemplateAst.
 
-template_to_static_dynamic(TemplateAst, Bindings, ParseOpts) ->
+eval_template(TemplateAst, Bindings, ParseOpts) ->
     ScanOpts = #{
         % Consider it a triple-quoted string that start one line below.
         % See https://www.erlang.org/eeps/eep-0064#triple-quoted-string-start
@@ -147,7 +148,7 @@ template_to_static_dynamic(TemplateAst, Bindings, ParseOpts) ->
         % TODO: Indentation option
         indentation => 4
     },
-    Template = eval_template(TemplateAst, Bindings),
+    {value, Template, _NewBindings} = erl_eval:exprs([TemplateAst], Bindings),
     Tokens = arizona_scanner:scan(ScanOpts, Template),
     {StaticAst, DynamicAst} = arizona_parser:parse(Tokens, ParseOpts),
     Static = erl_syntax:list(StaticAst),
@@ -163,10 +164,6 @@ line(Form) ->
         Anno ->
             erl_anno:line(Anno)
     end.
-
-eval_template(TemplateAst, Bindings) ->
-    {value, Template, _NewBindings} = erl_eval:exprs([TemplateAst], Bindings),
-    Template.
 
 token(Name, Params) when is_atom(Name), is_list(Params) ->
     erl_syntax:revert(erl_syntax:tuple([erl_syntax:atom(Name) | Params])).

--- a/src/arizona_transform.erl
+++ b/src/arizona_transform.erl
@@ -16,20 +16,19 @@
 %% --------------------------------------------------------------------
 
 -spec parse_transform(Forms0, Opts) -> Forms1 when
-    Forms0 :: [erl_syntax:syntaxTree()],
+    Forms0 :: [tuple()],
     Opts :: list(),
-    Forms1 :: [erl_syntax:syntaxTree()].
+    Forms1 :: [tuple()].
 parse_transform(Forms0, _Opts) ->
     Forms = [transform_function(Form) || Form <- Forms0],
     % NOTE: Uncomment the function below for debugging.
     % debug(Forms0, Forms),
     Forms.
 
--spec transform(Form, Bindings) -> Transformed when
-    Form :: erl_syntax:syntaxTree(),
+-spec transform(FormOrForms, Bindings) -> Transformed when
+    FormOrForms :: tuple() | [tuple()],
     Bindings :: erl_eval:binding_struct(),
-    Transformed :: Ast | [Ast],
-    Ast :: erl_syntax:syntaxTree().
+    Transformed :: tuple() | [tuple()].
 transform(
     {call, _Pos1, {remote, _Pos2, {atom, _Pos3, Mod}, {atom, _Pos4, Fun}}, Body} = Form,
     Bindings


### PR DESCRIPTION
# Description

This PR fixes a bug in the parser when parsing multiple forms in the same Erlang expression, for example: `{Foo = bar, Foo}`.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
