### PR TITLE
Change the `arizona_view:handle_event/3` callback return

### DIFF
--- a/priv/static/assets/js/arizona-worker.js
+++ b/priv/static/assets/js/arizona-worker.js
@@ -10,7 +10,7 @@ const state = {
 self.importScripts('/assets/js/arizona/patch.js');
 
 // Messages from client
-self.onmessage = function(e) {
+self.onmessage = function (e) {
   const { data: msg } = e;
 
   console.log('[WebWorker] client sent:', msg);
@@ -38,19 +38,19 @@ function connect(queryParams) {
     state.queryParams = queryParams;
     state.socket = socket;
 
-    socket.onopen = function() {
+    socket.onopen = function () {
       console.log('[WebSocket] connected:', state);
       sendMsgToClient('connect');
 
       resolve();
     };
 
-    socket.onclose = function(e) {
+    socket.onclose = function (e) {
       console.log('[WebSocket] disconnected:', e);
     };
 
     // Messages from server
-    socket.onmessage = function(e) {
+    socket.onmessage = function (e) {
       console.log('[WebSocket] msg:', e.data);
       const data = JSON.parse(e.data);
       Array.isArray(data) ? data.forEach(handleEvent) : handleEvent(data);
@@ -85,7 +85,7 @@ function sendMsgToClient(eventName, payload) {
 }
 
 function sendMsgToServer(payload) {
-  state.socket.send(JSON.stringify(payload))
+  state.socket.send(JSON.stringify(payload));
 }
 
 function genSocketUrl(queryParams) {

--- a/priv/static/assets/js/arizona-worker.js
+++ b/priv/static/assets/js/arizona-worker.js
@@ -20,13 +20,12 @@ self.onmessage = function (e) {
     return;
   }
 
-  const { subject, attachment } = msg;
-  switch (subject) {
+  switch (msg.subject) {
     case 'connect':
-      connect(attachment);
+      connect(msg.attachment);
       break;
     default:
-      sendMsgToServer([subject, attachment]);
+      sendMsgToServer(msg);
   }
 };
 
@@ -84,8 +83,8 @@ function sendMsgToClient(eventName, payload) {
   self.postMessage({ eventName, payload });
 }
 
-function sendMsgToServer(payload) {
-  state.socket.send(JSON.stringify(payload));
+function sendMsgToServer(msg) {
+  state.socket.send(JSON.stringify(msg));
 }
 
 function genSocketUrl(queryParams) {

--- a/priv/static/assets/js/arizona.js
+++ b/priv/static/assets/js/arizona.js
@@ -7,33 +7,35 @@ globalThis['arizona'] = (() => {
   // --------------------------------------------------------------------
 
   function connect(params = {}, callback, opts) {
-    if (typeof callback === "function") {
-      _subscribe("connect", callback, opts)
+    if (typeof callback === 'function') {
+      _subscribe('connect', callback, opts);
     }
 
-    const searchParams = Object.fromEntries([...new URLSearchParams(window.location.search)]);
+    const searchParams = Object.fromEntries([
+      ...new URLSearchParams(window.location.search),
+    ]);
     const queryParams = {
       ...searchParams,
       ...params,
       path: location.pathname,
     };
-    _sendMsgToWorker("connect", queryParams)
+    _sendMsgToWorker('connect', queryParams);
   }
 
   function on(eventName, callback, opts) {
-    _subscribe(eventName, callback, opts)
+    _subscribe(eventName, callback, opts);
   }
 
   function event(eventName) {
     function emmit(viewId, payload) {
-      _sendMsgToWorker("event", [viewId, eventName, payload])
+      _sendMsgToWorker('event', [viewId, eventName, payload]);
     }
 
     function subscribe(callback, opts) {
-      _subscribe(eventName, callback, opts)
+      _subscribe(eventName, callback, opts);
     }
 
-    return Object.freeze({ emmit, subscribe })
+    return Object.freeze({ emmit, subscribe });
   }
 
   // --------------------------------------------------------------------
@@ -71,7 +73,7 @@ globalThis['arizona'] = (() => {
       unsubscribers,
     });
 
-    return function() {
+    return function () {
       _unsubscribe(id);
     };
   }
@@ -107,7 +109,7 @@ globalThis['arizona'] = (() => {
   const subscribers = new Map();
   const unsubscribers = new Map();
 
-  worker.addEventListener('message', function(e) {
+  worker.addEventListener('message', function (e) {
     console.log('[WebWorker] msg:', e.data);
 
     const { eventName, payload } = e.data;
@@ -120,13 +122,13 @@ globalThis['arizona'] = (() => {
         });
       }
     }
-    subscribers.get(eventName)?.forEach(function({ id, callback, opts }) {
+    subscribers.get(eventName)?.forEach(function ({ id, callback, opts }) {
       callback(payload);
       opts.once && _unsubscribe(id);
     });
   });
 
-  worker.addEventListener('error', function(e) {
+  worker.addEventListener('error', function (e) {
     console.error('[WebWorker] error:', e);
   });
 

--- a/priv/static/assets/js/arizona.js
+++ b/priv/static/assets/js/arizona.js
@@ -6,20 +6,41 @@ globalThis['arizona'] = (() => {
   // API function definitions
   // --------------------------------------------------------------------
 
-  function connect(params = {}) {
+  function connect(params = {}, callback, opts) {
+    if (typeof callback === "function") {
+      _subscribe("connect", callback, opts)
+    }
+
+    const searchParams = Object.fromEntries([...new URLSearchParams(window.location.search)]);
     const queryParams = {
-      ...searchParams(),
+      ...searchParams,
       ...params,
       path: location.pathname,
     };
-    send(undefined, 'connect', queryParams);
+    _sendMsgToWorker("connect", queryParams)
   }
 
-  function send(viewId, eventName, payload) {
-    sendToWorker.bind(this)(viewId, eventName, payload);
+  function on(eventName, callback, opts) {
+    _subscribe(eventName, callback, opts)
   }
 
-  function subscribe(eventName, callback, opts = {}) {
+  function event(eventName) {
+    function emmit(viewId, payload) {
+      _sendMsgToWorker("event", [viewId, eventName, payload])
+    }
+
+    function subscribe(callback, opts) {
+      _subscribe(eventName, callback, opts)
+    }
+
+    return Object.freeze({ emmit, subscribe })
+  }
+
+  // --------------------------------------------------------------------
+  // Private functions
+  // --------------------------------------------------------------------
+
+  function _subscribe(eventName, callback, opts = {}) {
     if (
       typeof eventName !== 'string' ||
       typeof callback !== 'function' ||
@@ -50,12 +71,12 @@ globalThis['arizona'] = (() => {
       unsubscribers,
     });
 
-    return function () {
-      unsubscribe(id);
+    return function() {
+      _unsubscribe(id);
     };
   }
 
-  function unsubscribe(id) {
+  function _unsubscribe(id) {
     const eventName = unsubscribers.get(id);
     if (!eventName) return;
     const eventSubs = subscribers.get(eventName);
@@ -74,16 +95,8 @@ globalThis['arizona'] = (() => {
     });
   }
 
-  // --------------------------------------------------------------------
-  // Private functions
-  // --------------------------------------------------------------------
-
-  function searchParams() {
-    return Object.fromEntries([...new URLSearchParams(window.location.search)]);
-  }
-
-  function sendToWorker(viewId, eventName, payload) {
-    worker.postMessage({ viewId, eventName, payload });
+  function _sendMsgToWorker(subject, attachment) {
+    worker.postMessage({ subject, attachment });
   }
 
   // --------------------------------------------------------------------
@@ -94,7 +107,7 @@ globalThis['arizona'] = (() => {
   const subscribers = new Map();
   const unsubscribers = new Map();
 
-  worker.addEventListener('message', function (e) {
+  worker.addEventListener('message', function(e) {
     console.log('[WebWorker] msg:', e.data);
 
     const { eventName, payload } = e.data;
@@ -107,15 +120,15 @@ globalThis['arizona'] = (() => {
         });
       }
     }
-    subscribers.get(eventName)?.forEach(function ({ id, callback, opts }) {
+    subscribers.get(eventName)?.forEach(function({ id, callback, opts }) {
       callback(payload);
-      opts.once && unsubscribe(id);
+      opts.once && _unsubscribe(id);
     });
   });
 
-  worker.addEventListener('error', function (e) {
+  worker.addEventListener('error', function(e) {
     console.error('[WebWorker] error:', e);
   });
 
-  return Object.freeze({ connect, send, subscribe, unsubscribe });
+  return Object.freeze({ connect, on, event });
 })();

--- a/src/arizona.erl
+++ b/src/arizona.erl
@@ -120,6 +120,9 @@ Arizona follows a component-based architecture where:
 -type mount_ret() :: arizona_view:mount_ret().
 -export_type([mount_ret/0]).
 
+-type handle_event_ret() :: arizona_view:handle_event_ret().
+-export_type([handle_event_ret/0]).
+
 -type event_name() :: arizona_view:event_name().
 -export_type([event_name/0]).
 

--- a/src/arizona_js.erl
+++ b/src/arizona_js.erl
@@ -17,11 +17,12 @@
     Js :: binary().
 send_event(ViewId, EventName, Payload) when is_binary(ViewId), is_binary(EventName) ->
     iolist_to_binary([
-        "arizona.send(&quot;",
-        ViewId,
-        "&quot;, &quot;",
-        EventName,
-        "&quot;, ",
-        json:encode(Payload),
+        "arizona.event(",
+        ["&quot;", EventName, "&quot;"],
+        ").emmit(",
+        [
+            ["&quot;", ViewId, "&quot;, "],
+            json:encode(Payload)
+        ],
         ")"
     ]).

--- a/src/arizona_view.erl
+++ b/src/arizona_view.erl
@@ -159,11 +159,11 @@ This callback **is required** for all view modules.
 
 The updated view state (`t:view/0`) after handling the event.
 """.
--callback handle_event(EventName, Payload, View0) -> View1 when
+-callback handle_event(EventName, Payload, View0) -> Return when
     EventName :: event_name(),
     Payload :: event_payload(),
-    View0 :: arizona_view:view(),
-    View1 :: arizona_view:view().
+    View0 :: view(),
+    Return :: handle_event_ret().
 
 %% --------------------------------------------------------------------
 %% Types (and their exports)
@@ -191,6 +191,14 @@ The updated view state (`t:view/0`) after handling the event.
 
 -type mount_ret() :: {ok, View :: view()} | ignore.
 -export_type([mount_ret/0]).
+
+-type handle_event_ret() ::
+    {noreply, View :: view()}
+    | {reply, Events :: events(), View :: view()}.
+-export_type([handle_event_ret/0]).
+
+-type events() :: [{Name :: event_name(), Payload :: event_payload()}].
+-export_type([events/0]).
 
 -type event_name() :: binary().
 -export_type([event_name/0]).
@@ -347,7 +355,7 @@ set_changed_bindings(ChangedBindings, #view{} = View) when is_map(ChangedBinding
     View#view{changed_bindings = ChangedBindings}.
 
 -spec rendered(View) -> Rendered when
-    View :: arizona_view:view(),
+    View :: view(),
     Rendered :: arizona_renderer:rendered().
 rendered(#view{} = View) ->
     View#view.rendered.
@@ -532,11 +540,11 @@ It updates the view's state based on the event and returns the updated view.
 
 The updated view state (`t:view/0`) after handling the event.
 """.
--spec handle_event(EventName, Payload, View0) -> View1 when
+-spec handle_event(EventName, Payload, View) -> Return when
     EventName :: event_name(),
     Payload :: event_payload(),
-    View0 :: arizona_view:view(),
-    View1 :: arizona_view:view().
+    View :: view(),
+    Return :: handle_event_ret().
 handle_event(EventName, Payload, #view{} = View) ->
     erlang:apply(View#view.module, handle_event, [EventName, Payload, View]).
 

--- a/src/arizona_view.erl
+++ b/src/arizona_view.erl
@@ -193,8 +193,8 @@ The updated view state (`t:view/0`) after handling the event.
 -export_type([mount_ret/0]).
 
 -type handle_event_ret() ::
-    {noreply, View :: view()}
-    | {reply, Events :: events(), View :: view()}.
+    {reply, Events :: events(), View :: view()}
+    | {noreply, View :: view()}.
 -export_type([handle_event_ret/0]).
 
 -type events() :: [{Name :: event_name(), Payload :: event_payload()}].

--- a/test/arizona_view_handler_SUITE.erl
+++ b/test/arizona_view_handler_SUITE.erl
@@ -67,13 +67,13 @@ render(View) ->
     </main>
     """").
 
--spec handle_event(EventName, Payload, View0) -> View1 when
+-spec handle_event(EventName, Payload, View) -> Return when
     EventName :: arizona:event_name(),
     Payload :: arizona:event_payload(),
-    View0 :: arizona:view(),
-    View1 :: arizona:view().
+    View :: arizona:view(),
+    Return :: arizona:handle_event_ret().
 handle_event(_EventName, _Payload, View) ->
-    View.
+    {noreply, View}.
 
 %% --------------------------------------------------------------------
 %% Tests


### PR DESCRIPTION
# Description

This PR allows the possibility to reply to the client when handling an event in any view, for example:

```erlang
-module(arizona_example_counter_view).
-compile({parse_transform, arizona_transform}).
-behaviour(arizona_view).

% ...

handle_event(~"incr", Incr, View0) ->
    Count = arizona:get_binding(count, View0),
    View = arizona:put_binding(count, Count + Incr, View0),
    Events = [{~"incr", Count + Incr}], % those events are sent back to the client
    {reply, Events, View}. % or {noreply, View}
```

Subscribing on the client side:

```js
arizona.on("incr", (count) => {
  console.log("[Client] Received incr:", count)
}, { once: false }) // if true, the callback is called once.
```

The change in the message structure sent to the server aims to help implement real-time communication, like channels in Phoenix.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
