### PR TITLE
Fix Node.js version file reference in priv-static-assets-js workflow

### DIFF
--- a/.github/workflows/priv-static-assets-js.yml
+++ b/.github/workflows/priv-static-assets-js.yml
@@ -52,7 +52,7 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version-file: .nvmrc
+          node-version-file: .tool-versions
           cache: "npm"
           cache-dependency-path: "package-lock.json"
 


### PR DESCRIPTION
# Description

Change from non-existent `.nvmrc` to `.tool-versions`.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)