### PR TITLE
Fix husky hooks setup and prettier gitignore integration

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Commit message hook for Arizona project
+# Validates commit message format
+
+set -e
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# The commit message file is passed as the first argument
+COMMIT_MSG_FILE="$1"
+
+if [ -f "$COMMIT_MSG_FILE" ]; then
+    COMMIT_MSG=$(head -n 1 "$COMMIT_MSG_FILE")
+    
+    # Check commit message length (72 characters)
+    if [ ${#COMMIT_MSG} -gt 72 ]; then
+        echo -e "${RED}✗ Commit message first line too long (${#COMMIT_MSG} chars, max 72)${NC}"
+        echo -e "${RED}  Message: ${COMMIT_MSG}${NC}"
+        echo -e "${YELLOW}  Please shorten your commit message to 72 characters or less.${NC}"
+        exit 1
+    fi
+    
+    echo -e "${GREEN}✓ Commit message format valid${NC}"
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -12,25 +12,14 @@ NC='\033[0m' # No Color
 
 echo -e "${GREEN}Running pre-commit checks...${NC}"
 
-# 1. Check commit message format (72 characters)
-echo -e "${YELLOW}→ Checking commit message format...${NC}"
-if [ -f ".git/COMMIT_EDITMSG" ]; then
-    COMMIT_MSG=$(head -n 1 .git/COMMIT_EDITMSG)
-    if [ ${#COMMIT_MSG} -gt 72 ]; then
-        echo -e "${RED}✗ Commit message first line too long (${#COMMIT_MSG} chars, max 72)${NC}"
-        echo -e "${RED}  Message: ${COMMIT_MSG}${NC}"
-        exit 1
-    fi
-fi
-
-# 2. Check for merge conflict markers
+# 1. Check for merge conflict markers
 echo -e "${YELLOW}→ Checking for merge conflict markers...${NC}"
 if git diff --cached --name-only | xargs grep -l "^<<<<<<< \|^======= \|^>>>>>>> " 2>/dev/null; then
     echo -e "${RED}✗ Merge conflict markers found in staged files${NC}"
     exit 1
 fi
 
-# 3. Check Erlang formatting
+# 2. Check Erlang formatting
 echo -e "${YELLOW}→ Checking Erlang code formatting...${NC}"
 if command -v rebar3 >/dev/null 2>&1; then
     if ! rebar3 fmt --check >/dev/null 2>&1; then
@@ -42,7 +31,7 @@ else
     echo -e "${YELLOW}⚠ rebar3 not found, skipping Erlang format check${NC}"
 fi
 
-# 4. Check JavaScript formatting
+# 3. Check JavaScript formatting
 echo -e "${YELLOW}→ Checking JavaScript code formatting...${NC}"
 if command -v npm >/dev/null 2>&1; then
     if ! npm run format:check >/dev/null 2>&1; then

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "type": "module",
   "scripts": {
     "build": "node ./esbuild.config.js",
-    "format": "prettier --write \"./*.js\" \"./assets/**/*.js\" \"**/*.json\" \"**/*.yml\" --config prettier.config.js --ignore-path .prettierignore",
-    "format:check": "prettier --check \"./*.js\" \"./assets/**/*.js\" \"**/*.json\" \"**/*.yml\" --config prettier.config.js --ignore-path .prettierignore",
+    "format": "prettier --write \"./*.js\" \"./assets/**/*.js\" \"**/*.json\" \"**/*.yml\" --config prettier.config.js --ignore-path .gitignore --ignore-path .prettierignore",
+    "format:check": "prettier --check \"./*.js\" \"./assets/**/*.js\" \"**/*.json\" \"**/*.yml\" --config prettier.config.js --ignore-path .gitignore --ignore-path .prettierignore",
     "lint:js": "eslint eslint.config.js --fix",
     "lint:js:check": "eslint eslint.config.js",
     "lint:md": "markdownlint-cli2 \".github/**/*.md\" \"*.md\"",


### PR DESCRIPTION
# Description

## Summary
Fixes husky git hooks setup to work out-of-the-box and resolves prettier checking git-ignored files causing pre-push failures.
                                                                                     
## Problems
1. **Broken husky setup**: Hooks were using deprecated v8 structure requiring manual symlinks
2. **Unreliable commit validation**: Commit message validation checked stale `.git/COMMIT_EDITMSG` files
3. **Prettier checking ignored files**: Pre-push failed because prettier formatted git-ignored files like `test-results/.last-run.json`
4. **Manual setup required**: Hooks didn't work automatically after clone/install
                                                                                     
## Solutions
- **Modernize husky setup**: Remove deprecated `_/` internal structure, use husky v9 standards
- **Fix commit message validation**: Move from `pre-commit` to proper `commit-msg` hook that receives actual message
- **Fix prettier gitignore integration**: Add `--ignore-path .gitignore` to respect git-ignored files
- **Ensure automatic setup**: Hooks now install and work immediately after `npm install`
                                                                                     
## Changes
### Husky Hooks
- Remove deprecated husky internal files and manual symlinks
- Move commit message length validation to `commit-msg` hook
- Update `pre-commit` hook to focus on code quality checks only
- Add proper error messages with guidance
                                                                                     
### Prettier Integration
- Add `--ignore-path .gitignore` to prettier format commands
- Prevents prettier from processing git-ignored directories
- Fixes pre-push hook failures on temporary/build files
                                                                                     
## Testing
- ✅ Commit with valid message (≤72 chars) - passes
- ✅ Commit with long message (>72 chars) - properly rejected
- ✅ Prettier respects gitignore and doesn't check ignored files
- ✅ Pre-push succeeds without formatting git-ignored files
- ✅ Hooks work automatically without manual setup
                                                                                     
## Impact
- Eliminates pre-push failures from git-ignored file formatting
- Prevents commits with overly long messages (enforces 72 char limit)
- Removes need for manual husky configuration
- Improves developer experience with reliable, automatic git hooks
- Maintains existing code quality checks while fixing edge cases

---

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)