### PR TITLE
Fix Elvis linting violations by using infinity timeouts in gen_server:call

### DIFF
--- a/src/arizona_live.erl
+++ b/src/arizona_live.erl
@@ -202,7 +202,7 @@ Returns the updated socket after mounting.
     Req :: arizona_request:request(),
     Socket :: arizona_socket:socket().
 mount(Pid, Req) ->
-    gen_server:call(Pid, {mount, Req}).
+    gen_server:call(Pid, {mount, Req}, 5000).
 
 -doc ~"""
 Render the LiveView to generate output.
@@ -222,7 +222,7 @@ after rendering.
     Pid :: pid(),
     Socket :: arizona_socket:socket().
 render(Pid) ->
-    gen_server:call(Pid, render).
+    gen_server:call(Pid, render, 5000).
 
 -doc ~"""
 Handle a client event in the LiveView.
@@ -247,7 +247,7 @@ or reply response with the updated socket.
     Socket :: arizona_socket:socket(),
     Reply :: term().
 handle_event(Pid, Event, Params) ->
-    gen_server:call(Pid, {handle_event, Event, Params}).
+    gen_server:call(Pid, {handle_event, Event, Params}, 5000).
 
 -doc ~"""
 Set the rendering mode for the LiveView.

--- a/src/arizona_live.erl
+++ b/src/arizona_live.erl
@@ -202,7 +202,7 @@ Returns the updated socket after mounting.
     Req :: arizona_request:request(),
     Socket :: arizona_socket:socket().
 mount(Pid, Req) ->
-    gen_server:call(Pid, {mount, Req}, 5000).
+    gen_server:call(Pid, {mount, Req}, infinity).
 
 -doc ~"""
 Render the LiveView to generate output.
@@ -222,7 +222,7 @@ after rendering.
     Pid :: pid(),
     Socket :: arizona_socket:socket().
 render(Pid) ->
-    gen_server:call(Pid, render, 5000).
+    gen_server:call(Pid, render, infinity).
 
 -doc ~"""
 Handle a client event in the LiveView.
@@ -247,7 +247,7 @@ or reply response with the updated socket.
     Socket :: arizona_socket:socket(),
     Reply :: term().
 handle_event(Pid, Event, Params) ->
-    gen_server:call(Pid, {handle_event, Event, Params}, 5000).
+    gen_server:call(Pid, {handle_event, Event, Params}, infinity).
 
 -doc ~"""
 Set the rendering mode for the LiveView.


### PR DESCRIPTION
# Description

## Summary

- Fix Elvis `no_common_caveats_call` rule violations in `arizona_live.erl`
- Replace 5000ms timeouts with `infinity` in three gen_server:call functions
- Follow OTP team guidance that infinity is the preferred default timeout

## Error log

```shell
# src/arizona_live.erl [FAIL]
  - no_common_caveats_call (https://github.com/inaka/elvis_core/tree/main/doc_rules/elvis_style/no_common_caveats_call.md)
    - The call to gen_server:call/2 on line 205 might have performance drawbacks or implicit behavior.
    - The call to gen_server:call/2 on line 225 might have performance drawbacks or implicit behavior.
    - The call to gen_server:call/2 on line 250 might have performance drawbacks or implicit behavior.
===> Linting failed
```

## Changes

- `mount/2`: Use infinity timeout for mount operations
- `render/1`: Use infinity timeout for render operations  
- `handle_event/3`: Use infinity timeout for event handling

## Background

Elvis linting was failing on `gen_server:call/2` usage, requiring explicit timeouts. Following OTP team guidance, `infinity` is
preferred over arbitrary timeouts like 5000ms because client-side timeouts are problematic and well-designed servers should not block.

Reference: https://erlangforums.com/t/thoughts-on-the-default-timeout-for-gen-server-call/2812/6?u=williamthome

---

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
