### PR TITLE
Replace merge heuristics with opaque types and pattern matching

### DIFF
--- a/test/arizona_websocket_SUITE.erl
+++ b/test/arizona_websocket_SUITE.erl
@@ -392,7 +392,12 @@ test_mock_live_module_for_reply_responses(_Config) ->
 test_json_encoding_tuple_to_array_conversion(_Config) ->
     % Test JSON encoding with tuple-to-array conversion using nested diff structure
     % This simulates the DiffChanges structure returned by arizona_socket:get_changes/1
-    TestDiffChanges = [{root, [{1, ~"test_value"}, {2, {nested, ~"data"}}]}],
+    TestDiffChanges = [
+        {root, [
+            {1, arizona_differ:html_content(~"test_value")},
+            {2, arizona_differ:html_content([~"nested", ~"data"])}
+        ]}
+    ],
 
     % Create the payload structure that handle_noreply_response would create
     DiffPayload = #{


### PR DESCRIPTION
# Description

Depends on #336.

## 🎯 What & Why

This PR eliminates 65+ lines of fragile heuristic-based merge logic by introducing a clean opaque type system. Previously, `arizona_socket` had to guess whether data was HTML content or component changes using complex pattern matching. Now, element changes are self-describing types that enable simple, bulletproof merging logic.

## 🔧 Key Changes

### New Opaque Type System

```erlang
-opaque element_change() ::
    {html_content, arizona_html:html()}
    | {component_changes, [component_change()]}.
```

**Before**: Raw terms like `"hello"`, `[{root, [{1, "value"}]}]` - ambiguous and error-prone  
**After**: Typed wrappers like `{html_content, "hello"}`, `{component_changes, [...]}` - clear and safe

### Smart JSON Encoding

The WebSocket encoder automatically unwraps opaque types for JavaScript consumption:
```erlang
% Erlang: {html_content, "test"}
% JSON: "test"  ✨ Transparent unwrapping
```

### The Big Win: No More Heuristics! 
**Removed 65+ lines** of fragile merge logic from `arizona_socket.erl`:
```erlang
% BEFORE: Fragile heuristics trying to guess data types
looks_like_component_changes([{ComponentId, ElementChanges} | Rest]) when
    (is_atom(ComponentId) orelse is_binary(ComponentId)) andalso is_list(ElementChanges) ->
    case looks_like_element_changes(ElementChanges) of
        true -> looks_like_component_changes(Rest);
        false -> false
    end;
% ... 60+ more lines of guessing logic

% AFTER: Clean, bulletproof pattern matching
arizona_differ:merge_element_changes(NewChange, ExistingChange)
```

## 🚀 Impact

- **Reliability**: No more "is this HTML or components?" guessing games that could fail on edge cases
- **Performance**: Direct pattern matching instead of multi-step type detection
- **Type Safety**: Impossible to accidentally mix HTML content with component changes

---

- [ ] I have performed a self-review of my changes
- [ ] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)