### PR TITLE
Fix CI cache invalidation for rebar.config changes

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -51,7 +51,8 @@ jobs:
           rebar3-\
           ${{ runner.os }}-\
           otp-${{ steps.setup-beam.outputs.otp-version }}-\
-          rebar3-${{ steps.setup-beam.outputs.rebar3-version }}" \
+          rebar3-${{ steps.setup-beam.outputs.rebar3-version }}-\
+          config-${{ hashFiles('rebar.config') }}" \
           >> "${GITHUB_OUTPUT}"
 
       - name: Cache _build

--- a/.github/workflows/rebar-lock.yml
+++ b/.github/workflows/rebar-lock.yml
@@ -74,7 +74,7 @@ jobs:
             -os-${{runner.os}}\
             -otp-${{steps.setup-beam.outputs.otp-version}}\
             -rebar3-${{steps.setup-beam.outputs.rebar3-version}}\
-            -hash-${{hashFiles('rebar.lock')}}"
+            -hash-${{hashFiles('rebar.lock')}}-${{hashFiles('rebar.config')}}"
 
       - run: |
           rebar3 upgrade --all


### PR DESCRIPTION
# Description

- Include rebar.config hash in rebar3 cache key
- Ensures cache invalidation when plugin versions change (e.g., erlfmt)
- Fixes formatting check failures in CI due to stale cached plugins

The previous cache key only included OTP and rebar3 versions, but changes to project_plugins in rebar.config (like erlfmt version updates) would not invalidate the rebar3 cache, causing CI to use stale plugin versions while local development used fresh ones.

---

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
