### PR TITLE
Replace template tuples with arizona_template:new/5 calls

### DIFF
--- a/src/arizona_parser.erl
+++ b/src/arizona_parser.erl
@@ -77,15 +77,14 @@ create_template_ast(StaticParts, DynamicElements, CompileOpts) ->
     Fingerprint = erlang:phash2(FingerprintData),
     FingerprintAST = erl_syntax:integer(Fingerprint),
 
-    % Create tuple AST: {template, Static, Dynamic, DynamicSequence, DynamicAnno, Fingerprint}
-    erl_syntax:tuple([
-        erl_syntax:atom(template),
-        StaticListAST,
-        DynamicAST,
-        DynamicSequenceAST,
-        DynamicAnnoAST,
-        FingerprintAST
-    ]).
+    % Create arizona_template:new/5 call
+    erl_syntax:application(
+        erl_syntax:module_qualifier(
+            erl_syntax:atom(arizona_template),
+            erl_syntax:atom(new)
+        ),
+        [StaticListAST, DynamicAST, DynamicSequenceAST, DynamicAnnoAST, FingerprintAST]
+    ).
 
 %% Create AST for static list
 -spec create_static_list_ast(StaticParts) -> erl_syntax:syntaxTree() when

--- a/src/arizona_template.erl
+++ b/src/arizona_template.erl
@@ -5,6 +5,7 @@
 %% API function exports
 %% --------------------------------------------------------------------
 
+-export([new/5]).
 -export([from_string/1]).
 -export([is_template/1]).
 -export([from_string/4]).
@@ -26,6 +27,7 @@
 %% Ignore xref warnings
 %% --------------------------------------------------------------------
 
+-ignore_xref([new/5]).
 -ignore_xref([from_string/1]).
 -ignore_xref([from_string/4]).
 -ignore_xref([get_dynamic_anno/1]).
@@ -46,6 +48,8 @@
 -export_type([template/0]).
 -export_type([static/0]).
 -export_type([dynamic/0]).
+-export_type([dynamic_tuple/0]).
+-export_type([dynamic_tuple_callback/0]).
 -export_type([dynamic_sequence/0]).
 -export_type([dynamic_anno/0]).
 -export_type([fingerprint/0]).
@@ -58,7 +62,7 @@
 
 -record(template, {
     static :: static(),
-    dynamic :: dynamic() | fun((CallbackArg :: term()) -> dynamic()),
+    dynamic :: dynamic(),
     dynamic_sequence :: dynamic_sequence(),
     dynamic_anno :: dynamic_anno(),
     fingerprint :: fingerprint()
@@ -66,7 +70,9 @@
 
 -opaque template() :: #template{}.
 -nominal static() :: [binary()].
--nominal dynamic() :: tuple().
+-nominal dynamic() :: dynamic_tuple() | dynamic_tuple_callback().
+-nominal dynamic_tuple() :: tuple().
+-nominal dynamic_tuple_callback() :: fun((CallbackArg :: term()) -> dynamic_tuple()).
 -nominal dynamic_sequence() :: [pos_integer()].
 -nominal dynamic_anno() :: tuple().
 -nominal fingerprint() :: non_neg_integer().
@@ -83,6 +89,22 @@
 %% --------------------------------------------------------------------
 %% API Functions
 %% --------------------------------------------------------------------
+
+-spec new(Static, Dynamic, DynamicSequence, DynamicAnno, Fingerprint) -> Template when
+    Static :: static(),
+    Dynamic :: dynamic(),
+    DynamicSequence :: dynamic_sequence(),
+    DynamicAnno :: dynamic_anno(),
+    Fingerprint :: fingerprint(),
+    Template :: template().
+new(Static, Dynamic, DynamicSequence, DynamicAnno, Fingerprint) ->
+    #template{
+        static = Static,
+        dynamic = Dynamic,
+        dynamic_sequence = DynamicSequence,
+        dynamic_anno = DynamicAnno,
+        fingerprint = Fingerprint
+    }.
 
 -spec from_string(String) -> Template when
     String :: binary(),


### PR DESCRIPTION
# Description

Previously, the parser was creating template tuples directly: `{template, Static, Dynamic, DynamicSequence, DynamicAnno, Fingerprint}`. This violated the opaque type abstraction and caused Dialyzer errors in dependent projects.

Now the parser generates proper function calls: `arizona_template:new(Static, Dynamic, DynamicSequence, DynamicAnno, Fingerprint)`, which maintains type safety and prevents external code from directly accessing internal template structure.

---

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
