### PR TITLE
Fix UTF-8 encoding issues in Arizona template system

### DIFF
--- a/assets/js/e2e/parallel/datagrid.spec.js
+++ b/assets/js/e2e/parallel/datagrid.spec.js
@@ -189,11 +189,11 @@ test.describe('Arizona Datagrid App', () => {
     const statusHeader = page.locator('th').filter({ hasText: 'Status' });
     const actionsHeader = page.locator('th').filter({ hasText: 'Actions' });
 
-    await expect(roleHeader).not.toHaveClass(/sortable/);
-    await expect(statusHeader).not.toHaveClass(/sortable/);
+    await expect(roleHeader).toHaveClass(/sortable/);
+    await expect(statusHeader).toHaveClass(/sortable/);
     await expect(actionsHeader).not.toHaveClass(/sortable/);
 
-    // Verify these headers don't have pointer cursor
+    // Verify these headers have pointer cursor
     const roleCursor = await roleHeader.evaluate((el) => {
       return getComputedStyle(el).cursor;
     });
@@ -201,8 +201,8 @@ test.describe('Arizona Datagrid App', () => {
       return getComputedStyle(el).cursor;
     });
 
-    expect(roleCursor).not.toBe('pointer');
-    expect(statusCursor).not.toBe('pointer');
+    expect(roleCursor).toBe('pointer');
+    expect(statusCursor).toBe('pointer');
   });
 
   test('should delete user via action button with WebSocket updates', async ({ page }) => {
@@ -343,13 +343,13 @@ test.describe('Arizona Datagrid App', () => {
     const inactiveBadge = page.locator('.status-badge-inactive').first();
     const pendingBadge = page.locator('.status-badge-pending').first();
 
-    await expect(activeBadge).toContainText('✓'); // Check mark
+    await expect(activeBadge).toContainText('✅');
     await expect(activeBadge).toContainText('active');
 
-    await expect(inactiveBadge).toContainText('○'); // Circle
+    await expect(inactiveBadge).toContainText('⚪');
     await expect(inactiveBadge).toContainText('inactive');
 
-    await expect(pendingBadge).toContainText('⌛'); // Hourglass
+    await expect(pendingBadge).toContainText('⏳');
     await expect(pendingBadge).toContainText('pending');
   });
 
@@ -366,7 +366,7 @@ test.describe('Arizona Datagrid App', () => {
 
     // Verify sortable headers are keyboard accessible
     const sortableHeaders = page.locator('th.sortable');
-    await expect(sortableHeaders).toHaveCount(3); // Name, Email, Created
+    await expect(sortableHeaders).toHaveCount(5); // Name, Email, Role, Status, Created
 
     // Test keyboard navigation on sortable header (click instead of Enter as that's the implemented interaction)
     await sortableHeaders.first().click();

--- a/rebar.lock
+++ b/rebar.lock
@@ -3,7 +3,7 @@
  {<<"cowlib">>,{pkg,<<"cowlib">>,<<"2.15.0">>},1},
  {<<"eqwalizer_support">>,
   {git_subdir,"https://github.com/whatsapp/eqwalizer.git",
-              {ref,"46efaf846c1f9e2ab1883d065a77b7d5f678b219"},
+              {ref,"092cf1e1e9854c8d2ef8fa8b9935b1dc45fff070"},
               "eqwalizer_support"},
   0},
  {<<"fs">>,{pkg,<<"fs">>,<<"11.4.1">>},0},

--- a/src/arizona_parser.erl
+++ b/src/arizona_parser.erl
@@ -90,16 +90,7 @@ create_template_ast(StaticParts, DynamicElements, CompileOpts) ->
 -spec create_static_list_ast(StaticParts) -> erl_syntax:syntaxTree() when
     StaticParts :: [binary()].
 create_static_list_ast(StaticParts) ->
-    StaticElements = [
-        erl_syntax:binary([
-            erl_syntax:binary_field(
-                erl_syntax:string(binary_to_list(Part)),
-                none,
-                [erl_syntax:atom(utf8)]
-            )
-        ])
-     || Part <- StaticParts
-    ],
+    StaticElements = [erl_syntax:abstract(Part) || Part <- StaticParts],
     erl_syntax:list(StaticElements).
 
 %% Create AST for dynamic elements (tuple, annotations, sequence)

--- a/src/arizona_parser.erl
+++ b/src/arizona_parser.erl
@@ -5,6 +5,7 @@
 %% --------------------------------------------------------------------
 
 -export([parse_tokens/2]).
+-export([quote/1]).
 -export([format_error/2]).
 
 %% --------------------------------------------------------------------
@@ -36,6 +37,17 @@
 parse_tokens(Tokens, CompileOpts) ->
     {StaticParts, DynamicElements} = separate_static_dynamic(Tokens),
     create_template_ast(StaticParts, DynamicElements, CompileOpts).
+
+-spec quote(Text) -> Ast when
+    Text :: binary(),
+    Ast :: [erl_syntax:syntaxTree()].
+quote(Text) ->
+    % Convert UTF-8 binary to proper Unicode character list for merl:quote
+    SafeText = unicode:characters_to_list(Text),
+    case merl:quote(SafeText) of
+        F when is_list(F) -> F;
+        F -> [F]
+    end.
 
 -spec format_error(Reason, StackTrace) -> ErrorMap when
     Reason :: arizona_create_dynamic_callback_failed | term(),
@@ -135,11 +147,8 @@ create_dynamic_ast(DynamicElements, CompileOpts) ->
     CompileOpts :: [compile:option()],
     Ast :: erl_syntax:syntaxTree().
 create_dynamic_callback_ast(ExprText, CompileOpts) ->
-    Forms =
-        case merl:quote(ExprText) of
-            F when is_list(F) -> F;
-            F -> [F]
-        end,
+    Forms = quote(ExprText),
+
     % Check if we're already in a recursive parse transform to prevent infinite loops
     InRecursiveTransform = proplists:get_bool(in_dynamic_callback, CompileOpts),
 

--- a/src/arizona_scanner.erl
+++ b/src/arizona_scanner.erl
@@ -234,11 +234,7 @@ expr_category(Expr, State) ->
 %% Parse expression using merl, handling exceptions gracefully
 parse_expression(Expr) ->
     try
-        Forms =
-            case merl:quote(Expr) of
-                F when is_list(F) -> F;
-                F -> [F]
-            end,
+        Forms = arizona_parser:quote(Expr),
         {ok, Forms}
     catch
         Class:Exception:StackTrace ->

--- a/test/support/e2e/datagrid/arizona_datagrid_layout.erl
+++ b/test/support/e2e/datagrid/arizona_datagrid_layout.erl
@@ -34,34 +34,9 @@ render(Bindings) ->
                 cursor: pointer;
                 transition: all var(--transition-fast);
                 position: relative;
-                padding-right: 2rem;
             }
             .table th.sortable:hover \{
                 background-color: var(--color-gray-100);
-            }
-            .table th.sortable::after \{
-                content: '';
-                position: absolute;
-                right: 0.875rem;
-                top: 50%;
-                transform: translateY(-50%) translateY(2px);
-                width: 0;
-                height: 0;
-                border-left: 3px solid transparent;
-                border-right: 3px solid transparent;
-                border-top: 4px solid var(--color-gray-400);
-            }
-            .table th.sortable::before \{
-                content: '';
-                position: absolute;
-                right: 0.875rem;
-                top: 50%;
-                transform: translateY(-50%) translateY(-2px);
-                width: 0;
-                height: 0;
-                border-left: 3px solid transparent;
-                border-right: 3px solid transparent;
-                border-bottom: 4px solid var(--color-gray-400);
             }
             .table th.sortable:hover::after \{
                 border-top-color: var(--color-gray-600);

--- a/test/support/e2e/datagrid/arizona_datagrid_view.erl
+++ b/test/support/e2e/datagrid/arizona_datagrid_view.erl
@@ -18,8 +18,8 @@ mount(Req) ->
             cols => [
                 #{name => name, label => ~"Name", sortable => true},
                 #{name => email, label => ~"Email", sortable => true},
-                #{name => role, label => ~"Role", sortable => false},
-                #{name => status, label => ~"Status", sortable => false},
+                #{name => role, label => ~"Role", sortable => true},
+                #{name => status, label => ~"Status", sortable => true},
                 #{name => created_at, label => ~"Created", sortable => true},
                 #{name => actions, label => ~"Actions", sortable => false}
             ],
@@ -173,9 +173,9 @@ mount(Req) ->
                         #{name := status} ->
                             {StatusClass, StatusIcon} =
                                 case maps:get(status, Row) of
-                                    ~"active" -> {~"status-badge status-badge-active", ~"&#10003;"};
-                                    ~"inactive" -> {~"status-badge status-badge-inactive", ~"&#9675;"};
-                                    ~"pending" -> {~"status-badge status-badge-pending", ~"&#8987;"}
+                                    ~"active" -> {~"status-badge status-badge-active", ~"✅"};
+                                    ~"inactive" -> {~"status-badge status-badge-inactive", ~"⚪"};
+                                    ~"pending" -> {~"status-badge status-badge-pending", ~"⏳"}
                                 end,
                             arizona_template:from_string(~"""
                             <span class="{StatusClass}">
@@ -197,7 +197,7 @@ mount(Req) ->
                                     class="action-btn action-btn-danger"
                                     onclick="arizona.sendEvent('delete_user', \{id: '{UserId}'})"
                                 >
-                                    &#128465; Delete
+                                    🗑️ Delete
                                 </button>
                             </div>
                             """)
@@ -217,7 +217,9 @@ render(Bindings) ->
         {arizona_template:render_stateless(arizona_datagrid_view, render_table, #{
             cols => arizona_template:get_binding(cols, Bindings),
             rows => arizona_template:get_binding(rows, Bindings),
-            callback => arizona_template:get_binding(callback, Bindings)
+            callback => arizona_template:get_binding(callback, Bindings),
+            sort_column => arizona_template:get_binding(sort_column, Bindings),
+            sort_direction => arizona_template:get_binding(sort_direction, Bindings)
         })}
     </div>
     """").
@@ -230,6 +232,8 @@ render_table(Bindings) ->
                 <tr>
                     {arizona_template:render_list(fun(Col) ->
                         Sortable = maps:get(sortable, Col, false),
+                        SortColumn = arizona_template:get_binding(sort_column, Bindings),
+                        SortDirection = arizona_template:get_binding(sort_direction, Bindings),
                         arizona_template:from_string(~""""
                         <th scope="col" class="{
                             case Sortable of
@@ -250,7 +254,13 @@ render_table(Bindings) ->
                             {maps:get(label, Col)}
                             {
                                 case Sortable of
-                                    true -> ~" <i class=\"fas fa-sort\"></i>";
+                                    true ->
+                                        ColumnName = maps:get(name, Col),
+                                        case {SortColumn, SortDirection} of
+                                            {ColumnName, asc} -> ~" 🔼";
+                                            {ColumnName, desc} -> ~" 🔽";
+                                            _ -> ~""
+                                        end;
                                     false -> ~""
                                 end
                             }

--- a/test/support/e2e/shared/arizona_test_components.erl
+++ b/test/support/e2e/shared/arizona_test_components.erl
@@ -7,7 +7,7 @@ render_menu(Bindings) ->
     <nav class="test-nav">
         <div class="nav-container">
             <div class="nav-brand">
-                <h1>Arizona Test Apps</h1>
+                <h1>🌵 Arizona Test Apps</h1>
             </div>
             <ul class="nav-menu">
                 {


### PR DESCRIPTION
# Description

Resolves UTF-8 encoding problems where characters like "É" rendered as "Ã" due to double-encoding in both static and dynamic template content.

## Changes

- **Static Content**: Fixed AST generation in `arizona_parser.erl` by replacing `erl_syntax:string(binary_to_list(Part))` with `erl_syntax:abstract(Part)`
- **Dynamic Content**: Added `quote/1` wrapper using `unicode:characters_to_list/1` before `merl:quote/1` to handle UTF-8 binaries properly
- **Templates**: Updated examples to use Unicode emojis (✅, ⚪, ⏳, 🗑️) and made datagrid Role/Status columns sortable
- **Tests**: Updated e2e tests for new emoji expectations and sortable column behavior

## Technical Details

Erlang's parsing functions aren't UTF-8 aware by default - UTF-8 bytes were treated as separate Latin-1 characters, causing double-encoding.

---

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
