### PR TITLE
Fix CSS escaping in realtime layout template

### DIFF
--- a/test/support/e2e/realtime/arizona_realtime_layout.erl
+++ b/test/support/e2e/realtime/arizona_realtime_layout.erl
@@ -15,7 +15,7 @@ render(Bindings) ->
                 font-family: Arial, sans-serif;
                 margin: 40px;
                 background: #f5f5f5;
-            \}
+            }
             .container \{
                 max-width: 800px;
                 margin: 0 auto;
@@ -23,28 +23,28 @@ render(Bindings) ->
                 padding: 40px;
                 border-radius: 8px;
                 box-shadow: 0 2px 10px rgba(0,0,0,0.1);
-            \}
+            }
             h1 \{
                 color: #333;
                 margin-bottom: 30px;
-            \}
+            }
             .clock \{
                 font-size: 48px;
                 font-weight: bold;
                 color: #2563eb;
                 text-align: center;
                 margin: 20px 0;
-            \}
+            }
             .info \{
                 background: #e0f2fe;
                 padding: 20px;
                 border-radius: 6px;
                 margin: 20px 0;
-            \}
+            }
             .tabs \{
                 color: #666;
                 font-style: italic;
-            \}
+            }
         </style>
     </head>
     <body>


### PR DESCRIPTION
# Description

This PR removes unnecessary backslash escaping in CSS closing braces in the realtime layout test template.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
