### PR TITLE
Implement proper configuration system for Arizona

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,15 @@ In your `rebar.config`:
 ### 2. Start Server
 
 ```erlang
-{ok, _Pid} = arizona_server:start(#{
-    port => 8080,
-    routes => [
-        {live, ~"/my-view", my_view_module},
-        {live_websocket, ~"/live/websocket"},
-        {static, ~"/assets", {priv_dir, arizona, ~"static/assets"}}
-    ]
+arizona:start(#{
+    server => #{
+        transport_opts => [{port, 1912}],
+        routes => [
+            {live, ~"/my-view", my_view_module},
+            {live_websocket, ~"/live/websocket"},
+            {static, ~"/assets", {priv_dir, arizona, ~"static/assets"}}
+        ]
+    }
 }).
 ```
 

--- a/scripts/start_test_server.sh
+++ b/scripts/start_test_server.sh
@@ -33,9 +33,12 @@ Routes = [
     {static, ~\"/assets\", {priv_dir, arizona, ~\"static/assets\"}}
 ],
 {ok, _ClockPid} = arizona_clock_server:start_link(),
-case arizona_server:start(#{
-    port => 8080,
-    routes => Routes,
+case arizona:start(#{
+    server => #{
+        enabled => true,
+        transport_opts => [{port, 8080}],
+        routes => Routes
+    },
     reloader => #{
         enabled => true,
         rules => [
@@ -87,7 +90,7 @@ case arizona_server:start(#{
         ]
     }
 }) of
-    {ok, _} ->
+    ok ->
         io:format(\"Arizona test server started on port 8080~n\"),
         receive stop -> ok end;
     Error ->

--- a/src/arizona_app.erl
+++ b/src/arizona_app.erl
@@ -19,9 +19,11 @@
     Pid :: pid(),
     ErrReason :: term().
 start(_StartType, _StartArgs) ->
-    case arizona_sup:start_link() of
-        {ok, Pid} ->
-            {ok, Pid};
+    maybe
+        {ok, SupPid} ?= arizona_sup:start_link(),
+        ok ?= arizona:start(get_env_config()),
+        {ok, SupPid}
+    else
         {error, Reason} ->
             {error, Reason}
     end.
@@ -30,3 +32,15 @@ start(_StartType, _StartArgs) ->
     State :: term().
 stop(_State) ->
     ok.
+
+%% --------------------------------------------------------------------
+%% Internal functions
+%% --------------------------------------------------------------------
+
+get_env_config() ->
+    ServerConfig = application:get_env(arizona, server, #{enabled => false}),
+    ReloaderConfig = application:get_env(arizona, reloader, #{enabled => false}),
+    #{
+        server => ServerConfig,
+        reloader => ReloaderConfig
+    }.

--- a/test/arizona_handler_SUITE.erl
+++ b/test/arizona_handler_SUITE.erl
@@ -40,7 +40,7 @@ init_per_suite(Config) ->
     {ok, _} = application:ensure_all_started(inets),
     % Start arizona server
     {ok, _Pid} = arizona_server:start(#{
-        port => ServerPort,
+        transport_opts => [{port, ServerPort}],
         routes => [
             {live, ViewRouteUrl, MockViewModule},
             {live, ErrorViewRouteUrl, MockErrorViewModule},

--- a/test/arizona_websocket_SUITE.erl
+++ b/test/arizona_websocket_SUITE.erl
@@ -50,7 +50,7 @@ init_per_suite(Config) ->
     {ok, _} = application:ensure_all_started(gun),
     %% Start arizona server
     {ok, _Pid} = arizona_server:start(#{
-        port => ServerPort,
+        transport_opts => [{port, ServerPort}],
         routes => [
             {live, ViewWithLayoutRouteUrl, MockViewWithLayoutModule},
             {live_websocket, WebSocketRouteUrl}


### PR DESCRIPTION
# Description

- Add arizona:start/1 as main entry point with config validation
- Replace manual port parameter with structured server_config type
- Support both list and map formats for transport_opts
- Integrate with Ranch and Cowboy configuration directly
- Add sys.config support via arizona_app.erl
- Update tests to use new configuration structure
- Change default port from 8080 to 1912 (Arizona statehood year)
- Separate server and reloader configuration concerns
- Maintain backward compatibility with existing Ranch/Cowboy types

---

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)