### PR TITLE
Refactor route handling to support mount arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ arizona:start(#{
     server => #{
         transport_opts => [{port, 1912}],
         routes => [
-            {live, ~"/my-view", my_view_module},
+            {live, ~"/my-view", my_view_module, #{mount => arg}},
             {live_websocket, ~"/live/websocket"},
             {static, ~"/assets", {priv_dir, arizona, ~"static/assets"}}
         ]

--- a/scripts/start_test_server.sh
+++ b/scripts/start_test_server.sh
@@ -24,11 +24,11 @@ exec erl \
     -noshell -eval "
 {ok, _} = application:ensure_all_started(arizona),
 Routes = [
-    {live, ~\"/realtime\", arizona_realtime_view},
-    {live, ~\"/counter\", arizona_counter_view},
-    {live, ~\"/todo\", arizona_todo_app_view},
-    {live, ~\"/datagrid\", arizona_datagrid_view},
-    {live, ~\"/modal\", arizona_modal_view},
+    {live, ~\"/realtime\", arizona_realtime_view, #{}},
+    {live, ~\"/counter\", arizona_counter_view, #{}},
+    {live, ~\"/todo\", arizona_todo_app_view, #{}},
+    {live, ~\"/datagrid\", arizona_datagrid_view, #{}},
+    {live, ~\"/modal\", arizona_modal_view, #{}},
     {live_websocket, ~\"/live/websocket\"},
     {static, ~\"/assets\", {priv_dir, arizona, ~\"static/assets\"}}
 ],

--- a/src/arizona_live.erl
+++ b/src/arizona_live.erl
@@ -5,7 +5,7 @@
 %% API function exports
 %% --------------------------------------------------------------------
 
--export([start_link/3]).
+-export([start_link/4]).
 -export([is_connected/1]).
 -export([get_view/1]).
 -export([initial_render/1]).
@@ -49,13 +49,14 @@
 %% API function definitions
 %% --------------------------------------------------------------------
 
--spec start_link(ViewModule, ArizonaRequest, TransportPid) -> Return when
+-spec start_link(ViewModule, MountArg, ArizonaRequest, TransportPid) -> Return when
     ViewModule :: module(),
+    MountArg :: dynamic(),
     ArizonaRequest :: arizona_request:request(),
     TransportPid :: pid(),
     Return :: gen_server:start_ret().
-start_link(ViewModule, ArizonaRequest, TransportPid) ->
-    gen_server:start_link(?MODULE, {ViewModule, ArizonaRequest, TransportPid}, []).
+start_link(ViewModule, MountArg, ArizonaRequest, TransportPid) ->
+    gen_server:start_link(?MODULE, {ViewModule, MountArg, ArizonaRequest, TransportPid}, []).
 
 -spec is_connected(Pid) -> IsConnected when
     Pid :: pid(),
@@ -89,14 +90,15 @@ handle_event(Pid, StatefulIdOrUndefined, Event, Params) ->
 %% --------------------------------------------------------------------
 
 -spec init(InitArgs) -> {ok, State} when
-    InitArgs :: {ViewModule, ArizonaRequest, TransportPid},
+    InitArgs :: {ViewModule, MountArg, ArizonaRequest, TransportPid},
     ViewModule :: module(),
+    MountArg :: dynamic(),
     ArizonaRequest :: arizona_request:request(),
     TransportPid :: pid(),
     State :: state().
-init({ViewModule, ArizonaRequest, TransportPid}) ->
+init({ViewModule, MountArg, ArizonaRequest, TransportPid}) ->
     ok = pg:join(?MODULE, connected, self()),
-    View = arizona_view:call_mount_callback(ViewModule, ArizonaRequest),
+    View = arizona_view:call_mount_callback(ViewModule, MountArg, ArizonaRequest),
     {ok, #state{
         view = View,
         tracker = arizona_tracker:new(),

--- a/src/arizona_server.erl
+++ b/src/arizona_server.erl
@@ -6,8 +6,7 @@
 
 -export([start/1]).
 -export([stop/0]).
--export([get_route_metadata/1]).
--export([get_route_handler/1]).
+-export([get_handler_opts/1]).
 
 %% --------------------------------------------------------------------
 %% Ignore xref warnings
@@ -20,7 +19,6 @@
 %% Types exports
 %% --------------------------------------------------------------------
 
--export_type([route_metadata/0]).
 -export_type([route/0]).
 -export_type([server_config/0]).
 -export_type([scheme/0]).
@@ -31,20 +29,13 @@
 %% Types definitions
 %% --------------------------------------------------------------------
 
--record(route_metadata, {
-    type :: live | live_websocket | static,
-    handler :: module()
-}).
-
 -nominal route() ::
-    {live, Path :: binary(), LiveModule :: module()}
+    {live, Path :: binary(), ViewModule :: module(), MountArg :: dynamic()}
     | {live_websocket, Path :: binary()}
     | {static, Path :: binary(), {dir, Directory :: binary()}}
     | {static, Path :: binary(), {file, FileName :: binary()}}
     | {static, Path :: binary(), {priv_dir, App :: atom(), Directory :: binary()}}
     | {static, Path :: binary(), {priv_file, App :: atom(), FileName :: binary()}}.
-
--opaque route_metadata() :: #route_metadata{}.
 
 -nominal server_config() :: #{
     enabled => boolean(),
@@ -67,7 +58,7 @@
 start(Config) when is_map(Config) ->
     % Compile routes
     Dispatch = compile_routes(maps:get(routes, Config)),
-    ok = persistent_term:put(arizona_dispatch, Dispatch),
+    ok = persistent_term:put(get_dispatch(), Dispatch),
 
     % Get transport and protocol options
     DefaultPort = 1912,
@@ -76,34 +67,31 @@ start(Config) when is_map(Config) ->
 
     % Start listener based on scheme
     Scheme = maps:get(scheme, Config, http),
-    Ref = arizona_listener,
+    Ref = get_listener(),
     start_listener(Scheme, Ref, TransportOpts, ProtoOpts).
 
 -spec stop() -> ok.
 stop() ->
-    ok = cowboy:stop_listener(arizona_listener),
+    ok = cowboy:stop_listener(get_listener()),
     ok.
 
--spec get_route_metadata(Req) -> RouteMetadata when
+-spec get_handler_opts(Req) -> Opts when
     Req :: cowboy_req:req(),
-    RouteMetadata :: route_metadata().
-get_route_metadata(Req) ->
+    Opts :: dynamic().
+get_handler_opts(Req) ->
     {ok, _Req, Env} = cowboy_router:execute(
         Req,
-        #{dispatch => {persistent_term, arizona_dispatch}}
+        #{dispatch => {persistent_term, get_dispatch()}}
     ),
-    HandlerOpts = maps:get(handler_opts, Env),
-    validate_and_create_route_metadata(HandlerOpts).
-
--spec get_route_handler(RouteMetadata) -> Handler when
-    RouteMetadata :: route_metadata(),
-    Handler :: module().
-get_route_handler(#route_metadata{handler = Handler}) ->
-    Handler.
+    maps:get(handler_opts, Env).
 
 %% --------------------------------------------------------------------
 %% Internal functions
 %% --------------------------------------------------------------------
+
+get_dispatch() -> arizona_dispatch.
+
+get_listener() -> arizona_listener.
 
 compile_routes(Routes) ->
     % Convert Arizona routes to Cowboy routes
@@ -119,17 +107,12 @@ compile_routes(Routes) ->
 -spec route_to_cowboy(Route) -> CowboyRoute when
     Route :: route(),
     CowboyRoute :: {'_' | iodata(), module(), term()}.
-route_to_cowboy({live, Path, LiveModule}) when is_binary(Path), is_atom(LiveModule) ->
+route_to_cowboy({live, Path, ViewModule, MountArg}) when is_binary(Path), is_atom(ViewModule) ->
     % LiveView routes use arizona_handler
-    {Path, arizona_handler, #{
-        type => live,
-        handler => LiveModule
-    }};
+    {Path, arizona_handler, {ViewModule, MountArg}};
 route_to_cowboy({live_websocket, Path}) when is_binary(Path) ->
     % WebSocket endpoint for all LiveView connections
-    {Path, arizona_websocket, #{
-        type => live_websocket
-    }};
+    {Path, arizona_websocket, undefined};
 route_to_cowboy({static, Path, {dir, Directory}}) when is_binary(Path), is_binary(Directory) ->
     % Static file serving from filesystem directory
     DirPath = filename:join(Path, "[...]"),
@@ -193,7 +176,7 @@ get_proto_opts(Config) ->
     end,
 
     % Arizona always controls dispatch
-    ArizonaEnv = UserEnv#{dispatch => {persistent_term, arizona_dispatch}},
+    ArizonaEnv = UserEnv#{dispatch => {persistent_term, get_dispatch()}},
     UserProtoOpts#{env => ArizonaEnv}.
 
 %% Start listener based on scheme
@@ -201,13 +184,3 @@ start_listener(http, Ref, TransportOpts, ProtoOpts) ->
     cowboy:start_clear(Ref, TransportOpts, ProtoOpts);
 start_listener(https, Ref, TransportOpts, ProtoOpts) ->
     cowboy:start_tls(Ref, TransportOpts, ProtoOpts).
-
-%% Validate handler options and create route metadata
-validate_and_create_route_metadata(#{type := Type, handler := Handler}) when
-    (Type =:= live orelse Type =:= live_websocket orelse Type =:= static),
-    is_atom(Handler)
-->
-    #route_metadata{
-        type = Type,
-        handler = Handler
-    }.

--- a/src/arizona_view.erl
+++ b/src/arizona_view.erl
@@ -4,7 +4,7 @@
 %% API function exports
 %% --------------------------------------------------------------------
 
--export([call_mount_callback/2]).
+-export([call_mount_callback/3]).
 -export([call_render_callback/1]).
 -export([call_handle_event_callback/3]).
 -export([call_handle_info_callback/2]).
@@ -59,7 +59,8 @@
 %% Behavior callback definitions
 %% --------------------------------------------------------------------
 
--callback mount(ArizonaRequest) -> View when
+-callback mount(MountArg, ArizonaRequest) -> View when
+    MountArg :: dynamic(),
     ArizonaRequest :: arizona_request:request(),
     View :: view().
 
@@ -87,12 +88,13 @@
 %% API function definitions
 %% --------------------------------------------------------------------
 
--spec call_mount_callback(Module, ArizonaRequest) -> View when
+-spec call_mount_callback(Module, MountArg, ArizonaRequest) -> View when
     Module :: module(),
+    MountArg :: dynamic(),
     ArizonaRequest :: arizona_request:request(),
     View :: view().
-call_mount_callback(Module, ArizonaRequest) when is_atom(Module) ->
-    apply(Module, mount, [ArizonaRequest]).
+call_mount_callback(Module, MountArg, ArizonaRequest) when is_atom(Module) ->
+    apply(Module, mount, [MountArg, ArizonaRequest]).
 
 -spec call_render_callback(View) -> Template when
     View :: view(),

--- a/test/arizona_differ_SUITE.erl
+++ b/test/arizona_differ_SUITE.erl
@@ -322,10 +322,10 @@ mock_view_module(ViewModule, ViewId, StatefulModule, StatefulId, StatelessModule
                 -module('@view_module').
                 -behaviour(arizona_view).
                 -compile({parse_transform, arizona_parse_transform}).
-                -export([mount/1]).
+                -export([mount/2]).
                 -export([render/1]).
 
-                mount(Req) ->
+                mount(_Arg, Req) ->
                     {ReqBindings, _Req1} = arizona_request:get_bindings(Req),
                     arizona_view:new('@view_module', maps:merge(#{
                         id => ~"'@view_id",
@@ -462,6 +462,6 @@ mount_view(Module, Bindings) ->
     ArizonaRequest = arizona_request:new(?MODULE, undefined, #{
         bindings => Bindings
     }),
-    View = arizona_view:call_mount_callback(Module, ArizonaRequest),
+    View = arizona_view:call_mount_callback(Module, #{}, ArizonaRequest),
     {_Struct, HierarchicalView} = arizona_hierarchical:hierarchical_view(View),
     HierarchicalView.

--- a/test/arizona_handler_SUITE.erl
+++ b/test/arizona_handler_SUITE.erl
@@ -42,9 +42,9 @@ init_per_suite(Config) ->
     {ok, _Pid} = arizona_server:start(#{
         transport_opts => [{port, ServerPort}],
         routes => [
-            {live, ViewRouteUrl, MockViewModule},
-            {live, ErrorViewRouteUrl, MockErrorViewModule},
-            {live, ViewWithLayoutRouteUrl, MockViewWithLayoutModule}
+            {live, ViewRouteUrl, MockViewModule, #{}},
+            {live, ErrorViewRouteUrl, MockErrorViewModule, #{}},
+            {live, ViewWithLayoutRouteUrl, MockViewWithLayoutModule, #{}}
         ]
     }),
 
@@ -54,10 +54,10 @@ init_per_suite(Config) ->
     -compile({parse_transform, arizona_parse_transform}).
     -behaviour(arizona_view).
 
-    -export([mount/1]).
+    -export([mount/2]).
     -export([render/1]).
 
-    mount(_Req) ->
+    mount(_Arg, _Req) ->
         arizona_view:new('@module', #{
             id => ~"test_id",
             title => ~"Arizona"
@@ -83,10 +83,10 @@ init_per_suite(Config) ->
     -compile({parse_transform, arizona_parse_transform}).
     -behaviour(arizona_view).
 
-    -export([mount/1]).
+    -export([mount/2]).
     -export([render/1]).
 
-    mount(_Req) ->
+    mount(_Arg, _Req) ->
         error('@module').
 
     render(Bindings) ->
@@ -108,10 +108,10 @@ init_per_suite(Config) ->
     -compile({parse_transform, arizona_parse_transform}).
     -behaviour(arizona_view).
 
-    -export([mount/1]).
+    -export([mount/2]).
     -export([render/1]).
 
-    mount(_Req) ->
+    mount(_Arg, _Req) ->
         Layout = {'@layout_module', '@layout_render_fun', '@layout_slot_name', #{
             title => ~"Arizona With Layout"
         }},

--- a/test/arizona_live_SUITE.erl
+++ b/test/arizona_live_SUITE.erl
@@ -54,11 +54,11 @@ init_per_suite(Config) ->
     -compile({parse_transform, arizona_parse_transform}).
     -behaviour(arizona_view).
 
-    -export([mount/1]).
+    -export([mount/2]).
     -export([render/1]).
     -export([handle_event/3]).
 
-    mount(_Req) ->
+    mount(_Arg, _Req) ->
         arizona_view:new('@module', #{
             id => ~"live_test_id",
             counter => 0
@@ -118,10 +118,10 @@ init_per_suite(Config) ->
     -compile({parse_transform, arizona_parse_transform}).
     -behaviour(arizona_view).
 
-    -export([mount/1]).
+    -export([mount/2]).
     -export([render/1]).
 
-    mount(_Req) ->
+    mount(_Arg, _Req) ->
         arizona_view:new('@module', #{
             id => ~"view_with_stateful_id"
         }, none).
@@ -151,11 +151,11 @@ init_per_suite(Config) ->
     -compile({parse_transform, arizona_parse_transform}).
     -behaviour(arizona_view).
 
-    -export([mount/1]).
+    -export([mount/2]).
     -export([render/1]).
     -export([handle_info/2]).
 
-    mount(_Req) ->
+    mount(_Arg, _Req) ->
         arizona_view:new('@module', #{
             id => ~"handle_info_test_id",
             message_count => 0
@@ -239,7 +239,7 @@ mock_request() ->
 init_per_testcase(initial_render_test, Config) ->
     % Start basic live process but don't call initial_render (test will do it)
     {mock_view_module, MockViewModule} = proplists:lookup(mock_view_module, Config),
-    {ok, Pid} = arizona_live:start_link(MockViewModule, mock_request(), self()),
+    {ok, Pid} = arizona_live:start_link(MockViewModule, #{}, mock_request(), self()),
     [{live_pid, Pid} | Config];
 init_per_testcase(TestcaseName, Config) when
     TestcaseName =:= handle_stateful_event_reply_test;
@@ -250,7 +250,7 @@ init_per_testcase(TestcaseName, Config) when
         mock_view_with_stateful_module, Config
     ),
     MockRequest = mock_request(),
-    {ok, Pid} = arizona_live:start_link(MockViewWithStatefulModule, MockRequest, self()),
+    {ok, Pid} = arizona_live:start_link(MockViewWithStatefulModule, #{}, MockRequest, self()),
     % Initialize with render to create stateful components
     _HierarchicalStructure = arizona_live:initial_render(Pid),
     [{live_pid, Pid} | Config];
@@ -260,7 +260,7 @@ init_per_testcase(handle_info_test, Config) ->
         mock_view_with_handle_info_module, Config
     ),
     MockRequest = mock_request(),
-    {ok, Pid} = arizona_live:start_link(MockViewWithHandleInfoModule, MockRequest, self()),
+    {ok, Pid} = arizona_live:start_link(MockViewWithHandleInfoModule, #{}, MockRequest, self()),
     % Initialize render to set up tracker
     _HierarchicalStructure = arizona_live:initial_render(Pid),
     [{live_pid, Pid} | Config];
@@ -268,7 +268,7 @@ init_per_testcase(_TestcaseName, Config) ->
     % Default: start basic live process and initialize render
     {mock_view_module, MockViewModule} = proplists:lookup(mock_view_module, Config),
     MockRequest = mock_request(),
-    {ok, Pid} = arizona_live:start_link(MockViewModule, MockRequest, self()),
+    {ok, Pid} = arizona_live:start_link(MockViewModule, #{}, MockRequest, self()),
     % Initialize render to set up tracker
     _HierarchicalStructure = arizona_live:initial_render(Pid),
     [{live_pid, Pid} | Config].
@@ -304,7 +304,7 @@ initial_render_test(Config) when is_list(Config) ->
     ct:comment("Test initial_render API call and hierarchical structure"),
     {mock_view_module, MockViewModule} = proplists:lookup(mock_view_module, Config),
     MockRequest = mock_request(),
-    {ok, Pid} = arizona_live:start_link(MockViewModule, MockRequest, self()),
+    {ok, Pid} = arizona_live:start_link(MockViewModule, #{}, MockRequest, self()),
     HierarchicalStructure = arizona_live:initial_render(Pid),
 
     ?assertMatch(#{~"live_test_id" := #{static := _, dynamic := _}}, HierarchicalStructure),

--- a/test/arizona_websocket_SUITE.erl
+++ b/test/arizona_websocket_SUITE.erl
@@ -52,7 +52,7 @@ init_per_suite(Config) ->
     {ok, _Pid} = arizona_server:start(#{
         transport_opts => [{port, ServerPort}],
         routes => [
-            {live, ViewWithLayoutRouteUrl, MockViewWithLayoutModule},
+            {live, ViewWithLayoutRouteUrl, MockViewWithLayoutModule, #{}},
             {live_websocket, WebSocketRouteUrl}
         ]
     }),
@@ -63,10 +63,10 @@ init_per_suite(Config) ->
     -compile({parse_transform, arizona_parse_transform}).
     -behaviour(arizona_view).
 
-    -export([mount/1]).
+    -export([mount/2]).
     -export([render/1]).
 
-    mount(_Req) ->
+    mount(_Arg, _Req) ->
         Layout = {'@layout_module', '@layout_render_fun', '@layout_slot_name', #{
             title => ~"Arizona With Layout"
         }},

--- a/test/support/e2e/counter/arizona_counter_view.erl
+++ b/test/support/e2e/counter/arizona_counter_view.erl
@@ -1,11 +1,11 @@
 -module(arizona_counter_view).
 -behaviour(arizona_view).
 -compile({parse_transform, arizona_parse_transform}).
--export([mount/1]).
+-export([mount/2]).
 -export([render/1]).
 -export([handle_event/3]).
 
-mount(Req) ->
+mount(_Arg, Req) ->
     {Params, _Req} = arizona_request:get_params(Req),
     IsRealtimeEnabled = proplists:get_bool(~"realtime", Params),
     case IsRealtimeEnabled andalso arizona_live:is_connected(self()) of

--- a/test/support/e2e/datagrid/arizona_datagrid_view.erl
+++ b/test/support/e2e/datagrid/arizona_datagrid_view.erl
@@ -1,12 +1,12 @@
 -module(arizona_datagrid_view).
 -behaviour(arizona_view).
 -compile({parse_transform, arizona_parse_transform}).
--export([mount/1]).
+-export([mount/2]).
 -export([render/1]).
 -export([render_table/1]).
 -export([handle_event/3]).
 
-mount(Req) ->
+mount(_Arg, Req) ->
     Layout =
         {arizona_datagrid_layout, render, main_content, #{
             active_url => arizona_request:get_path(Req)

--- a/test/support/e2e/modal/arizona_modal_view.erl
+++ b/test/support/e2e/modal/arizona_modal_view.erl
@@ -1,12 +1,12 @@
 -module(arizona_modal_view).
 -behaviour(arizona_view).
 -compile({parse_transform, arizona_parse_transform}).
--export([mount/1]).
+-export([mount/2]).
 -export([render/1]).
 -export([render_modal/1]).
 -export([handle_event/3]).
 
-mount(Req) ->
+mount(_Arg, Req) ->
     Layout =
         {arizona_modal_layout, render, main_content, #{
             active_url => arizona_request:get_path(Req)

--- a/test/support/e2e/realtime/arizona_realtime_view.erl
+++ b/test/support/e2e/realtime/arizona_realtime_view.erl
@@ -1,11 +1,11 @@
 -module(arizona_realtime_view).
 -behaviour(arizona_view).
 -compile({parse_transform, arizona_parse_transform}).
--export([mount/1]).
+-export([mount/2]).
 -export([render/1]).
 -export([handle_event/3]).
 
-mount(Req) ->
+mount(_Arg, Req) ->
     case arizona_live:is_connected(self()) of
         true ->
             arizona_pubsub:join(~"time_update", self());

--- a/test/support/e2e/todo/arizona_todo_app_view.erl
+++ b/test/support/e2e/todo/arizona_todo_app_view.erl
@@ -1,7 +1,7 @@
 -module(arizona_todo_app_view).
 -behaviour(arizona_view).
 -compile({parse_transform, arizona_parse_transform}).
--export([mount/1]).
+-export([mount/2]).
 -export([render/1]).
 -export([handle_event/3]).
 -export([render_stats/1]).
@@ -9,7 +9,7 @@
 -export([render_clear_button/1]).
 -export([filter_todos/2]).
 
-mount(Req) ->
+mount(_Arg, Req) ->
     InitialTodos = [
         #{id => 1, text => ~"Learn Erlang", completed => false},
         #{id => 2, text => ~"Build web app", completed => true},


### PR DESCRIPTION
# Description

- Update route definition to accept mount arguments
- Modify `arizona_handler` to accept {ViewModule, MountArg} tuple
- Update `arizona_live` to pass mount arguments to view callbacks
- Refactor `arizona_view` mount callback to accept mount arguments
- Update `arizona_websocket` to handle new route format
- Update all test view modules to use new `mount/2` callback signature
- Clean up `arizona_server` route metadata handling

---

- [ ] I have performed a self-review of my changes
- [ ] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
