### PR TITLE
Use layout type and add proper guard in `arizona_view:new/3`

### DIFF
--- a/src/arizona_view.erl
+++ b/src/arizona_view.erl
@@ -197,13 +197,9 @@ Layout tuple specifies wrapper module, function, slot name, and bindings.
 -spec new(Module, Bindings, Layout) -> View when
     Module :: module(),
     Bindings :: arizona_binder:map(),
-    Layout :: {LayoutModule, LayoutRenderFun, LayoutSlotName, LayoutBindings} | none,
-    LayoutModule :: module(),
-    LayoutRenderFun :: atom(),
-    LayoutSlotName :: atom(),
-    LayoutBindings :: arizona_binder:map(),
+    Layout :: layout() | none,
     View :: view().
-new(Module, Bindings, Layout) when is_atom(Module) ->
+new(Module, Bindings, Layout) when is_atom(Module), (is_tuple(Layout) orelse Layout =:= none) ->
     State = arizona_stateful:new(Module, Bindings),
     #view{
         layout = Layout,


### PR DESCRIPTION
# Description

Improve type safety and clarity in view creation:
- Use `layout()` type instead of expanded tuple specification for better readability
- Add proper guard clause to validate Layout parameter (tuple or none atom)
- Maintains backward compatibility while improving type checking at runtime

---

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
