### PR TITLE
Add `mount_arg` type definition and improve type consistency

### DIFF
--- a/src/arizona_handler.erl
+++ b/src/arizona_handler.erl
@@ -55,7 +55,7 @@ stacktrace information for debugging.
     CowboyRequest :: cowboy_req:req(),
     State :: {ViewModule, MountArg},
     ViewModule :: module(),
-    MountArg :: dynamic(),
+    MountArg :: arizona_view:mount_arg(),
     CowboyRequest1 :: cowboy_req:req().
 init(CowboyRequest, State) ->
     try

--- a/src/arizona_live.erl
+++ b/src/arizona_live.erl
@@ -107,7 +107,7 @@ process group for tracking.
 """.
 -spec start_link(ViewModule, MountArg, ArizonaRequest, TransportPid) -> Return when
     ViewModule :: module(),
-    MountArg :: dynamic(),
+    MountArg :: arizona_view:mount_arg(),
     ArizonaRequest :: arizona_request:request(),
     TransportPid :: pid(),
     Return :: gen_server:start_ret().
@@ -174,7 +174,7 @@ handle_event(Pid, StatefulIdOrUndefined, Event, Params) ->
 -spec init(InitArgs) -> {ok, State} when
     InitArgs :: {ViewModule, MountArg, ArizonaRequest, TransportPid},
     ViewModule :: module(),
-    MountArg :: dynamic(),
+    MountArg :: arizona_view:mount_arg(),
     ArizonaRequest :: arizona_request:request(),
     TransportPid :: pid(),
     State :: state().

--- a/src/arizona_view.erl
+++ b/src/arizona_view.erl
@@ -71,6 +71,7 @@ render(Bindings) ->
 
 -export_type([view/0]).
 -export_type([layout/0]).
+-export_type([mount_arg/0]).
 
 %% --------------------------------------------------------------------
 %% Types definitions
@@ -88,6 +89,7 @@ render(Bindings) ->
 }).
 
 -opaque view() :: #view{}.
+
 -nominal layout() :: {
     Module :: module(),
     RenderFun :: atom(),
@@ -95,12 +97,14 @@ render(Bindings) ->
     Bindings :: arizona_binder:map()
 }.
 
+-nominal mount_arg() :: dynamic().
+
 %% --------------------------------------------------------------------
 %% Behavior callback definitions
 %% --------------------------------------------------------------------
 
 -callback mount(MountArg, ArizonaRequest) -> View when
-    MountArg :: dynamic(),
+    MountArg :: mount_arg(),
     ArizonaRequest :: arizona_request:request(),
     View :: view().
 
@@ -136,7 +140,7 @@ to initialize the view. Used during page navigation and initial load.
 """.
 -spec call_mount_callback(Module, MountArg, ArizonaRequest) -> View when
     Module :: module(),
-    MountArg :: dynamic(),
+    MountArg :: mount_arg(),
     ArizonaRequest :: arizona_request:request(),
     View :: view().
 call_mount_callback(Module, MountArg, ArizonaRequest) when is_atom(Module) ->

--- a/src/arizona_websocket.erl
+++ b/src/arizona_websocket.erl
@@ -91,7 +91,7 @@ and mount arguments, and prepares data for WebSocket initialization.
     Req :: cowboy_req:req(),
     State :: undefined,
     ViewModule :: module(),
-    MountArg :: dynamic(),
+    MountArg :: arizona_view:mount_arg(),
     ArizonaReq :: arizona_request:request().
 init(CowboyRequest, undefined) ->
     % Extract path from query parameter ?path=/users
@@ -116,7 +116,7 @@ performs initial render, and sends initial hierarchical structure to client.
 -spec websocket_init(InitData) -> Result when
     InitData :: {ViewModule, MountArg, ArizonaRequest},
     ViewModule :: module(),
-    MountArg :: dynamic(),
+    MountArg :: arizona_view:mount_arg(),
     ArizonaRequest :: arizona_request:request(),
     Result :: call_result().
 websocket_init({ViewModule, MountArg, ArizonaRequest}) ->


### PR DESCRIPTION
# Description

Introduce proper typing for view mount arguments across the framework:

- Add `mount_arg()` nominal type in arizona_view module
- Export `mount_arg/0` type for use in other modules
- Update `arizona_websocket`, `arizona_live`, and `arizona_handler` to use typed `mount_arg/0`
- Replace generic `dynamic()` type with specific `arizona_view:mount_arg()`
- Improve type safety and documentation clarity for view mounting process

This provides better type checking and clearer API documentation for view mount arguments.

---

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
