### PR TITLE
Implement `render_map` functionality with parse transform optimization

### DIFF
--- a/src/arizona_differ.erl
+++ b/src/arizona_differ.erl
@@ -197,7 +197,7 @@ diff patches for changed map elements. Each map entry is rendered as
 a {Key, Value} tuple to the callback function.
 
 Returns `t:diff/0` if fingerprints match and elements can be diffed,
-otherwise falls back to `t:arizona_hierarchical:map_struct/0`.
+otherwise falls back to `t:arizona_hierarchical:list_struct/0`.
 """.
 -spec diff_map(Template, Map, ParentId, ElementIndex, View) -> {Result, View1} when
     Template :: arizona_template:template(),

--- a/test/arizona_live_SUITE.erl
+++ b/test/arizona_live_SUITE.erl
@@ -195,8 +195,8 @@ init_per_suite(Config) ->
 end_per_suite(Config) ->
     {pg_live_pid, PgLivePid} = proplists:lookup(pg_live_pid, Config),
     {pg_pubsub_pid, PgPubSubPid} = proplists:lookup(pg_pubsub_pid, Config),
-    exit(PgLivePid, normal),
-    exit(PgPubSubPid, normal),
+    is_process_alive(PgLivePid) andalso exit(PgLivePid, normal),
+    is_process_alive(PgPubSubPid) andalso exit(PgPubSubPid, normal),
 
     % Clean up mock modules
     {mock_view_module, MockViewModule} = proplists:lookup(mock_view_module, Config),
@@ -277,7 +277,7 @@ init_per_testcase(_TestcaseName, Config) ->
 end_per_testcase(_TestcaseName, Config) ->
     case proplists:lookup(live_pid, Config) of
         {live_pid, Pid} when is_pid(Pid) ->
-            gen_server:stop(Pid);
+            is_process_alive(Pid) andalso gen_server:stop(Pid);
         _ ->
             ok
     end.

--- a/test/arizona_live_SUITE.erl
+++ b/test/arizona_live_SUITE.erl
@@ -227,16 +227,6 @@ end_per_suite(Config) ->
 
     ok.
 
-%% --------------------------------------------------------------------
-%% Helper functions
-%% --------------------------------------------------------------------
-
-%% Create a standard mock request for testing
-mock_request() ->
-    arizona_request:new(arizona_cowboy_request, #{}, #{
-        method => ~"GET", path => ~"/test"
-    }).
-
 init_per_testcase(initial_render_test, Config) ->
     % Start basic live process but don't call initial_render (test will do it)
     {mock_view_module, MockViewModule} = proplists:lookup(mock_view_module, Config),
@@ -450,3 +440,13 @@ terminate_callback_test(Config) when is_list(Config) ->
     %% Verify the process terminated cleanly
     %% The terminate callback should have been called without errors
     ?assert(not is_process_alive(Pid)).
+
+%% --------------------------------------------------------------------
+%% Helper functions
+%% --------------------------------------------------------------------
+
+%% Create a standard mock request for testing
+mock_request() ->
+    arizona_request:new(arizona_cowboy_request, #{}, #{
+        method => ~"GET", path => ~"/test"
+    }).

--- a/test/arizona_renderer_SUITE.erl
+++ b/test/arizona_renderer_SUITE.erl
@@ -18,6 +18,7 @@ groups() ->
             render_stateful_test,
             render_stateless_test,
             render_list_test,
+            render_map_test,
             render_dynamic_test
         ]}
     ].
@@ -132,6 +133,40 @@ render_list_test(Config) when is_list(Config) ->
         [~"<li>", ~"third", ~"</li>"]
     ],
     ?assertEqual(ExpectedHtml, Html).
+
+render_map_test(Config) when is_list(Config) ->
+    ct:comment("render_map should transform to optimized template structure"),
+    {mock_stateful_module, MockStatefulModule} = proplists:lookup(mock_stateful_module, Config),
+    MockView = create_mock_view(MockStatefulModule, #{id => ~"map"}),
+
+    % Test the parse transform by using render_map in template
+    TemplateAST = arizona_parse_transform:extract_callback_function_body(
+        ?MODULE, ?LINE, merl:quote(~""""
+        fun({Key, Value}) ->
+            arizona_template:from_string(~"""
+            <li>Key: {Key}, Value: {Value}</li>
+            """)
+        end
+        """"), []
+    ),
+    {value, Template, #{}} = erl_eval:expr(erl_syntax:revert(TemplateAST), #{}),
+
+    Map = #{~"first" => ~"1", ~"second" => ~"2"},
+    {Html, _UpdatedView} = arizona_renderer:render_map(Template, Map, ~"map", MockView),
+
+    % The result should contain the map entries (order may vary)
+    ?assertEqual(2, length(Html)),
+    % Check that both expected items are present
+    ExpectedItems = [
+        [~"<li>Key: ", ~"first", ~", Value: ", ~"1", ~"</li>"],
+        [~"<li>Key: ", ~"second", ~", Value: ", ~"2", ~"</li>"]
+    ],
+    lists:foreach(
+        fun(ExpectedItem) ->
+            ?assert(lists:member(ExpectedItem, Html))
+        end,
+        ExpectedItems
+    ).
 
 render_dynamic_test(Config) when is_list(Config) ->
     ct:comment("render_dynamic/2 should render template dynamic parts"),

--- a/test/arizona_renderer_SUITE.erl
+++ b/test/arizona_renderer_SUITE.erl
@@ -111,7 +111,7 @@ render_list_test(Config) when is_list(Config) ->
     MockView = create_mock_view(MockStatefulModule, #{id => ~"list"}),
 
     % Test the parse transform by using render_list in template
-    TemplateAST = arizona_parse_transform:extract_list_function_body(
+    TemplateAST = arizona_parse_transform:extract_callback_function_body(
         ?MODULE, ?LINE, merl:quote(~""""
         fun(Item) ->
             arizona_template:from_string(~"""

--- a/test/arizona_template_SUITE.erl
+++ b/test/arizona_template_SUITE.erl
@@ -42,6 +42,8 @@ groups() ->
             render_slot_template_callback_test,
             render_slot_term_test,
             render_list_template_callback_test,
+            render_map_template_callback_test,
+            render_map_error_test,
             from_string_with_module_function_test,
             render_list_error_test
         ]}
@@ -214,4 +216,20 @@ render_list_error_test(Config) when is_list(Config) ->
     ?assertError(
         {function_info_failed, _},
         arizona_template:render_list(BadCallback, List)
+    ).
+
+render_map_template_callback_test(Config) when is_list(Config) ->
+    ct:comment("render_map_template/2 should return arity 4 render callback"),
+    Template = arizona_template:from_string(~"<li>Key: {Key}, Value: {Value}</li>"),
+    Map = #{~"first" => ~"1", ~"second" => ~"2"},
+    Callback = arizona_template:render_map_template(Template, Map),
+    ?assert(is_function(Callback, 4)).
+
+render_map_error_test(Config) when is_list(Config) ->
+    ct:comment("render_map/2 should handle function info failure gracefully"),
+    BadCallback = fun(_Item) -> ok end,
+    Map = #{~"key1" => ~"value1", ~"key2" => ~"value2"},
+    ?assertError(
+        {function_info_failed, _},
+        arizona_template:render_map(BadCallback, Map)
     ).


### PR DESCRIPTION
# Description

Add comprehensive `render_map` support that follows the same patterns and optimizations as `render_list`, enabling efficient map rendering in templates using `{Key, Value}` tuple iteration.

## Key Features

- **Parse Transform**: Added `transform_render_map/5` with same optimizations as `render_list`
- **Generic Helpers**: Refactored shared code into `render_callback_collection/3` and `render_callback_dynamic/5` to eliminate duplication between list and map functions
- **Consistent API**: `render_map/2` and `render_map_template/2` follow identical patterns to their list counterparts with proper type safety
- **Map Comprehension**: Uses efficient `Key := Value <- Map` iteration pattern
- **Unified Types**: Both list and map rendering return `list_struct/0` since the hierarchical structure is identical

## Implementation Details

- **arizona_template**: Added `render_map/2`, `render_map_template/2`, and generic `render_callback_collection/3` helper that both list and map functions use
- **arizona_parse_transform**: Added `transform_render_map/5` and renamed `extract_list_function_body/4` to `extract_callback_function_body/4` for reuse
- **arizona_renderer**: Added `render_map/4` with proper documentation and unified `render_callback_item/6` helper for both collections
- **arizona_differ**: Added `diff_map/5` using shared `render_callback_dynamic/5` helper
- **arizona_hierarchical**: Added `hierarchical_map/5` using shared `render_callback_hierarchical/6` helper

## Breaking Changes

None - this is purely additive functionality.

---

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)