### PR TITLE
Rename static blog modules to follow arizona_ prefix pattern

### DIFF
--- a/scripts/start_test_server.sh
+++ b/scripts/start_test_server.sh
@@ -30,10 +30,10 @@ Routes = [
     {view, ~\"/todo\", arizona_todo_app_view, #{}},
     {view, ~\"/datagrid\", arizona_datagrid_view, #{}},
     {view, ~\"/modal\", arizona_modal_view, #{}},
-    {view, ~\"/\", blog_home_view, #{title => ~\"My Arizona Blog\"}},
-    {view, ~\"/about\", blog_about_view, #{title => ~\"About Me\"}},
+    {view, ~\"/\", arizona_blog_home_view, #{title => ~\"My Arizona Blog\"}},
+    {view, ~\"/about\", arizona_blog_about_view, #{title => ~\"About Me\"}},
     % In a real implementation, you might load post data from files or database
-    {view, ~\"/post/:post_id\", blog_post_view, #{
+    {view, ~\"/post/:post_id\", arizona_blog_post_view, #{
         ~\"hello-world\" => #{
             title => ~\"Hello World\",
             content => ~\"Welcome to my first blog post!\"

--- a/test/support/e2e/static/arizona_blog_about_view.erl
+++ b/test/support/e2e/static/arizona_blog_about_view.erl
@@ -1,4 +1,4 @@
--module(blog_about_view).
+-module(arizona_blog_about_view).
 -behaviour(arizona_view).
 -compile({parse_transform, arizona_parse_transform}).
 -export([mount/2, render/1]).
@@ -6,7 +6,7 @@
 mount(PageBindings, _Req) ->
     Bindings = #{id => ~"about"},
     Layout =
-        {blog_layout, render, main_content, #{
+        {arizona_blog_layout, render, main_content, #{
             page_title => maps:get(title, PageBindings),
             nav_active => ~"about"
         }},

--- a/test/support/e2e/static/arizona_blog_home_view.erl
+++ b/test/support/e2e/static/arizona_blog_home_view.erl
@@ -1,4 +1,4 @@
--module(blog_home_view).
+-module(arizona_blog_home_view).
 -behaviour(arizona_view).
 -compile({parse_transform, arizona_parse_transform}).
 -export([mount/2, render/1]).
@@ -18,7 +18,7 @@ mount(PageBindings, _Req) ->
         ]
     },
     Layout =
-        {blog_layout, render, main_content, #{
+        {arizona_blog_layout, render, main_content, #{
             page_title => maps:get(title, PageBindings),
             nav_active => ~"home"
         }},

--- a/test/support/e2e/static/arizona_blog_layout.erl
+++ b/test/support/e2e/static/arizona_blog_layout.erl
@@ -1,4 +1,4 @@
--module(blog_layout).
+-module(arizona_blog_layout).
 -compile({parse_transform, arizona_parse_transform}).
 -export([render/1]).
 

--- a/test/support/e2e/static/arizona_blog_post_view.erl
+++ b/test/support/e2e/static/arizona_blog_post_view.erl
@@ -1,4 +1,4 @@
--module(blog_post_view).
+-module(arizona_blog_post_view).
 -behaviour(arizona_view).
 -compile({parse_transform, arizona_parse_transform}).
 -export([mount/2, render/1]).
@@ -12,7 +12,7 @@ mount(Posts, Req) ->
                 id => ~"post"
             },
             Layout =
-                {blog_layout, render, main_content, #{
+                {arizona_blog_layout, render, main_content, #{
                     page_title => maps:get(title, Post),
                     nav_active => ~"blog"
                 }},

--- a/test/support/e2e/static/arizona_static_blog_example.erl
+++ b/test/support/e2e/static/arizona_static_blog_example.erl
@@ -1,4 +1,4 @@
--module(static_blog_example).
+-module(arizona_static_blog_example).
 -export([generate_site/0]).
 
 %% Generate the complete static site


### PR DESCRIPTION
# Description

Standardized all E2E test modules in test/support/e2e/static/ to use the arizona_ prefix:

- blog_about_view → arizona_blog_about_view
- blog_home_view → arizona_blog_home_view
- blog_layout → arizona_blog_layout
- blog_post_view → arizona_blog_post_view
- static_blog_example → arizona_static_blog_example

Updated module declarations, internal references, and route configurations to maintain consistency with other test modules throughout the codebase.

---

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
