### PR TITLE
Add Contributors section and Star History chart

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -2,3 +2,9 @@
 default: true
 MD013:
   line_length: 100
+MD033:
+  allowed_elements:
+    - a
+    - img
+    - picture
+    - source

--- a/README.md
+++ b/README.md
@@ -573,6 +573,35 @@ I also accept coffees :coffee:
 Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for development setup,
 testing guidelines, and contribution workflow.
 
+### Contributors
+
+<a href="https://github.com/arizona-framework/arizona/graphs/contributors">
+  <img
+    src="https://contrib.rocks/image?repo=arizona-framework/arizona&max=400&columns=20"
+    width="100%"
+  />
+</a>
+
+## Star History
+
+<a href="https://star-history.com/#arizona-framework/arizona">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://api.star-history.com/svg?repos=arizona-framework/arizona&type=Date&theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://api.star-history.com/svg?repos=arizona-framework/arizona&type=Date"
+    />
+    <img
+      src="https://api.star-history.com/svg?repos=arizona-framework/arizona&type=Date"
+      alt="Star History Chart"
+      width="100%"
+    />
+  </picture>
+</a>
+
 ## License
 
 Copyright (c) 2023-2025 [William Fank Thomé](https://github.com/williamthome)

--- a/README.md
+++ b/README.md
@@ -577,8 +577,9 @@ testing guidelines, and contribution workflow.
 
 <a href="https://github.com/arizona-framework/arizona/graphs/contributors">
   <img
-    src="https://contrib.rocks/image?repo=arizona-framework/arizona&max=400&columns=20"
-    width="100%"
+    src="https://contrib.rocks/image?repo=arizona-framework/arizona&max=100&columns=10"
+    width="15%"
+    alt="Contributors"
   />
 </a>
 


### PR DESCRIPTION
# Description

- Add Contributors section with contrib.rocks image
- Add Star History chart with dark/light theme support
- Enhance project visibility and community recognition

---

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
