### PR TITLE
Fix tracker context for stateful components in mixed layouts

### DIFF
--- a/src/arizona_differ.erl
+++ b/src/arizona_differ.erl
@@ -104,6 +104,7 @@ diff_stateful(Module, Bindings, ParentId, ElementIndex, View) ->
             {Diff, DiffState, DiffView} = track_diff_stateful(
                 Id, Template, StatefulState, PrepRenderView
             ),
+            _OldTracker = arizona_tracker_dict:set_current_stateful_id(ParentId),
             StatefulView = arizona_view:put_stateful_state(Id, DiffState, DiffView),
             case Diff of
                 [] ->
@@ -261,13 +262,12 @@ diff_template(Template, ParentId, ElementIndex, View) ->
 %% --------------------------------------------------------------------
 
 track_diff_stateful(Id, Template, StatefulState, View) ->
-    _OldTracker = arizona_tracker_dict:set_current_stateful_id(Id),
+    Tracker = arizona_tracker_dict:set_current_stateful_id(Id),
     ChangedBindings = arizona_stateful:get_changed_bindings(StatefulState),
     case arizona_binder:is_empty(ChangedBindings) of
         true ->
             {[], StatefulState, View};
         false ->
-            Tracker = arizona_tracker_dict:get_tracker(),
             StatefulDependencies = arizona_tracker:get_stateful_dependencies(Id, Tracker),
             % Clear dependencies only for changed variables
             ChangedVarNames = arizona_binder:keys(ChangedBindings),

--- a/src/arizona_hierarchical.erl
+++ b/src/arizona_hierarchical.erl
@@ -114,7 +114,9 @@ hierarchical_stateful(Module, Bindings, ParentId, ElementIndex, View) ->
         ParentId, ElementIndex, Fingerprint, PrepRenderView
     ),
 
-    track_hierarchical_stateful(Id, Template, FingerprintView).
+    Result = track_hierarchical_stateful(Id, Template, FingerprintView),
+    _OldTracker = arizona_tracker_dict:set_current_stateful_id(ParentId),
+    Result.
 
 -doc ~"""
 Generates hierarchical structure for a stateless component.

--- a/src/arizona_renderer.erl
+++ b/src/arizona_renderer.erl
@@ -114,8 +114,6 @@ state, sets current component ID, and renders the resulting template.
     View1 :: arizona_view:view().
 render_stateful(Module, Bindings, View) ->
     {Id, Template, PrepRenderView} = arizona_lifecycle:prepare_render(Module, Bindings, View),
-    _OldTracker = arizona_tracker_dict:clear_stateful_dependencies(Id),
-    _ClearTracker = arizona_tracker_dict:set_current_stateful_id(Id),
     render_template(Template, Id, PrepRenderView).
 
 -doc ~"""

--- a/src/arizona_tracker_dict.erl
+++ b/src/arizona_tracker_dict.erl
@@ -21,8 +21,6 @@ undefined
 #tracker{...}
 3> arizona_tracker_dict:record_variable_dependency(title).
 #tracker{...}
-4> Tracker = arizona_tracker_dict:get_tracker().
-#tracker{...}
 ```
 """.
 
@@ -30,7 +28,6 @@ undefined
 %% API function exports
 %% --------------------------------------------------------------------
 
--export([get_tracker/0]).
 -export([set_tracker/1]).
 -export([set_current_stateful_id/1]).
 -export([set_current_element_index/1]).
@@ -41,16 +38,6 @@ undefined
 %% --------------------------------------------------------------------
 %% API Functions
 %% --------------------------------------------------------------------
-
--doc ~"""
-Retrieves the tracker stored in the process dictionary.
-
-Returns the current tracker or `undefined` if none is stored.
-""".
--spec get_tracker() -> Tracker | undefined when
-    Tracker :: arizona_tracker:tracker().
-get_tracker() ->
-    get(?MODULE).
 
 -doc ~"""
 Stores a tracker in the process dictionary.
@@ -155,3 +142,12 @@ clear_changed_variable_dependencies(StatefulId, VarNames) ->
             ),
             set_tracker(UpdatedTracker)
     end.
+
+%% --------------------------------------------------------------------
+%% Internal helper functions
+%% --------------------------------------------------------------------
+
+-spec get_tracker() -> Tracker | undefined when
+    Tracker :: arizona_tracker:tracker().
+get_tracker() ->
+    get(?MODULE).


### PR DESCRIPTION
# Description

When stateful components are positioned before template variables in a layout, the tracker context would switch to the nested component's ID and never restore to the parent component ID. This caused subsequent variables to be tracked under the wrong component, resulting in incomplete diff dependencies.

Changes:
- `arizona_differ`: Restore parent tracker context after `track_diff_stateful`
- `arizona_hierarchical`: Restore parent tracker context after `track_hierarchical_stateful`
- `arizona_renderer` Remove tracker logic (only used in diff/hierarchical phases)
- `arizona_tracker_dict`: Move `get_tracker/0` to internal helper function

Fixes issue where template layout:
  `{render_stateful(...)}<div>{variable}</div>` would only track `{id => [1]}` instead of `{id => [1], variable => [N]}`

---

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
