### PR TITLE
Move render_callback_item helper function to better location

### DIFF
--- a/src/arizona_renderer.erl
+++ b/src/arizona_renderer.erl
@@ -255,6 +255,12 @@ render_static_dynamic(Static, DynamicSequence, Dynamic, ParentId, View) ->
     Html = zip_static_dynamic(Static, DynamicRender),
     {Html, FinalView}.
 
+%% Helper function for render_list and render_map
+render_callback_item(DynamicSequence, DynamicCallback, Static, CallbackArg, ParentId, View) ->
+    Dynamic = DynamicCallback(CallbackArg),
+    {DynamicHtml, _UpdatedView} = render_dynamic(DynamicSequence, Dynamic, ParentId, View),
+    zip_static_dynamic(Static, DynamicHtml).
+
 %% Zip static and dynamic parts for list item
 zip_static_dynamic([], []) ->
     [];
@@ -296,9 +302,3 @@ zip_static_dynamic_test_() ->
     ].
 
 -endif.
-
-%% Helper function for render_list and render_map
-render_callback_item(DynamicSequence, DynamicCallback, Static, CallbackArg, ParentId, View) ->
-    Dynamic = DynamicCallback(CallbackArg),
-    {DynamicHtml, _UpdatedView} = render_dynamic(DynamicSequence, Dynamic, ParentId, View),
-    zip_static_dynamic(Static, DynamicHtml).


### PR DESCRIPTION
# Description

Move the render_callback_item helper function from the end of the module to right after render_static_dynamic where it's more logically positioned.

This improves code organization by placing the helper function closer to the functions that use it (render_list and render_map), making the code more readable and maintainable.

No functional changes - this is purely a code organization improvement.

---

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
