### PR TITLE
Enhance reloader system with handler options support

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Create `config/sys.config`:
             enabled => true,  % Enable file watcher coordination
             rules => [
                 #{
-                    handler => my_erlang_handler,  % Your custom handler module
+                    handler => {my_erlang_handler, #{profile => dev}},  % {Module, Options}
                     watcher => #{
                         directories => ["src"],
                         patterns => [".*\\.erl$"],
@@ -176,10 +176,11 @@ application:set_env([{arizona, [
 % Example:
 -module(my_erlang_handler).
 -behaviour(arizona_reloader).
--export([reload/1]).
+-export([reload/2]).
 
-reload(Files) ->
-    io:format("Compiling ~p~n", [Files]),
+reload(Files, Options) ->
+    Profile = maps:get(profile, Options, default),
+    io:format("Compiling ~p with profile ~p~n", [Files, Profile]),
     % Your custom build logic here
     ok.
 ```
@@ -804,11 +805,11 @@ Example handler implementing the `arizona_reloader` behavior:
 ```erlang
 -module(my_custom_handler).
 -behaviour(arizona_reloader).
--export([reload/1]).
+-export([reload/2]).
 
-reload(Files) ->
+reload(Files, Options) ->
     % Your custom logic: compile, build, reload, etc.
-    io:format("Files changed: ~p~n", [Files]),
+    io:format("Files changed: ~p with options: ~p~n", [Files, Options]),
     % You implement what happens here
     ok.
 ```

--- a/scripts/start_test_server.sh
+++ b/scripts/start_test_server.sh
@@ -57,7 +57,7 @@ maybe
             enabled => true,
             rules => [
                 #{
-                    handler => arizona_erl_test_reloader,
+                    handler => {arizona_erl_test_reloader, #{}},
                     watcher => #{
                         directories => [\"src\", \"test/support/e2e\"],
                         patterns => [\".*\\\\.erl$\"],
@@ -65,7 +65,7 @@ maybe
                     }
                 },
                 #{
-                    handler => arizona_js_test_reloader,
+                    handler => {arizona_js_test_reloader, undefined},
                     watcher => #{
                         directories => [\"assets/js\"],
                         patterns => [\".*\\\\.js$\"],

--- a/test/support/e2e/shared/arizona_erl_test_reloader.erl
+++ b/test/support/e2e/shared/arizona_erl_test_reloader.erl
@@ -1,10 +1,11 @@
 -module(arizona_erl_test_reloader).
 -behaviour(arizona_reloader).
--export([reload/1]).
+-export([reload/2]).
 
-reload(Files) ->
+reload(Files, Options) ->
     try
-        Cmd = "rebar3 as test compile",
+        Profile = maps:get(profile, Options, test),
+        Cmd = io_lib:format("rebar3 as ~p compile", [Profile]),
         ok = io:format("~n$ ~s~n", [Cmd]),
         CompileResult = os:cmd(Cmd, #{exception_on_failure => true}),
         ok = io:format("~ts", [CompileResult]),

--- a/test/support/e2e/shared/arizona_js_test_reloader.erl
+++ b/test/support/e2e/shared/arizona_js_test_reloader.erl
@@ -1,6 +1,6 @@
 -module(arizona_js_test_reloader).
 -behaviour(arizona_reloader).
--export([reload/1]).
+-export([reload/2]).
 
-reload(_Files) ->
+reload(_Files, _Options) ->
     os:cmd("npm run build").


### PR DESCRIPTION
# Description

- Update `arizona_reloader` behavior to require `reload/2` callback with options
- Change rule format to `{Module, Options}` tuple for consistent configuration
- Add `handler_options()` type for flexible configuration
- Update `arizona_erl_test_reloader` to support configurable rebar3 profiles
- Update documentation and examples to reflect new API
- Maintain backward compatibility in `start_test_server.sh`

---

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
