### PR TITLE
Make reloader rules configuration optional

### DIFF
--- a/src/arizona_reloader.erl
+++ b/src/arizona_reloader.erl
@@ -97,7 +97,7 @@ monitors specific directories and delegates to the configured handler.
 
 -nominal config() :: #{
     enabled := boolean(),
-    rules := [rule()]
+    rules => [rule()]
 }.
 -nominal rule() :: #{
     handler := {module(), handler_options()},
@@ -152,7 +152,8 @@ Returns `ok` on success or `{error, Reason}` on failure.
     Config :: config(),
     Result :: ok | {error, Reason},
     Reason :: dynamic().
-start(#{enabled := true, rules := Rules}) ->
+start(#{enabled := true} = Config) ->
+    Rules = maps:get(rules, Config, []),
     start_reloader_instances(Rules);
 start(Config) when is_map(Config) ->
     ok.


### PR DESCRIPTION
# Description

Updates arizona_reloader to allow configuration without explicit rules field:
- Change rules type from required (:=) to optional (=>) in config spec
- Update start/1 implementation to use maps:get with empty list default
- Enables minimal reloader config: #{enabled => false} without rules field
- Maintains backward compatibility with existing configurations

---

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
