### PR TITLE
Configure npm package for publishing JavaScript client library

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,56 @@
+---
+name: Publish to npm
+
+"on":
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to publish (e.g., v0.1.0)"
+        required: true
+        type: string
+
+# Required for OIDC token generation
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version-file: .tool-versions
+          cache: "npm"
+          cache-dependency-path: "package-lock.json"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run full CI suite
+        run: npm run ci
+
+      - name: Build package
+        run: npm run build
+
+      - name: Verify package contents
+        run: npm pack --dry-run
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/assets/types/index.d.ts
+++ b/assets/types/index.d.ts
@@ -1,0 +1,59 @@
+// Main Arizona Framework TypeScript Definitions
+
+export interface ArizonaClientOptions {
+  logLevel?: 'silent' | 'error' | 'warning' | 'info' | 'debug';
+}
+
+export interface ConnectOptions {
+  wsPath?: string;
+  workerPath?: string;
+}
+
+export interface EventParams {
+  [key: string]: any;
+}
+
+export interface WorkerMessage {
+  type: 'connect' | 'send' | 'disconnect' | 'connected' | 'disconnected' | 'message' | 'error';
+  data?: any;
+}
+
+export interface HierarchicalComponent {
+  id: string;
+  static: [string, string];
+  dynamic?: any;
+  children?: HierarchicalComponent[];
+}
+
+export interface RenderPatch {
+  html: string;
+  patches: any[];
+}
+
+export default class ArizonaClient {
+  worker: Worker | null;
+  connected: boolean;
+  hierarchical: ArizonaHierarchical;
+  logLevel: number;
+
+  constructor(opts?: ArizonaClientOptions);
+  connect(opts?: ConnectOptions): void;
+  sendEvent(event: string, params?: EventParams): void;
+  disconnect(): void;
+  private handleWorkerMessage(message: WorkerMessage): void;
+  private log(level: string, message: string, ...args: any[]): void;
+}
+
+export class ArizonaHierarchical {
+  private components: Map<string, HierarchicalComponent>;
+
+  constructor();
+  registerComponent(component: HierarchicalComponent): void;
+  render(componentId: string, data?: any): string;
+  applyPatch(patch: RenderPatch): void;
+  private renderComponent(component: HierarchicalComponent, data?: any): string;
+}
+
+export function sanitizeForLog(value: any): string;
+
+export as namespace Arizona;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,55 @@
 {
-  "name": "Arizona JS",
+  "name": "@arizona-framework/client",
+  "version": "0.1.0",
+  "description": "JavaScript client library for Arizona Framework",
   "type": "module",
+  "main": "./priv/static/assets/js/arizona.min.js",
+  "module": "./priv/static/assets/js/arizona.min.js",
+  "types": "./assets/types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./assets/types/index.d.ts",
+      "import": "./priv/static/assets/js/arizona.min.js",
+      "require": "./priv/static/assets/js/arizona.min.js"
+    },
+    "./worker": {
+      "import": "./priv/static/assets/js/arizona-worker.min.js",
+      "require": "./priv/static/assets/js/arizona-worker.min.js"
+    }
+  },
+  "files": [
+    "README.md",
+    "LICENSE.md",
+    "package.json",
+    "priv/static/assets/js/*",
+    "assets/types/*"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/arizona-framework/arizona.git"
+  },
+  "homepage": "https://github.com/arizona-framework/arizona",
+  "bugs": {
+    "url": "https://github.com/arizona-framework/arizona/issues"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "browserslist": ["defaults", "not IE 11"],
+  "keywords": [
+    "arizona",
+    "framework",
+    "javascript",
+    "client",
+    "websocket",
+    "realtime"
+  ],
+  "author": "William Fank Thomé <willilamthome@hotmail.com>",
+  "license": "Apache-2.0",
+  "sideEffects": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "node ./esbuild.config.js",
     "format": "prettier --write \"./*.js\" \"./assets/**/*.js\" \"**/*.json\" \"**/*.yml\" --config prettier.config.js --ignore-path .gitignore --ignore-path .prettierignore",
@@ -22,7 +71,9 @@
     "test:e2e:report": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "ci": "npm run format:check && npm run lint:check && npm test",
-    "prepare": "husky"
+    "prepare": "husky",
+    "prepack": "npm run build",
+    "prepublishOnly": "npm run ci"
   },
   "devDependencies": {
     "@eslint/js": "9.35.0",


### PR DESCRIPTION
# Description

- Set package name to `@arizona-framework/client` with version 0.1.0 for development release
- Add modern ES module exports for main library and worker
- Configure publishing metadata (repository, homepage, bugs, author)
- Set engine requirements (Node.js >=18) and browser compatibility
- Add npm publishing scripts (prepack, prepublishOnly)
- Enable tree-shaking with sideEffects: false
- Configure public access for npm registry

---

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
