### PR TITLE
Remove CI step from npm publishing workflow

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -43,9 +43,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run full CI suite
-        run: npm run ci
-
       - name: Check if version needs publishing
         id: check-version
         run: |


### PR DESCRIPTION
# Description

- Remove full CI suite from publish workflow to avoid actionlint dependency
- Trust main branch is already verified through PR workflows
- Streamline publishing for faster, more reliable releases
- Focus workflow on core publish logic: version check → build → publish

This eliminates actionlint errors and reduces publish time significantly.

---

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
