### PR TITLE
Remove prepublishOnly CI script to avoid actionlint dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,8 +72,7 @@
     "test:e2e:ui": "playwright test --ui",
     "ci": "npm run format:check && npm run lint:check && npm test",
     "prepare": "husky",
-    "prepack": "npm run build",
-    "prepublishOnly": "npm run ci"
+    "prepack": "npm run build"
   },
   "devDependencies": {
     "@eslint/js": "9.35.0",


### PR DESCRIPTION
# Description

- Remove prepublishOnly script that runs full CI suite
- Keep prepack build script for essential package preparation
- Eliminates actionlint dependency issues during npm publish
- Streamlines publishing process further

Now both workflow and package.json avoid CI/actionlint completely.

---

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
