### PR TITLE
Fix repository URL format in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/arizona-framework/arizona.git"
+    "url": "git+https://github.com/arizona-framework/arizona.git"
   },
   "homepage": "https://github.com/arizona-framework/arizona",
   "bugs": {


### PR DESCRIPTION
# Description

- Add git+ prefix to repository URL to match npm standards
- Resolves npm warning: "repository.url" was normalized
- Follows npm package.json best practices for git URLs

This eliminates the npm publish warning about URL format.

---

- [ ] I have performed a self-review of my changes
- [ ] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
