### PR TITLE
Add lazy evaluation support for get functions across binding modules

### DIFF
--- a/src/arizona_stateful.erl
+++ b/src/arizona_stateful.erl
@@ -64,6 +64,7 @@ handle_event(~"increment", _Params, State) ->
 -export([get_module/1]).
 -export([get_binding/2]).
 -export([get_binding/3]).
+-export([get_binding_lazy/3]).
 -export([get_bindings/1]).
 -export([put_binding/3]).
 -export([merge_bindings/2]).
@@ -77,6 +78,7 @@ handle_event(~"increment", _Params, State) ->
 -ignore_xref([new/2]).
 -ignore_xref([get_binding/2]).
 -ignore_xref([get_binding/3]).
+-ignore_xref([get_binding_lazy/3]).
 -ignore_xref([put_binding/3]).
 
 %% --------------------------------------------------------------------
@@ -212,18 +214,33 @@ get_binding(Key, #state{} = State) ->
     arizona_binder:get(Key, State#state.bindings).
 
 -doc ~"""
-Gets a binding value by key with default function fallback.
+Gets a binding value by key with default fallback.
 
-Returns the value if key exists, otherwise calls the default function.
-Useful for optional component properties.
+Returns the value if key exists, otherwise returns the provided
+default value. This is a safe lookup that never raises an exception.
 """.
 -spec get_binding(Key, State, Default) -> Value when
     Key :: arizona_binder:key(),
     State :: state(),
-    Default :: arizona_binder:default_fun(),
+    Default :: arizona_binder:value(),
     Value :: arizona_binder:value().
 get_binding(Key, #state{} = State, Default) ->
     arizona_binder:get(Key, State#state.bindings, Default).
+
+-doc ~"""
+Gets a binding value by key with lazy default function fallback.
+
+Returns the value if key exists, otherwise calls the default function
+to generate a fallback value. Useful for expensive computations that
+should only be performed when needed.
+""".
+-spec get_binding_lazy(Key, State, DefaultFun) -> Value when
+    Key :: arizona_binder:key(),
+    State :: state(),
+    DefaultFun :: arizona_binder:default_fun(),
+    Value :: arizona_binder:value().
+get_binding_lazy(Key, #state{} = State, DefaultFun) ->
+    arizona_binder:get_lazy(Key, State#state.bindings, DefaultFun).
 
 -doc ~"""
 Returns all component bindings.

--- a/src/arizona_template.erl
+++ b/src/arizona_template.erl
@@ -55,6 +55,7 @@ be created at compile-time via parse transforms or at runtime.
 -export([get_fingerprint/1]).
 -export([get_binding/2]).
 -export([get_binding/3]).
+-export([get_binding_lazy/3]).
 -export([find_binding/2]).
 -export([render_stateful/2]).
 -export([render_stateless/3]).
@@ -75,6 +76,7 @@ be created at compile-time via parse transforms or at runtime.
 -ignore_xref([get_fingerprint/1]).
 -ignore_xref([get_binding/2]).
 -ignore_xref([get_binding/3]).
+-ignore_xref([get_binding_lazy/3]).
 -ignore_xref([find_binding/2]).
 -ignore_xref([render_stateful/2]).
 -ignore_xref([render_stateless/3]).
@@ -365,17 +367,34 @@ get_binding(Key, Bindings) ->
 Retrieves a variable binding value with default and dependency tracking.
 
 Template DSL function - only use inside `arizona_template:from_string/1` strings.
-Returns the bound value or calls default function if key not found.
+Returns the bound value or provided default value if key not found.
 """.
 -spec get_binding(Key, Bindings, Default) -> Value when
     Key :: arizona_binder:key(),
     Bindings :: arizona_binder:bindings(),
-    Default :: arizona_binder:default_fun(),
+    Default :: arizona_binder:value(),
     Value :: arizona_binder:value().
 get_binding(Key, Bindings, Default) ->
     % Record variable dependency for runtime tracking
     _OldTracker = arizona_tracker_dict:record_variable_dependency(Key),
     arizona_binder:get(Key, Bindings, Default).
+
+-doc ~"""
+Retrieves a variable binding value with lazy default function and dependency tracking.
+
+Template DSL function - only use inside `arizona_template:from_string/1` strings.
+Returns the bound value or calls default function if key not found. Useful for
+expensive computations that should only be performed when needed.
+""".
+-spec get_binding_lazy(Key, Bindings, DefaultFun) -> Value when
+    Key :: arizona_binder:key(),
+    Bindings :: arizona_binder:bindings(),
+    DefaultFun :: arizona_binder:default_fun(),
+    Value :: arizona_binder:value().
+get_binding_lazy(Key, Bindings, DefaultFun) ->
+    % Record variable dependency for runtime tracking
+    _OldTracker = arizona_tracker_dict:record_variable_dependency(Key),
+    arizona_binder:get_lazy(Key, Bindings, DefaultFun).
 
 -doc ~"""
 Safely finds a variable binding value with dependency tracking.

--- a/test/arizona_differ_SUITE.erl
+++ b/test/arizona_differ_SUITE.erl
@@ -463,24 +463,22 @@ mock_view_module(ViewModule, ViewId, StatefulModule, StatefulId, StatelessModule
                     arizona_template:from_string(~"""
                     <div {arizona_template:get_binding(id, Bindings)}>
                         {arizona_template:get_binding(title, Bindings)}
-                        {case arizona_template:get_binding(
-                            show_stateful, Bindings, fun() -> true end
-                        ) of
+                        {case arizona_template:get_binding(show_stateful, Bindings, true) of
                             true ->
                                 arizona_template:render_stateful(StatefulModule, #{
                                     id => arizona_template:get_binding(stateful_id, Bindings),
                                     title => arizona_template:get_binding(title, Bindings),
                                     show_stateless => arizona_template:get_binding(
-                                        show_stateless, Bindings, fun() -> true end
+                                        show_stateless, Bindings, true
                                     ),
                                     stateless_items => arizona_template:get_binding(
-                                        stateless_items, Bindings, fun() -> [] end
+                                        stateless_items, Bindings, []
                                     )
                                 });
                             false ->
                                 ~""
                         end})
-                        {arizona_template:get_binding(footer, Bindings, fun() -> ~"" end)}
+                        {arizona_template:get_binding(footer, Bindings, ~"")}
                     </div>
                     """).
                 """", [
@@ -517,13 +515,13 @@ mock_stateful_module(StatefulModule, StatelessModule, StatelessFun) ->
                     <div {arizona_template:get_binding(id, Bindings)}>
                         {arizona_template:get_binding(title, Bindings)}
                         {case arizona_template:get_binding(
-                            show_stateless, Bindings, fun() -> true end
+                            show_stateless, Bindings, true
                         ) of
                             true ->
                                 arizona_template:render_stateless(StatelessModule, StatelessFun, #{
                                     title => arizona_template:get_binding(title, Bindings),
                                     items => arizona_template:get_binding(
-                                        stateless_items, Bindings, fun() -> [] end
+                                        stateless_items, Bindings, []
                                     )
                                 });
                             false ->
@@ -557,7 +555,7 @@ mock_stateless_module(Module, RenderFun) ->
                 '@render_fun'(Bindings) ->
                     arizona_template:from_string(~""""
                     <h1>{arizona_template:get_binding(title, Bindings)}</h1>
-                    {case arizona_template:get_binding(items, Bindings, fun() -> [] end) of
+                    {case arizona_template:get_binding(items, Bindings, []) of
                         [] ->
                             ~"";
                         Items ->

--- a/test/arizona_stateful_SUITE.erl
+++ b/test/arizona_stateful_SUITE.erl
@@ -188,8 +188,8 @@ get_binding_test(Config) when is_list(Config) ->
 get_binding_with_default_test(Config) when is_list(Config) ->
     ct:comment("get_binding/3 should use default when key not found"),
     State = arizona_stateful:new(test_module, #{name => ~"Bob"}),
-    Name = arizona_stateful:get_binding(name, State, fun() -> ~"Default" end),
-    Role = arizona_stateful:get_binding(role, State, fun() -> ~"guest" end),
+    Name = arizona_stateful:get_binding(name, State, ~"Default"),
+    Role = arizona_stateful:get_binding(role, State, ~"guest"),
     ?assertEqual(~"Bob", Name),
     ?assertEqual(~"guest", Role).
 

--- a/test/arizona_template_SUITE.erl
+++ b/test/arizona_template_SUITE.erl
@@ -135,9 +135,9 @@ get_binding_with_default_test(Config) when is_list(Config) ->
     ct:comment("get_binding/3 should use default when key not found"),
     BindingsMap = #{name => ~"John"},
     Bindings = arizona_binder:new(BindingsMap),
-    ?assertEqual(~"John", arizona_template:get_binding(name, Bindings, fun() -> ~"Default" end)),
+    ?assertEqual(~"John", arizona_template:get_binding(name, Bindings, ~"Default")),
     ?assertEqual(
-        ~"Default", arizona_template:get_binding(missing, Bindings, fun() -> ~"Default" end)
+        ~"Default", arizona_template:get_binding(missing, Bindings, ~"Default")
     ).
 
 find_binding_test(Config) when is_list(Config) ->


### PR DESCRIPTION
# Description

* arizona_binder: Add get_lazy/3 for function-based lazy defaults
  - Update get/3 to take simple default values instead of functions
  - Add proper -doc attributes for both functions
  - Update documentation examples to show both usage patterns

* arizona_stateful: Add get_binding_lazy/3 for lazy component bindings
  - Update get_binding/3 to use simple default values
  - Maintain backward compatibility for existing 2-arity calls
  - Add comprehensive documentation for both functions

* arizona_template: Add get_binding_lazy/3 for lazy template defaults
  - Update get_binding/3 to use simple values with dependency tracking
  - Preserve template DSL functionality with new lazy option
  - Document both approaches for template rendering

* Tests: Update all test suites for new function signatures
  - arizona_binder_SUITE: Add tests for both get/3 and get_lazy/3
  - arizona_stateful_SUITE: Update to use simple defaults
  - arizona_template_SUITE: Update to use simple defaults
  - arizona_differ_SUITE: Update generated code to use simple defaults
  - Add test coverage for lazy evaluation behavior

This provides a cleaner API where simple defaults use direct values while expensive computations can use lazy function evaluation.

---

- [ ] I have performed a self-review of my changes
- [ ] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
