### PR TITLE
Update minimum OTP version requirement to 28

### DIFF
--- a/README.md
+++ b/README.md
@@ -960,7 +960,7 @@ Arizona provides additional tools to enhance the development experience:
 
 ## Requirements
 
-- Erlang/OTP 27+
+- Erlang/OTP 28+
 
 ## Sponsors
 

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{minimum_otp_vsn, "27"}.
+{minimum_otp_vsn, "28"}.
 
 {erl_first_files, [
     "src/arizona_token.erl",


### PR DESCRIPTION
# Description

Arizona Framework now requires Erlang/OTP 28+ to leverage latest language features and improvements. Update both rebar.config and README.md to reflect this requirement.

---

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
