### PR TITLE
Rename `arizona_template:from_string` to `from_html` across codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ mount(_Arg, _Request) ->
     ).
 
 render(Bindings) ->
-    arizona_template:from_string(~"""
+    arizona_template:from_html(~"""
     <div id="{arizona_template:get_binding(id, Bindings)}">
         <h1>{arizona_template:get_binding(greeting, Bindings)}</h1>
         <p>Clicked: {arizona_template:get_binding(count, Bindings)} times</p>
@@ -247,7 +247,7 @@ Arizona templates combine HTML with Erlang expressions using a simple and intuit
 ### Basic Expressions
 
 ```erlang
-arizona_template:from_string(~"""
+arizona_template:from_html(~"""
 <div>
     <h1>{arizona_template:get_binding(title, Bindings)}</h1>
     <p>User: {arizona_template:get_binding(username, Bindings)}</p>
@@ -260,7 +260,7 @@ arizona_template:from_string(~"""
 Render interactive components that maintain their own state between updates:
 
 ```erlang
-arizona_template:from_string(~"""
+arizona_template:from_html(~"""
 <div>
     {arizona_template:render_stateful(counter_component, #{
         id => ~"my_counter",
@@ -275,7 +275,7 @@ arizona_template:from_string(~"""
 Render pure functions that return templates based solely on their input:
 
 ```erlang
-arizona_template:from_string(~"""
+arizona_template:from_html(~"""
 <div>
     {arizona_template:render_stateless(my_module, render_header, #{
         title => ~"Welcome",
@@ -290,10 +290,10 @@ arizona_template:from_string(~"""
 Iterate over lists with automatic compile-time optimization via parse transforms:
 
 ```erlang
-arizona_template:from_string(~"""
+arizona_template:from_html(~"""
 <ul>
     {arizona_template:render_list(fun(Item) ->
-        arizona_template:from_string(~"""
+        arizona_template:from_html(~"""
         <li>{arizona_template:get_binding(name, Item)}</li>
         """)
     end, arizona_template:get_binding(items, Bindings))}
@@ -306,10 +306,10 @@ arizona_template:from_string(~"""
 Iterate over key-value pairs with optimized rendering performance:
 
 ```erlang
-arizona_template:from_string(~"""
+arizona_template:from_html(~"""
 <div>
     {arizona_template:render_map(fun({Key, Value}) ->
-        arizona_template:from_string(~"""
+        arizona_template:from_html(~"""
         <p>{Key}: {Value}</p>
         """)
     end, #{~"name" => ~"Arizona", ~"type" => ~"Framework"})}
@@ -322,7 +322,7 @@ arizona_template:from_string(~"""
 Insert dynamic content into predefined slots for flexible component composition:
 
 ```erlang
-arizona_template:from_string(~"""
+arizona_template:from_html(~"""
 <div class="modal">
     <h1>{arizona_template:render_slot(arizona_template:get_binding(header, Bindings))}</h1>
     <div class="content">
@@ -337,7 +337,7 @@ arizona_template:from_string(~"""
 Use template comments and escape braces for literal output in CSS or JavaScript:
 
 ```erlang
-arizona_template:from_string(~"""
+arizona_template:from_html(~"""
 <div>
     {% This is a comment and is not rendered }
     <h1>{arizona_template:get_binding(title, Bindings)}</h1>
@@ -452,7 +452,7 @@ Example layout with JavaScript client setup:
 -export([render/1]).
 
 render(Bindings) ->
-    arizona_template:from_string(~"""
+    arizona_template:from_html(~"""
     <!DOCTYPE html>
     <html>
     <head>

--- a/src/arizona_error_template.erl
+++ b/src/arizona_error_template.erl
@@ -37,7 +37,7 @@ mount({Error, Reason, StackTrace}, Req) ->
     Bindings :: arizona_binder:bindings(),
     Template :: arizona_template:template().
 render(Bindings) ->
-    arizona_template:from_string(~""""
+    arizona_template:from_html(~""""
     <!DOCTYPE html>
     <html lang="en">
     <head>
@@ -339,7 +339,7 @@ render(Bindings) ->
                 <div class="main-section">
                     {arizona_template:render_list(
                         fun({Title, Content, Open}) ->
-                        arizona_template:from_string(~"""
+                        arizona_template:from_html(~"""
                         <details class="section" {
                             case Open of
                                 true -> ~"open";

--- a/src/arizona_renderer.erl
+++ b/src/arizona_renderer.erl
@@ -24,7 +24,7 @@ the full component lifecycle and template evaluation.
 ## Example
 
 ```erlang
-1> Template = arizona_template:from_string(~\"<h1>{Title}</h1>\").
+1> Template = arizona_template:from_html(~\"<h1>{Title}</h1>\").
 2> {Html, View1} = arizona_renderer:render_template(Template, parent_id, View).
 {[~\"<h1>\", ~\"Hello\", ~\"</h1>\"], UpdatedView}
 ```

--- a/src/arizona_stateful.erl
+++ b/src/arizona_stateful.erl
@@ -32,7 +32,7 @@ mount(InitialBindings) ->
     arizona_stateful:new(?MODULE, InitialBindings#{count => 0}).
 
 render(Bindings) ->
-    arizona_template:from_string(~"""
+    arizona_template:from_html(~"""
     <div id="{arizona_template:get_binding(id, Bindings)}">
         <p>Count: {arizona_template:get_binding(count, Bindings)}</p>
         <button

--- a/src/arizona_stateless.erl
+++ b/src/arizona_stateless.erl
@@ -19,7 +19,7 @@ Stateless components are implemented as functions that:
 ```erlang
 %% In my_component.erl:
 render(Bindings) ->
-    arizona_template:from_string(~"""
+    arizona_template:from_html(~"""
     <div>
         Hello {arizona_template:get_binding(name, Bindings)},
         you are {arizona_template:get_binding(age, Bindings)} years old

--- a/src/arizona_template.erl
+++ b/src/arizona_template.erl
@@ -17,7 +17,7 @@ be created at compile-time via parse transforms or at runtime.
 ## API vs Template DSL Functions
 
 **Regular API functions:**
-- Template creation: `new/5`, `from_string/1`, `from_string/4`, `from_markdown/1`, `from_markdown/4`
+- Template creation: `new/5`, `from_html/1`, `from_html/4`, `from_markdown/1`, `from_markdown/4`
 - Type checking: `is_template/1`
 - Accessors: `get_static/1`, `get_dynamic/1`, etc.
 - Collection rendering: `render_list_template/2`, `render_map_template/2`
@@ -30,7 +30,7 @@ be created at compile-time via parse transforms or at runtime.
 ## Example
 
 ```erlang
-1> Template = arizona_template:from_string(~"""
+1> Template = arizona_template:from_html(~"""
 .. <h1>{arizona_template:get_binding(title, Bindings)}</h1>
 .. """).
 #template{...}
@@ -51,9 +51,9 @@ be created at compile-time via parse transforms or at runtime.
 %% --------------------------------------------------------------------
 
 -export([new/5]).
--export([from_string/1]).
+-export([from_html/1]).
 -export([is_template/1]).
--export([from_string/4]).
+-export([from_html/4]).
 -export([from_markdown/1]).
 -export([from_markdown/4]).
 -export([get_static/1]).
@@ -78,8 +78,8 @@ be created at compile-time via parse transforms or at runtime.
 %% --------------------------------------------------------------------
 
 -ignore_xref([new/5]).
--ignore_xref([from_string/1]).
--ignore_xref([from_string/4]).
+-ignore_xref([from_html/1]).
+-ignore_xref([from_html/4]).
 -ignore_xref([from_markdown/1]).
 -ignore_xref([from_markdown/4]).
 -ignore_xref([get_dynamic_anno/1]).
@@ -167,12 +167,12 @@ new(Static, Dynamic, DynamicSequence, DynamicAnno, Fingerprint) ->
         fingerprint = Fingerprint
     }.
 
--doc #{equiv => from_string(erlang, 0, String, #{})}.
--spec from_string(String) -> Template when
+-doc #{equiv => from_html(erlang, 0, String, #{})}.
+-spec from_html(String) -> Template when
     String :: binary(),
     Template :: template().
-from_string(String) ->
-    from_string(erlang, 0, String, #{}).
+from_html(String) ->
+    from_html(erlang, 0, String, #{}).
 
 -doc ~"""""
 Compiles a template string into a template record at runtime.
@@ -193,12 +193,12 @@ Arizona templates embed Erlang expressions within HTML using curly braces:
 
 ## Expression Examples
 
-> The following examples use `from_string/1` for simplicity.
+> The following examples use `from_html/1` for simplicity.
 
 ### Simple variable access
 
 ```erlang
-arizona_template:from_string(~"""
+arizona_template:from_html(~"""
 <h1>{arizona_template:get_binding(title, Bindings)}</h1>
 """).
 ```
@@ -206,7 +206,7 @@ arizona_template:from_string(~"""
 ### Complex expressions with case statements
 
 ```erlang
-arizona_template:from_string(~"""
+arizona_template:from_html(~"""
 <div class="todo {case maps:get(completed, Todo) of
       true -> ~"completed";
       false -> ~""
@@ -217,12 +217,12 @@ arizona_template:from_string(~"""
 ### Variable assignment within expressions
 
 ```erlang
-arizona_template:from_string(~""""
+arizona_template:from_html(~""""
 {
     Todos = arizona_template:get_binding(todos, Bindings),
     Filter = arizona_template:get_binding(filter, Bindings),
     arizona_template:render_list(fun(Todo) ->
-    arizona_template:from_string(~"""
+    arizona_template:from_html(~"""
     <li>{maps:get(text, Todo)}</li>
     """)
     end, filter_todos(Todos, Filter))
@@ -233,7 +233,7 @@ arizona_template:from_string(~""""
 ### Conditional rendering
 
 ```erlang
-arizona_template:from_string(~"""
+arizona_template:from_html(~"""
 {
     case length(TodoList) > 0 of
         true -> arizona_template:render_stateless(Module, render_footer, #{});
@@ -246,7 +246,7 @@ arizona_template:from_string(~"""
 ### Escaped braces in CSS
 
 ```erlang
-arizona_template:from_string(~"""
+arizona_template:from_html(~"""
 <style>
     .nav-container \{
         display: flex;
@@ -270,13 +270,13 @@ Within `{}` expressions, you have access to:
 2. **Parsing** - Tokens are parsed into an Abstract Syntax Tree (AST)
 3. **Evaluation** - AST is evaluated to create the final template record
 """"".
--spec from_string(Module, Line, String, Bindings) -> Template when
+-spec from_html(Module, Line, String, Bindings) -> Template when
     Module :: module(),
     Line :: arizona_token:line(),
     String :: string() | binary(),
     Bindings :: arizona_binder:map(),
     Template :: template().
-from_string(Module, Line, String, Bindings) when is_atom(Module), is_map(Bindings) ->
+from_html(Module, Line, String, Bindings) when is_atom(Module), is_map(Bindings) ->
     % Scan template content into tokens
     Tokens = arizona_scanner:scan_string(Line, String),
 
@@ -294,7 +294,7 @@ from_string(Module, Line, String, Bindings) when is_atom(Module), is_map(Binding
         value
     ).
 
--doc #{equiv => from_string(erlang, 0, String, #{})}.
+-doc #{equiv => from_html(erlang, 0, String, #{})}.
 -spec from_markdown(Markdown) -> Template when
     Markdown :: arizona_markdown:markdown(),
     Template :: template().
@@ -334,7 +334,7 @@ You have **{length(arizona_template:get_binding(todos, Bindings))}** tasks.
 
 ## Tasks
 {arizona_template:render_list(fun(Todo) ->
-    arizona_template:from_string(~"""
+    arizona_template:from_html(~"""
     - {maps:get(text, Todo)}
     """)
 end, arizona_template:get_binding(todos, Bindings))}
@@ -348,7 +348,7 @@ arizona_template:from_markdown(~""""
 | Name | Score | Status |
 |------|-------|--------|
 {arizona_template:render_list(fun(Player) ->
-    arizona_template:from_string(~"""
+    arizona_template:from_html(~"""
     | {maps:get(name, Player)} | {maps:get(score, Player)} | {maps:get(status, Player)} |
     """)
 end, arizona_template:get_binding(players, Bindings))}
@@ -405,7 +405,7 @@ from_markdown(Module, Line, Markdown, Bindings) when is_atom(Module), is_map(Bin
     HTML = arizona_markdown_processor:process_markdown_template(Markdown, Line),
 
     % Process final HTML as template
-    from_string(Module, Line, HTML, Bindings).
+    from_html(Module, Line, HTML, Bindings).
 
 -doc ~"""
 Checks if the given value is a template record.
@@ -474,7 +474,7 @@ get_fingerprint(#template{fingerprint = Fingerprint}) ->
 -doc ~"""
 Retrieves a variable binding value with dependency tracking.
 
-Template DSL function - only use inside `arizona_template:from_string/1` strings.
+Template DSL function - only use inside `arizona_template:from_html/1` strings.
 Records the variable dependency for differential updates and returns the bound value.
 """.
 -spec get_binding(Key, Bindings) -> Value when
@@ -489,7 +489,7 @@ get_binding(Key, Bindings) ->
 -doc ~"""
 Retrieves a variable binding value with default and dependency tracking.
 
-Template DSL function - only use inside `arizona_template:from_string/1` strings.
+Template DSL function - only use inside `arizona_template:from_html/1` strings.
 Returns the bound value or provided default value if key not found.
 """.
 -spec get_binding(Key, Bindings, Default) -> Value when
@@ -505,7 +505,7 @@ get_binding(Key, Bindings, Default) ->
 -doc ~"""
 Retrieves a variable binding value with lazy default function and dependency tracking.
 
-Template DSL function - only use inside `arizona_template:from_string/1` strings.
+Template DSL function - only use inside `arizona_template:from_html/1` strings.
 Returns the bound value or calls default function if key not found. Useful for
 expensive computations that should only be performed when needed.
 """.
@@ -522,7 +522,7 @@ get_binding_lazy(Key, Bindings, DefaultFun) ->
 -doc ~"""
 Safely finds a variable binding value with dependency tracking.
 
-Template DSL function - only use inside `arizona_template:from_string/1` strings.
+Template DSL function - only use inside `arizona_template:from_html/1` strings.
 Returns `{ok, Value}` if found, `error` if not found.
 """.
 -spec find_binding(Key, Bindings) -> {ok, Value} | error when
@@ -537,7 +537,7 @@ find_binding(Key, Bindings) ->
 -doc ~"""
 Creates a stateful component rendering callback.
 
-Template DSL function - only use inside `arizona_template:from_string/1` strings.
+Template DSL function - only use inside `arizona_template:from_html/1` strings.
 Returns a callback that handles all three rendering modes for the component.
 """.
 -spec render_stateful(Module, Bindings) -> Callback when
@@ -559,7 +559,7 @@ render_stateful(Module, Bindings) ->
 -doc ~"""
 Creates a stateless component rendering callback.
 
-Template DSL function - only use inside `arizona_template:from_string/1` strings.
+Template DSL function - only use inside `arizona_template:from_html/1` strings.
 Returns a callback that handles all three rendering modes for the component.
 """.
 -spec render_stateless(Module, Function, Bindings) -> Callback when
@@ -582,7 +582,7 @@ render_stateless(Module, Fun, Bindings) ->
 -doc ~"""
 Renders a slot with view, template, or HTML content.
 
-Template DSL function - only use inside `arizona_template:from_string/1` strings.
+Template DSL function - only use inside `arizona_template:from_html/1` strings.
 Handles different slot types: view (current view), template records, or HTML values.
 """.
 -spec render_slot(Slot) -> Callback when
@@ -612,7 +612,7 @@ render_slot(Term) ->
 -doc ~"""
 Creates a list rendering callback from an item template function.
 
-Template DSL function - only use inside `arizona_template:from_string/1` strings.
+Template DSL function - only use inside `arizona_template:from_html/1` strings.
 At compile time, arizona_parse_transform converts this into an optimized
 `render_list_template/2` call for better performance.
 

--- a/src/arizona_view.erl
+++ b/src/arizona_view.erl
@@ -48,7 +48,7 @@ mount(_MountArg, _Request) ->
     arizona_view:new(?MODULE, #{user => ~"Anonymous"}, none).
 
 render(Bindings) ->
-    arizona_template:from_string(~"""
+    arizona_template:from_html(~"""
     <h1>Welcome {arizona_template:get_binding(user, Bindings)}!</h1>
     """).
 

--- a/test/arizona_differ_SUITE.erl
+++ b/test/arizona_differ_SUITE.erl
@@ -307,7 +307,7 @@ diff_map_fingerprint_match(Config) when is_list(Config) ->
     TemplateAST = arizona_parse_transform:extract_callback_function_body(
         ?MODULE, ?LINE, merl:quote(~""""
         fun({Key, Value}) ->
-            arizona_template:from_string(~"""
+            arizona_template:from_html(~"""
             <li>Key: {Key}, Value: {Value}</li>
             """)
         end
@@ -354,7 +354,7 @@ diff_map_fingerprint_mismatch(Config) when is_list(Config) ->
     TemplateAST = arizona_parse_transform:extract_callback_function_body(
         ?MODULE, ?LINE, merl:quote(~""""
         fun({Key, Value}) ->
-            arizona_template:from_string(~"""
+            arizona_template:from_html(~"""
             <li>Key: {Key}, Value: {Value}</li>
             """)
         end
@@ -460,7 +460,7 @@ mock_view_module(ViewModule, ViewId, StatefulModule, StatefulId, StatelessModule
 
                 render(Bindings) ->
                     StatefulModule = '@stateful_module',
-                    arizona_template:from_string(~"""
+                    arizona_template:from_html(~"""
                     <div {arizona_template:get_binding(id, Bindings)}>
                         {arizona_template:get_binding(title, Bindings)}
                         {case arizona_template:get_binding(show_stateful, Bindings, true) of
@@ -511,7 +511,7 @@ mock_stateful_module(StatefulModule, StatelessModule, StatelessFun) ->
                 render(Bindings) ->
                     StatelessModule = '@stateless_module',
                     StatelessFun = '@stateless_fun',
-                    arizona_template:from_string(~"""
+                    arizona_template:from_html(~"""
                     <div {arizona_template:get_binding(id, Bindings)}>
                         {arizona_template:get_binding(title, Bindings)}
                         {case arizona_template:get_binding(
@@ -553,14 +553,14 @@ mock_stateless_module(Module, RenderFun) ->
                 -export(['@render_fun'/1]).
 
                 '@render_fun'(Bindings) ->
-                    arizona_template:from_string(~""""
+                    arizona_template:from_html(~""""
                     <h1>{arizona_template:get_binding(title, Bindings)}</h1>
                     {case arizona_template:get_binding(items, Bindings, []) of
                         [] ->
                             ~"";
                         Items ->
                             arizona_template:render_list(fun(Item) ->
-                                arizona_template:from_string(~"""
+                                arizona_template:from_html(~"""
                                 <li>{Item}</li>
                                 """)
                             end, Items)

--- a/test/arizona_live_SUITE.erl
+++ b/test/arizona_live_SUITE.erl
@@ -66,7 +66,7 @@ init_per_suite(Config) ->
         }, none).
 
     render(Bindings) ->
-        arizona_template:from_string(~"""
+        arizona_template:from_html(~"""
         <div>
             <p>Counter: {arizona_template:get_binding(counter, Bindings)}</p>
             <button>Increment</button>
@@ -101,7 +101,7 @@ init_per_suite(Config) ->
         }).
 
     render(Bindings) ->
-        arizona_template:from_string(~"""
+        arizona_template:from_html(~"""
         <span>Value: {arizona_template:get_binding(value, Bindings)}</span>
         """).
 
@@ -129,7 +129,7 @@ init_per_suite(Config) ->
 
     render(_Bindings) ->
         StatefulModule = '@stateful_module',
-        arizona_template:from_string(~"""
+        arizona_template:from_html(~"""
         <div>
             {arizona_template:render_stateful(StatefulModule, #{
                 id => ~"stateful_1",
@@ -163,7 +163,7 @@ init_per_suite(Config) ->
         }, none).
 
     render(Bindings) ->
-        arizona_template:from_string(~"""
+        arizona_template:from_html(~"""
         <div>Messages: {arizona_template:get_binding(message_count, Bindings)}</div>
         """).
 

--- a/test/arizona_renderer_SUITE.erl
+++ b/test/arizona_renderer_SUITE.erl
@@ -39,7 +39,7 @@ init_per_suite(Config) ->
         arizona_stateful:new('@module', Bindings).
 
     render(_Bindings) ->
-        arizona_template:from_string(~"""
+        arizona_template:from_html(~"""
         <h1>Stateful Template</h1>
         """).
     """", [{module, merl:term(MockStatefulModule)}]),
@@ -50,7 +50,7 @@ init_per_suite(Config) ->
     -export(['@render_fun'/1]).
 
     '@render_fun'(_Bindings) ->
-        arizona_template:from_string(~"""
+        arizona_template:from_html(~"""
         <div>Stateless Template</div>
         """).
     """", [
@@ -115,7 +115,7 @@ render_list_test(Config) when is_list(Config) ->
     TemplateAST = arizona_parse_transform:extract_callback_function_body(
         ?MODULE, ?LINE, merl:quote(~""""
         fun(Item) ->
-            arizona_template:from_string(~"""
+            arizona_template:from_html(~"""
             <li>{Item}</li>
             """)
         end
@@ -143,7 +143,7 @@ render_map_test(Config) when is_list(Config) ->
     TemplateAST = arizona_parse_transform:extract_callback_function_body(
         ?MODULE, ?LINE, merl:quote(~""""
         fun({Key, Value}) ->
-            arizona_template:from_string(~"""
+            arizona_template:from_html(~"""
             <li>Key: {Key}, Value: {Value}</li>
             """)
         end
@@ -170,7 +170,7 @@ render_map_test(Config) when is_list(Config) ->
 
 render_dynamic_test(Config) when is_list(Config) ->
     ct:comment("render_dynamic/2 should render template dynamic parts"),
-    Template = arizona_template:from_string(~"<span>Simple</span>"),
+    Template = arizona_template:from_html(~"<span>Simple</span>"),
     {mock_stateful_module, MockStatefulModule} = proplists:lookup(mock_stateful_module, Config),
     MockView = create_mock_view(MockStatefulModule, #{id => ~"foo"}),
     DynamicSequence = arizona_template:get_dynamic_sequence(Template),

--- a/test/arizona_stateful_SUITE.erl
+++ b/test/arizona_stateful_SUITE.erl
@@ -63,7 +63,7 @@ init_per_suite(Config) ->
         arizona_stateful:new('@module', Bindings).
 
     render(_Bindings) ->
-        arizona_template:from_string(~"""
+        arizona_template:from_html(~"""
         <h1>Mock Template</h1>
         """).
     """", [{module, merl:term(MockModule)}]),
@@ -80,7 +80,7 @@ init_per_suite(Config) ->
         arizona_stateful:new('@module', Bindings).
 
     render(_Bindings) ->
-        arizona_template:from_string(~"""
+        arizona_template:from_html(~"""
         <h1>Mock Template</h1>
         """).
 

--- a/test/arizona_static_SUITE.erl
+++ b/test/arizona_static_SUITE.erl
@@ -65,7 +65,7 @@ init_per_suite(Config) ->
     -export([render/1]).
 
     render(Bindings) ->
-        arizona_template:from_string(~"""
+        arizona_template:from_html(~"""
         <!DOCTYPE html>
         <html>
         <head>
@@ -102,7 +102,7 @@ init_per_suite(Config) ->
         }, Layout).
 
     render(_Bindings) ->
-        arizona_template:from_string(~"""
+        arizona_template:from_html(~"""
         <div id="home">
             <h1>Welcome Home</h1>
             <p>This is the home page.</p>
@@ -131,7 +131,7 @@ init_per_suite(Config) ->
         }, Layout).
 
     render(_Bindings) ->
-        arizona_template:from_string(~"""
+        arizona_template:from_html(~"""
         <div id="about">
             <h1>About Us</h1>
             <p>This is the about page.</p>
@@ -167,7 +167,7 @@ init_per_suite(Config) ->
         end.
 
     render(Bindings) ->
-        arizona_template:from_string(~"""
+        arizona_template:from_html(~"""
         <article id="post">
             <h1>{arizona_template:get_binding(title, Bindings)}</h1>
             <div class="content">

--- a/test/arizona_template_SUITE.erl
+++ b/test/arizona_template_SUITE.erl
@@ -18,9 +18,9 @@ all() ->
 groups() ->
     [
         {template_creation_tests, [parallel], [
-            from_string_simple_test,
-            from_string_with_dynamic_test,
-            from_string_full_params_test,
+            from_html_simple_test,
+            from_html_with_dynamic_test,
+            from_html_full_params_test,
             from_markdown_simple_test,
             from_markdown_with_dynamic_test,
             from_markdown_mixed_content_test,
@@ -48,7 +48,7 @@ groups() ->
             render_list_template_callback_test,
             render_map_template_callback_test,
             render_map_error_test,
-            from_string_with_module_function_test,
+            from_html_with_module_function_test,
             render_list_error_test
         ]}
     ].
@@ -57,24 +57,24 @@ groups() ->
 %% Template creation tests
 %% --------------------------------------------------------------------
 
-from_string_simple_test(Config) when is_list(Config) ->
-    ct:comment("from_string/1 should create template from simple string"),
-    Template = arizona_template:from_string(~"<h1>Hello World</h1>"),
+from_html_simple_test(Config) when is_list(Config) ->
+    ct:comment("from_html/1 should create template from simple string"),
+    Template = arizona_template:from_html(~"<h1>Hello World</h1>"),
     ?assert(arizona_template:is_template(Template)),
     Static = arizona_template:get_static(Template),
     ?assertEqual([~"<h1>Hello World</h1>"], Static).
 
-from_string_with_dynamic_test(Config) when is_list(Config) ->
-    ct:comment("from_string/1 should create template with dynamic content"),
-    Template = arizona_template:from_string(~"<h1>{~\"Test\"}</h1>"),
+from_html_with_dynamic_test(Config) when is_list(Config) ->
+    ct:comment("from_html/1 should create template with dynamic content"),
+    Template = arizona_template:from_html(~"<h1>{~\"Test\"}</h1>"),
     ?assert(arizona_template:is_template(Template)),
     Static = arizona_template:get_static(Template),
     ?assertEqual([~"<h1>", ~"</h1>"], Static).
 
-from_string_full_params_test(Config) when is_list(Config) ->
-    ct:comment("from_string/4 should create template with module, line, and bindings"),
+from_html_full_params_test(Config) when is_list(Config) ->
+    ct:comment("from_html/4 should create template with module, line, and bindings"),
     Bindings = #{title => ~"Test Title"},
-    Template = arizona_template:from_string(
+    Template = arizona_template:from_html(
         ?MODULE, ?LINE, ~"<h1>{arizona_template:get_binding(title, Bindings)}</h1>", Bindings
     ),
     ?assert(arizona_template:is_template(Template)),
@@ -150,7 +150,7 @@ from_markdown_with_comments_test(Config) when is_list(Config) ->
 
 is_template_test(Config) when is_list(Config) ->
     ct:comment("is_template/1 should correctly identify template records"),
-    Template = arizona_template:from_string(~"<div>Test</div>"),
+    Template = arizona_template:from_html(~"<div>Test</div>"),
     ?assert(arizona_template:is_template(Template)),
     ?assertNot(arizona_template:is_template(~"not a template")),
     ?assertNot(arizona_template:is_template(#{not_a => template})),
@@ -162,31 +162,31 @@ is_template_test(Config) when is_list(Config) ->
 
 get_static_test(Config) when is_list(Config) ->
     ct:comment("get_static/1 should return static content"),
-    Template = arizona_template:from_string(~"<div>Static</div>"),
+    Template = arizona_template:from_html(~"<div>Static</div>"),
     Static = arizona_template:get_static(Template),
     ?assertEqual([~"<div>Static</div>"], Static).
 
 get_dynamic_test(Config) when is_list(Config) ->
     ct:comment("get_dynamic/1 should return dynamic content"),
-    Template = arizona_template:from_string(~"<div>{~\"dynamic\"}</div>"),
+    Template = arizona_template:from_html(~"<div>{~\"dynamic\"}</div>"),
     Dynamic = arizona_template:get_dynamic(Template),
     ?assert(is_tuple(Dynamic)).
 
 get_dynamic_sequence_test(Config) when is_list(Config) ->
     ct:comment("get_dynamic_sequence/1 should return dynamic sequence"),
-    Template = arizona_template:from_string(~"<div>{~\"dynamic\"}</div>"),
+    Template = arizona_template:from_html(~"<div>{~\"dynamic\"}</div>"),
     Sequence = arizona_template:get_dynamic_sequence(Template),
     ?assert(is_list(Sequence)).
 
 get_dynamic_anno_test(Config) when is_list(Config) ->
     ct:comment("get_dynamic_anno/1 should return dynamic annotation"),
-    Template = arizona_template:from_string(~"<div>{~\"dynamic\"}</div>"),
+    Template = arizona_template:from_html(~"<div>{~\"dynamic\"}</div>"),
     Anno = arizona_template:get_dynamic_anno(Template),
     ?assert(is_tuple(Anno)).
 
 get_fingerprint_test(Config) when is_list(Config) ->
     ct:comment("get_fingerprint/1 should return template fingerprint"),
-    Template = arizona_template:from_string(~"<div>Test</div>"),
+    Template = arizona_template:from_html(~"<div>Test</div>"),
     Fingerprint = arizona_template:get_fingerprint(Template),
     ?assert(is_integer(Fingerprint)),
     ?assert(Fingerprint >= 0).
@@ -245,7 +245,7 @@ render_slot_view_callback_test(Config) when is_list(Config) ->
 
 render_slot_template_callback_test(Config) when is_list(Config) ->
     ct:comment("render_slot/1 with template should return arity 4 render callback"),
-    Template = arizona_template:from_string(~"<span>Slot Content</span>"),
+    Template = arizona_template:from_html(~"<span>Slot Content</span>"),
     Callback = arizona_template:render_slot(Template),
     ?assert(is_function(Callback, 4)).
 
@@ -261,16 +261,16 @@ render_slot_term_test(Config) when is_list(Config) ->
 
 render_list_template_callback_test(Config) when is_list(Config) ->
     ct:comment("render_list_template/2 should return arity 4 render callback"),
-    Template = arizona_template:from_string(~"<li>Static Item</li>"),
+    Template = arizona_template:from_html(~"<li>Static Item</li>"),
     List = [~"first", ~"second", ~"third"],
     Callback = arizona_template:render_list_template(Template, List),
     ?assert(is_function(Callback, 4)).
 
-from_string_with_module_function_test(Config) when is_list(Config) ->
-    ct:comment("from_string/4 should handle module function calls"),
+from_html_with_module_function_test(Config) when is_list(Config) ->
+    ct:comment("from_html/4 should handle module function calls"),
     TestModule = ?MODULE,
     Bindings = #{name => ~"World"},
-    Template = arizona_template:from_string(
+    Template = arizona_template:from_html(
         TestModule,
         ?LINE,
         ~"<h1>{arizona_template:get_binding(name, Bindings)}</h1>",
@@ -291,7 +291,7 @@ render_list_error_test(Config) when is_list(Config) ->
 
 render_map_template_callback_test(Config) when is_list(Config) ->
     ct:comment("render_map_template/2 should return arity 4 render callback"),
-    Template = arizona_template:from_string(~"<li>Key: {Key}, Value: {Value}</li>"),
+    Template = arizona_template:from_html(~"<li>Key: {Key}, Value: {Value}</li>"),
     Map = #{~"first" => ~"1", ~"second" => ~"2"},
     Callback = arizona_template:render_map_template(Template, Map),
     ?assert(is_function(Callback, 4)).

--- a/test/arizona_view_handler_SUITE.erl
+++ b/test/arizona_view_handler_SUITE.erl
@@ -65,7 +65,7 @@ init_per_suite(Config) ->
         }, none).
 
     render(Bindings) ->
-        arizona_template:from_string(~"""
+        arizona_template:from_html(~"""
         <!DOCTYPE html>
         <html>
         <head>
@@ -91,7 +91,7 @@ init_per_suite(Config) ->
         error('@module').
 
     render(Bindings) ->
-        arizona_template:from_string(~"""
+        arizona_template:from_html(~"""
         <!DOCTYPE html>
         <html>
         <head>
@@ -121,7 +121,7 @@ init_per_suite(Config) ->
         }, Layout).
 
     render(_Bindings) ->
-        arizona_template:from_string(~"""
+        arizona_template:from_html(~"""
         <h1>Mock View</h1>
         """).
     """", [
@@ -138,7 +138,7 @@ init_per_suite(Config) ->
 
     '@render_fun'(Bindings) ->
         SlotName = '@slot_name',
-        arizona_template:from_string(~"""
+        arizona_template:from_html(~"""
         <!DOCTYPE html>
         <html>
         <head>

--- a/test/arizona_websocket_SUITE.erl
+++ b/test/arizona_websocket_SUITE.erl
@@ -76,7 +76,7 @@ init_per_suite(Config) ->
         }, Layout).
 
     render(_Bindings) ->
-        arizona_template:from_string(~"""
+        arizona_template:from_html(~"""
         <h1>Mock View</h1>
         """).
     """", [
@@ -93,7 +93,7 @@ init_per_suite(Config) ->
 
     '@render_fun'(Bindings) ->
         SlotName = '@slot_name',
-        arizona_template:from_string(~"""
+        arizona_template:from_html(~"""
         <!DOCTYPE html>
         <html>
         <head>

--- a/test/support/benchmark/arizona_static_benchmark.erl
+++ b/test/support/benchmark/arizona_static_benchmark.erl
@@ -179,7 +179,7 @@ create_benchmark_view_module() ->
         }, none).
 
     render(_Bindings) ->
-        arizona_template:from_string(~"""
+        arizona_template:from_html(~"""
         <!DOCTYPE html>
         <html>
         <head>

--- a/test/support/e2e/blog/arizona_blog_app_layout.erl
+++ b/test/support/e2e/blog/arizona_blog_app_layout.erl
@@ -3,7 +3,7 @@
 -export([render/1]).
 
 render(Bindings) ->
-    arizona_template:from_string(~""""
+    arizona_template:from_html(~""""
     <!DOCTYPE html>
     <html lang="en">
     <head>

--- a/test/support/e2e/blog/arizona_blog_app_view.erl
+++ b/test/support/e2e/blog/arizona_blog_app_view.erl
@@ -29,7 +29,7 @@ mount(_Arg, Req) ->
 
 render(Bindings) ->
     Module = ?MODULE,
-    arizona_template:from_string(~"""
+    arizona_template:from_html(~"""
     <div id="{arizona_template:get_binding(id, Bindings)}">
     {
         ViewMode = arizona_template:get_binding(view_mode, Bindings),
@@ -68,7 +68,7 @@ render_post_list(Bindings) ->
         SelectedTag = arizona_template:get_binding(selected_tag, Bindings),
         AllTags = lists:usort(lists:flatten([maps:get(tags, Post) || Post <- Posts])),
         arizona_template:render_list(fun(Tag) ->
-            arizona_template:from_string(~"""
+            arizona_template:from_html(~"""
             {arizona_template:render_stateless(arizona_blog_app_view, render_tag, #{
                 tag => Tag,
                 selected => Tag =:= SelectedTag
@@ -86,7 +86,7 @@ render_post_list(Bindings) ->
         SelectedTag = arizona_template:get_binding(selected_tag, Bindings),
         FilteredPosts = filter_posts_by_tag(Posts, SelectedTag),
         arizona_template:render_list(fun(Post) ->
-            arizona_template:from_string(~"""
+            arizona_template:from_html(~"""
             {arizona_template:render_stateless(arizona_blog_app_view, render_post_preview, #{
                 post => Post
             })}
@@ -109,7 +109,7 @@ render_post_detail(Bindings) ->
     **By {Author}** • *{Date}*
 
     {arizona_template:render_list(fun(Tag) ->
-        arizona_template:from_string(~"""
+        arizona_template:from_html(~"""
         <span
             class="tag"
             style="{[
@@ -145,7 +145,7 @@ render_post_preview(Bindings) ->
     {Excerpt}
 
     {arizona_template:render_list(fun(Tag) ->
-        arizona_template:from_string(~"""
+        arizona_template:from_html(~"""
         <span
             class="tag"
             style="{[
@@ -186,7 +186,7 @@ render_tag(Bindings) ->
             all -> ~"All";
             _ -> atom_to_binary(Tag)
         end,
-    arizona_template:from_string(~"""
+    arizona_template:from_html(~"""
     <button onclick="arizona.sendEvent('filter_by_tag', \{tag: '{Tag}'})" style="{Style}">
         {TagDisplay}
     </button>
@@ -248,7 +248,7 @@ get_posts() ->
 
                 ```erlang
                 render(Bindings) ->
-                    arizona_template:from_string(~"""
+                    arizona_template:from_html(~"""
                     <div>
                         <h1>Count: \{arizona_template:get_binding(count, Bindings)}</h1>
                         <button onclick="arizona.sendEvent('increment')">+</button>

--- a/test/support/e2e/counter/arizona_counter_layout.erl
+++ b/test/support/e2e/counter/arizona_counter_layout.erl
@@ -3,7 +3,7 @@
 -export([render/1]).
 
 render(Bindings) ->
-    arizona_template:from_string(~"""
+    arizona_template:from_html(~"""
     <!DOCTYPE html>
     <html>
     <head>

--- a/test/support/e2e/counter/arizona_counter_stateful.erl
+++ b/test/support/e2e/counter/arizona_counter_stateful.erl
@@ -9,7 +9,7 @@ mount(Bindings) ->
     arizona_stateful:new(?MODULE, Bindings).
 
 render(Bindings) ->
-    arizona_template:from_string(~"""
+    arizona_template:from_html(~"""
     <div id="{arizona_template:get_binding(id, Bindings)}">
         <h1>Counter: <span data-testid="count">{arizona_template:get_binding(count, Bindings)}</span></h1>
         <button

--- a/test/support/e2e/counter/arizona_counter_view.erl
+++ b/test/support/e2e/counter/arizona_counter_view.erl
@@ -26,7 +26,7 @@ mount(_Arg, Req) ->
     arizona_view:new(?MODULE, Bindings, Layout).
 
 render(Bindings) ->
-    arizona_template:from_string(~"""
+    arizona_template:from_html(~"""
     <div id="{arizona_template:get_binding(id, Bindings)}">
         {arizona_template:render_stateful(arizona_counter_stateful, #{
             id => arizona_template:get_binding(counter_id, Bindings),

--- a/test/support/e2e/datagrid/arizona_datagrid_layout.erl
+++ b/test/support/e2e/datagrid/arizona_datagrid_layout.erl
@@ -3,7 +3,7 @@
 -export([render/1]).
 
 render(Bindings) ->
-    arizona_template:from_string(~"""
+    arizona_template:from_html(~"""
     <!DOCTYPE html>
     <html>
     <head>

--- a/test/support/e2e/datagrid/arizona_datagrid_view.erl
+++ b/test/support/e2e/datagrid/arizona_datagrid_view.erl
@@ -146,15 +146,15 @@ mount(_Arg, Req) ->
                 }
             ],
             callback => fun(Col, Row) ->
-                arizona_template:from_string(~""""
+                arizona_template:from_html(~""""
                 {
                     case Col of
                         #{name := name} ->
-                            arizona_template:from_string(~"""
+                            arizona_template:from_html(~"""
                             <strong>{maps:get(name, Row)}</strong>
                             """);
                         #{name := email} ->
-                            arizona_template:from_string(~"""
+                            arizona_template:from_html(~"""
                             <a href="mailto:{maps:get(email, Row)}">
                                 {maps:get(email, Row)}
                             </a>
@@ -165,7 +165,7 @@ mount(_Arg, Req) ->
                                 ~"moderator" -> ~"status-badge role-badge-moderator";
                                 ~"user" -> ~"status-badge role-badge-user"
                             end,
-                            arizona_template:from_string(~"""
+                            arizona_template:from_html(~"""
                             <span class="{RoleClass}">
                                 {maps:get(role, Row)}
                             </span>
@@ -177,20 +177,20 @@ mount(_Arg, Req) ->
                                     ~"inactive" -> {~"status-badge status-badge-inactive", ~"⚪"};
                                     ~"pending" -> {~"status-badge status-badge-pending", ~"⏳"}
                                 end,
-                            arizona_template:from_string(~"""
+                            arizona_template:from_html(~"""
                             <span class="{StatusClass}">
                                 {StatusIcon} {maps:get(status, Row)}
                             </span>
                             """);
                         #{name := created_at} ->
-                            arizona_template:from_string(~"""
+                            arizona_template:from_html(~"""
                             <small class="text-muted">
                                 {maps:get(created_at, Row)}
                             </small>
                             """);
                         #{name := actions} ->
                             UserId = maps:get(id, Row),
-                            arizona_template:from_string(~"""
+                            arizona_template:from_html(~"""
                             <div class="action-button-group" role="group">
                                 <button
                                     type="button"
@@ -212,7 +212,7 @@ mount(_Arg, Req) ->
     ).
 
 render(Bindings) ->
-    arizona_template:from_string(~""""
+    arizona_template:from_html(~""""
     <div id="{arizona_template:get_binding(id, Bindings)}">
         {arizona_template:render_stateless(arizona_datagrid_view, render_table, #{
             cols => arizona_template:get_binding(cols, Bindings),
@@ -225,7 +225,7 @@ render(Bindings) ->
     """").
 
 render_table(Bindings) ->
-    arizona_template:from_string(~""""""
+    arizona_template:from_html(~""""""
     <div class="table-responsive">
         <table class="table table-striped table-hover">
             <thead class="table-dark">
@@ -234,7 +234,7 @@ render_table(Bindings) ->
                         Sortable = maps:get(sortable, Col, false),
                         SortColumn = arizona_template:get_binding(sort_column, Bindings),
                         SortDirection = arizona_template:get_binding(sort_direction, Bindings),
-                        arizona_template:from_string(~""""
+                        arizona_template:from_html(~""""
                         <th scope="col" class="{
                             case Sortable of
                                 true -> ~"sortable";
@@ -244,7 +244,7 @@ render_table(Bindings) ->
                             case Sortable of
                                 true ->
                                     ColumnName = maps:get(name, Col),
-                                    arizona_template:from_string(~"""
+                                    arizona_template:from_html(~"""
                                     style="cursor: pointer;"
                                     onclick="arizona.sendEvent('sort_table', \{column: '{ColumnName}'})"
                                     """);
@@ -275,10 +275,10 @@ render_table(Bindings) ->
                     Cols = arizona_template:get_binding(cols, Bindings),
                     Callback = arizona_template:get_binding(callback, Bindings),
                     arizona_template:render_list(fun(Row) ->
-                        arizona_template:from_string(~""""
+                        arizona_template:from_html(~""""
                         <tr class="user-row" data-user-id="{maps:get(id, Row)}">
                             {arizona_template:render_list(fun(Col) ->
-                                arizona_template:from_string(~"""
+                                arizona_template:from_html(~"""
                                 <td class="align-middle">
                                     {Callback(Col, Row)}
                                 </td>

--- a/test/support/e2e/modal/arizona_modal_layout.erl
+++ b/test/support/e2e/modal/arizona_modal_layout.erl
@@ -3,7 +3,7 @@
 -export([render/1]).
 
 render(Bindings) ->
-    arizona_template:from_string(~"""
+    arizona_template:from_html(~"""
     <!DOCTYPE html>
     <html>
     <head>

--- a/test/support/e2e/modal/arizona_modal_view.erl
+++ b/test/support/e2e/modal/arizona_modal_view.erl
@@ -23,7 +23,7 @@ mount(_Arg, Req) ->
     ).
 
 render(Bindings) ->
-    arizona_template:from_string(~""""
+    arizona_template:from_html(~""""
     <div id="{arizona_template:get_binding(id, Bindings)}">
         <!-- Control buttons to test modal functionality -->
         <div class="control-container">
@@ -59,7 +59,7 @@ render(Bindings) ->
     """").
 
 render_modal(Bindings) ->
-    arizona_template:from_string(~""""
+    arizona_template:from_html(~""""
     <div class="modal-overlay" onclick="arizona.sendEvent('close_modal')">
         <div class="modal-container" onclick="event.stopPropagation()">
             <div class="modal-header">
@@ -86,7 +86,7 @@ render_modal(Bindings) ->
             <div class="modal-footer">
                 {
                     Confirm = arizona_template:get_binding(confirm, Bindings),
-                    arizona_template:from_string(~"""
+                    arizona_template:from_html(~"""
                     <button class="{maps:get(classes, Confirm)}" onclick="arizona.sendEvent('close_modal')">
                         {arizona_template:render_slot(maps:get(content, Confirm))}
                     </button>
@@ -94,7 +94,7 @@ render_modal(Bindings) ->
                 }
                 {
                     Cancel = arizona_template:get_binding(cancel, Bindings),
-                    arizona_template:from_string(~"""
+                    arizona_template:from_html(~"""
                     <button class="{maps:get(classes, Cancel)}" onclick="arizona.sendEvent('close_modal')">
                         {arizona_template:render_slot(maps:get(content, Cancel))}
                     </button>
@@ -130,7 +130,7 @@ get_header_slot(info) ->
 
 %% Generate inner_block slot based on modal type
 get_inner_block_slot(success, User) ->
-    arizona_template:from_string(~"""
+    arizona_template:from_html(~"""
     <div class="modal-icon modal-icon-success">
         <div class="icon-checkmark"></div>
     </div>
@@ -142,7 +142,7 @@ get_inner_block_slot(success, User) ->
     </div>
     """);
 get_inner_block_slot(error, User) ->
-    arizona_template:from_string(~"""
+    arizona_template:from_html(~"""
     <div class="modal-icon modal-icon-error">
         <div class="icon-warning"></div>
     </div>
@@ -154,7 +154,7 @@ get_inner_block_slot(error, User) ->
     </div>
     """);
 get_inner_block_slot(info, User) ->
-    arizona_template:from_string(~"""
+    arizona_template:from_html(~"""
     <div class="modal-icon modal-icon-info">
         <div class="icon-info"></div>
     </div>

--- a/test/support/e2e/presence/arizona_presence_layout.erl
+++ b/test/support/e2e/presence/arizona_presence_layout.erl
@@ -3,7 +3,7 @@
 -export([render/1]).
 
 render(Bindings) ->
-    arizona_template:from_string(~"""
+    arizona_template:from_html(~"""
     <!DOCTYPE html>
     <html>
     <head>

--- a/test/support/e2e/presence/arizona_presence_view.erl
+++ b/test/support/e2e/presence/arizona_presence_view.erl
@@ -38,7 +38,7 @@ mount(_MountArg, Request) ->
     arizona_view:new(?MODULE, Bindings, Layout).
 
 render(Bindings) ->
-    arizona_template:from_string(~""""
+    arizona_template:from_html(~""""
     <div
         id="{arizona_template:get_binding(id, Bindings)}"
         data-testid="presence-view"
@@ -84,7 +84,7 @@ render(Bindings) ->
                 {
                     OnlineUsers = arizona_template:get_binding(online_users, Bindings),
                     arizona_template:render_map(fun({UserId, UserInfo}) ->
-                        arizona_template:from_string(~"""
+                        arizona_template:from_html(~"""
                         <div class="user-item">
                             <strong>{maps:get(user_name, UserInfo)}</strong>
                             (ID: {UserId})

--- a/test/support/e2e/realtime/arizona_realtime_layout.erl
+++ b/test/support/e2e/realtime/arizona_realtime_layout.erl
@@ -3,7 +3,7 @@
 -export([render/1]).
 
 render(Bindings) ->
-    arizona_template:from_string(~"""
+    arizona_template:from_html(~"""
     <!DOCTYPE html>
     <html>
     <head>

--- a/test/support/e2e/realtime/arizona_realtime_view.erl
+++ b/test/support/e2e/realtime/arizona_realtime_view.erl
@@ -23,7 +23,7 @@ mount(_Arg, Req) ->
     arizona_view:new(?MODULE, Bindings, Layout).
 
 render(Bindings) ->
-    arizona_template:from_string(~"""
+    arizona_template:from_html(~"""
     <div id="{arizona_template:get_binding(id, Bindings)}">
         <div class="clock" data-testid="clock">
             {arizona_template:get_binding(current_time, Bindings)}

--- a/test/support/e2e/shared/arizona_test_components.erl
+++ b/test/support/e2e/shared/arizona_test_components.erl
@@ -3,7 +3,7 @@
 -export([render_menu/1]).
 
 render_menu(Bindings) ->
-    arizona_template:from_string(~""""
+    arizona_template:from_html(~""""
     <nav class="test-nav">
         <div class="nav-container">
             <div class="nav-brand">
@@ -14,7 +14,7 @@ render_menu(Bindings) ->
                     ActiveUrl = arizona_template:get_binding(active_url, Bindings),
                     arizona_template:render_list(fun(#{url := Url, name := Name, desc := Desc}) ->
                         Class = case Url of ActiveUrl -> ~"active"; _ -> ~"" end,
-                        arizona_template:from_string(~"""
+                        arizona_template:from_html(~"""
                         <li class="nav-item">
                             <a
                                 href="{Url}"

--- a/test/support/e2e/static/arizona_blog_about_view.erl
+++ b/test/support/e2e/static/arizona_blog_about_view.erl
@@ -13,7 +13,7 @@ mount(PageBindings, _Req) ->
     arizona_view:new(?MODULE, Bindings, Layout).
 
 render(Bindings) ->
-    arizona_template:from_string(~"""
+    arizona_template:from_html(~"""
     <div id="{arizona_template:get_binding(id, Bindings)}" class="about">
         <h1>About Me</h1>
         <p>This is a static blog built with Arizona framework!</p>

--- a/test/support/e2e/static/arizona_blog_home_view.erl
+++ b/test/support/e2e/static/arizona_blog_home_view.erl
@@ -25,12 +25,12 @@ mount(PageBindings, _Req) ->
     arizona_view:new(?MODULE, Bindings, Layout).
 
 render(Bindings) ->
-    arizona_template:from_string(~""""
+    arizona_template:from_html(~""""
     <div id="{arizona_template:get_binding(id, Bindings)}" class="home">
         <h1>Welcome to My Blog</h1>
         <div class="posts">
             {arizona_template:render_list(fun(#{url := URL, title := Title}) ->
-                arizona_template:from_string(~"""
+                arizona_template:from_html(~"""
                 <article class="post-preview">
                     <h2><a href="{URL}">{Title}</a></h2>
                 </article>

--- a/test/support/e2e/static/arizona_blog_layout.erl
+++ b/test/support/e2e/static/arizona_blog_layout.erl
@@ -3,7 +3,7 @@
 -export([render/1]).
 
 render(Bindings) ->
-    arizona_template:from_string(~""""
+    arizona_template:from_html(~""""
     <!DOCTYPE html>
     <html lang="en">
     <head>
@@ -28,7 +28,7 @@ render(Bindings) ->
             {
                 NavActive = arizona_template:get_binding(nav_active, Bindings),
                 arizona_template:render_list(fun({URL, Slug, Label}) ->
-                   arizona_template:from_string(~"""
+                   arizona_template:from_html(~"""
                    <a
                        href="{URL}"
                        class="{case NavActive of Slug -> ~"active"; _ -> ~"" end}"

--- a/test/support/e2e/static/arizona_blog_post_view.erl
+++ b/test/support/e2e/static/arizona_blog_post_view.erl
@@ -22,7 +22,7 @@ mount(Posts, Req) ->
     end.
 
 render(Bindings) ->
-    arizona_template:from_string(~""""
+    arizona_template:from_html(~""""
     <article id="{arizona_template:get_binding(id, Bindings)}" class="post">
         <header>
             <h1>{arizona_template:get_binding(title, Bindings)}</h1>

--- a/test/support/e2e/todo/arizona_todo_app_layout.erl
+++ b/test/support/e2e/todo/arizona_todo_app_layout.erl
@@ -3,7 +3,7 @@
 -export([render/1]).
 
 render(Bindings) ->
-    arizona_template:from_string(~"""
+    arizona_template:from_html(~"""
     <!DOCTYPE html>
     <html lang="en">
     <head>

--- a/test/support/e2e/todo/arizona_todo_app_view.erl
+++ b/test/support/e2e/todo/arizona_todo_app_view.erl
@@ -97,7 +97,7 @@ handle_event(~"clear_completed", _Params, View) ->
     {[], UpdatedView}.
 
 render(Bindings) ->
-    arizona_template:from_string(~""""
+    arizona_template:from_html(~""""
     <div
         id="{arizona_template:get_binding(id, Bindings)}"
         class="todo-app"
@@ -117,7 +117,7 @@ render(Bindings) ->
             {Todos = arizona_template:get_binding(todos, Bindings),
              Filter = arizona_template:get_binding(filter, Bindings),
              arizona_template:render_list(fun(#{id := Id} = Todo) ->
-                arizona_template:from_string(~"""
+                arizona_template:from_html(~"""
                 <div class="todo-item {case maps:get(completed, Todo) of true -> ~"completed"; false -> ~"" end}" data-testid="todo-{Id}">
                     <input
                         type="checkbox"
@@ -160,7 +160,7 @@ render(Bindings) ->
     """").
 
 render_stats(Bindings) ->
-    arizona_template:from_string(~"""
+    arizona_template:from_html(~"""
     <span class="todo-count" data-testid="todo-count">
         <strong>{length(lists:filter(fun(#{completed := Completed}) -> not Completed end, arizona_template:get_binding(todos, Bindings)))}</strong>
         {case length(lists:filter(fun(#{completed := Completed}) -> not Completed end, arizona_template:get_binding(todos, Bindings))) of
@@ -171,7 +171,7 @@ render_stats(Bindings) ->
     """).
 
 render_filters(Bindings) ->
-    arizona_template:from_string(~"""
+    arizona_template:from_html(~"""
     <ul class="filters" data-testid="filters">
         <li>
             <a class="{case arizona_template:get_binding(filter, Bindings) of all -> ~"selected"; _ -> ~"" end}"
@@ -192,7 +192,7 @@ render_filters(Bindings) ->
     """).
 
 render_clear_button(_Bindings) ->
-    arizona_template:from_string(~"""
+    arizona_template:from_html(~"""
     <button
         class="clear-completed"
         data-testid="clear-completed"


### PR DESCRIPTION
# Description

Comprehensive rename of the template API function from `from_string` to `from_html` for better semantic clarity and consistency. This change affects all source files, tests, examples, and documentation.

Changes:
- Updated `arizona_template` module documentation and examples
- Updated `arizona_parse_transform` references
- Updated all test suites and test function names
- Updated all example applications (counter, todo, blog, etc.)
- Updated all layout and view modules
- Updated README documentation and API examples
- Updated stateful/stateless component examples

The functionality remains identical - only the function name has changed for improved API consistency and semantic meaning.

---

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
