### PR TITLE
Add file-based template compilation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,12 +247,17 @@ Arizona templates combine HTML with Erlang expressions using a simple and intuit
 ### Basic Expressions
 
 ```erlang
+% Inline HTML template
 arizona_template:from_html(~"""
 <div>
     <h1>{arizona_template:get_binding(title, Bindings)}</h1>
     <p>User: {arizona_template:get_binding(username, Bindings)}</p>
 </div>
 """)
+
+% File-based template with compile-time optimization
+arizona_template:from_html({file, "templates/user.html"})
+arizona_template:from_html({priv_file, myapp, "templates/user.html"})
 ```
 
 ### Stateful Component Rendering
@@ -367,7 +372,7 @@ content-driven applications.
 {ok, Html} = arizona_markdown:to_html(~"# Hello **World**")
 % Returns: ~"<h1>Hello <strong>World</strong></h1>\n"
 
-% Markdown with Arizona template syntax
+% Inline markdown template
 arizona_template:from_markdown(~"""
 # {arizona_template:get_binding(title, Bindings)}
 Welcome **{arizona_template:get_binding(user, Bindings)}**!
@@ -379,6 +384,10 @@ Welcome **{arizona_template:get_binding(user, Bindings)}**!
     data => arizona_template:get_binding(widget_data, Bindings)
 })}
 """)
+
+% File-based markdown template with compile-time optimization
+arizona_template:from_markdown({file, "content/blog-post.md"})
+arizona_template:from_markdown({priv_file, myapp, "content/blog-post.md"})
 
 % With markdown options
 {ok, Html} = arizona_markdown:to_html(~"# Hello", [source_pos, smart])

--- a/test/arizona_template_SUITE_data/html_template.herl
+++ b/test/arizona_template_SUITE_data/html_template.herl
@@ -1,0 +1,16 @@
+<html>
+<head>
+    <title>{arizona_template:get_binding(title, Bindings)}</title>
+</head>
+<body>
+    <h1>{arizona_template:get_binding(heading, Bindings)}</h1>
+    <p>Welcome {arizona_template:get_binding(name, Bindings)}!</p>
+    <ul>
+        {arizona_template:render_list(fun(Item) ->
+            arizona_template:from_html(~"""
+            <li>{arizona_template:get_binding(text, Item)}</li>
+            """)
+        end, arizona_template:get_binding(items, Bindings))}
+    </ul>
+</body>
+</html>

--- a/test/arizona_template_SUITE_data/markdown_template.herl
+++ b/test/arizona_template_SUITE_data/markdown_template.herl
@@ -1,0 +1,18 @@
+# {arizona_template:get_binding(title, Bindings)}
+
+Welcome **{arizona_template:get_binding(name, Bindings)}**!
+
+{% Template comment - not rendered %}
+
+{arizona_template:render_stateful(my_widget_component, #{
+    id => ~"widget",
+    data => arizona_template:get_binding(widget_data, Bindings)
+})}
+
+## List of items
+
+{arizona_template:render_list(fun(Item) ->
+    arizona_template:from_html(~"""
+    - {arizona_template:get_binding(name, Item)}
+    """)
+end, arizona_template:get_binding(items, Bindings))}


### PR DESCRIPTION
# Description

* Support `{file, Filename}` and `{priv_file, App, Filename}` in `arizona_template:from_html/4` and `from_markdown/4`
* Add compile-time file template optimization in arizona_parse_transform
* Update documentation and examples for file-based template usage

---

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
