### PR TITLE
Fix presence demo user info display timing

### DIFF
--- a/test/support/e2e/presence/arizona_presence_controller.erl
+++ b/test/support/e2e/presence/arizona_presence_controller.erl
@@ -78,13 +78,15 @@ handle_join(Req, State) ->
                 json:encode(#{
                     status => ~"success",
                     message => ~"User joined successfully",
-                    user_id => UserId
+                    user_id => UserId,
+                    user_name => UserName
                 });
             {error, already_joined} ->
                 json:encode(#{
                     status => ~"error",
                     message => ~"User is already in presence",
-                    user_id => UserId
+                    user_id => UserId,
+                    user_name => UserName
                 })
         end,
 

--- a/test/support/e2e/presence/arizona_presence_view.erl
+++ b/test/support/e2e/presence/arizona_presence_view.erl
@@ -102,10 +102,12 @@ render(Bindings) ->
             let isJoined = false;
 
             // Update the displayed user info
-            const userIdSpan = document.querySelector('.user-id');
-            const userNameSpan = document.querySelector('.user-name');
-            if (userIdSpan) userIdSpan.textContent = currentUserId;
-            if (userNameSpan) userNameSpan.textContent = currentUserName;
+            function updateUserInfo() \{
+                const userIdSpan = document.querySelector('.user-id');
+                const userNameSpan = document.querySelector('.user-name');
+                if (userIdSpan) userIdSpan.textContent = currentUserId;
+                if (userNameSpan) userNameSpan.textContent = currentUserName;
+            }
 
             document.addEventListener('arizonaEvent', (\{ detail: event }) => \{
                 if (event.type !== 'status') return
@@ -156,6 +158,7 @@ render(Bindings) ->
                     const result = await response.json();
                     if (response.ok && result.status === 'success') \{
                         isJoined = true;
+                        updateUserInfo();
                         updateButtons();
                         showStatus('Successfully joined presence!');
                     } else \{
@@ -180,6 +183,7 @@ render(Bindings) ->
                     const result = await response.json();
                     if (response.ok && result.status === 'success') \{
                         isJoined = false;
+                        updateUserInfo();
                         updateButtons();
                         showStatus('Successfully left presence!');
                     } else \{
@@ -189,6 +193,8 @@ render(Bindings) ->
                     showStatus('Network error: ' + error.message, true);
                 }
             }
+
+            updateUserInfo();
         </script>
     </div>
     """").


### PR DESCRIPTION
# Description

Ensure client-generated user ID/name are displayed immediately on page load and after join/leave operations by calling `updateUserInfo()` at appropriate times. Also include user_name in API responses for consistency.

---

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
