### PR TITLE
Fix iolist rendering in diffs by converting to binary

### DIFF
--- a/assets/js/__tests__/e2e/parallel/hello-world.spec.js
+++ b/assets/js/__tests__/e2e/parallel/hello-world.spec.js
@@ -1,0 +1,124 @@
+import { test, expect } from '@playwright/test';
+import { waitForCondition, collectWebSocketMessages } from '../utils.js';
+
+test.describe('Arizona Hello World App', () => {
+  test('should load hello world page and display initial button', async ({ page }) => {
+    await page.goto('/hello-world');
+
+    // Check that the page loads with the button
+    const button = page.locator('button:has-text("Say Hello!")');
+    await expect(button).toBeVisible();
+
+    // Verify the button has the correct onclick attribute
+    await expect(button).toHaveAttribute('onclick', "arizona.pushEvent('hello_world')");
+
+    // Verify only one view container exists (no duplication)
+    const viewContainers = page.locator('#view');
+    await expect(viewContainers).toHaveCount(1);
+  });
+
+  test('should establish WebSocket connection and receive initial render', async ({ page }) => {
+    const initialMessages = collectWebSocketMessages(page, 'initial_render');
+
+    await page.goto('/hello-world');
+
+    // Wait for initial render message to arrive
+    await waitForCondition(() => {
+      return initialMessages.length > 0;
+    });
+
+    const initialMessage = initialMessages[0];
+    expect(initialMessage).toBeTruthy();
+    expect(initialMessage.type).toBe('initial_render');
+    expect(initialMessage.stateful_id).toBe('view');
+    expect(initialMessage.structure).toBeDefined();
+    expect(typeof initialMessage.structure).toBe('object');
+  });
+
+  test('should update view via WebSocket after button click and verify DOM update', async ({
+    page,
+  }) => {
+    const diffMessages = collectWebSocketMessages(page, 'diff');
+
+    await page.goto('/hello-world');
+
+    // Wait for initial load
+    const button = page.locator('button:has-text("Say Hello!")');
+    await expect(button).toBeVisible();
+
+    // Click the button
+    await button.click();
+
+    // Wait for WebSocket diff message
+    await waitForCondition(() => {
+      return diffMessages.length > 0;
+    });
+
+    const diffMessage = diffMessages[0];
+    expect(diffMessage.type).toBe('diff');
+    expect(diffMessage.stateful_id).toBe('view');
+    expect(diffMessage.changes).toBeDefined();
+    expect(Array.isArray(diffMessage.changes)).toBe(true);
+
+    // Verify the diff contains element changes
+    expect(diffMessage.changes.length).toBeGreaterThan(0);
+
+    const [elementIndex, newValue] = diffMessage.changes[0];
+    expect(typeof elementIndex).toBe('number');
+
+    // The new value should be a string "Hello, World!"
+    expect(typeof newValue).toBe('string');
+
+    // Verify UI updated - button should be replaced with text
+    await expect(button).not.toBeVisible();
+
+    // Check that the new content is visible
+    const viewDiv = page.locator('#view');
+    await expect(viewDiv).toContainText('Hello, World!');
+  });
+
+  test('should receive correct diff structure with string content', async ({ page }) => {
+    const diffMessages = collectWebSocketMessages(page, 'diff');
+
+    await page.goto('/hello-world');
+
+    // Click button to trigger update
+    const button = page.locator('button:has-text("Say Hello!")');
+    await button.click();
+
+    // Wait for diff message
+    await waitForCondition(() => {
+      return diffMessages.length > 0;
+    });
+
+    const diffMessage = diffMessages[0];
+
+    // The changes should contain the element index and the new string value
+    const [elementIndex, newValue] = diffMessage.changes[0];
+
+    // Verify structure matches expected format: [[index, "Hello, World!"]]
+    expect(typeof elementIndex).toBe('number');
+    expect(typeof newValue).toBe('string');
+
+    // Verify content
+    expect(newValue).toContain('Hello');
+    expect(newValue).toContain('World');
+  });
+
+  test('should handle single click and verify no errors', async ({ page }) => {
+    await page.goto('/hello-world');
+
+    const button = page.locator('button:has-text("Say Hello!")');
+    await expect(button).toBeVisible();
+
+    // Click once (button will be replaced with text after first click)
+    await button.click();
+
+    // Wait a bit for all processing
+    await page.waitForTimeout(500);
+
+    // Should show the greeting (no errors)
+    const viewDiv = page.locator('#view');
+    await expect(viewDiv).toContainText('Hello, World!');
+  });
+});

--- a/scripts/start_test_server.sh
+++ b/scripts/start_test_server.sh
@@ -29,6 +29,7 @@ maybe
             enabled => true,
             transport_opts => [{port, 8080}],
             routes => [
+                {view, ~\"/hello-world\", arizona_hello_world_view, #{}, []},
                 {view, ~\"/realtime\", arizona_realtime_view, #{}, []},
                 {view, ~\"/counter\", arizona_counter_view, #{}, []},
                 {view, ~\"/todo\", arizona_todo_app_view, #{}, []},

--- a/src/arizona_differ.erl
+++ b/src/arizona_differ.erl
@@ -52,7 +52,10 @@ Only changed dynamic parts are included in the diff.
 -nominal diff() :: [
     {
         arizona_tracker:element_index(),
-        diff() | arizona_hierarchical:hierarchical_structure() | arizona_html:html()
+        diff()
+        | arizona_hierarchical:hierarchical_structure()
+        | arizona_html:html()
+        | [arizona_html:html() | [arizona_html:html()]]
     }
 ].
 

--- a/src/arizona_erl.erl
+++ b/src/arizona_erl.erl
@@ -109,10 +109,10 @@ ast_to_html(ElementAST) ->
         list ->
             % List of elements
             Elements = erl_syntax:list_elements(ElementAST),
-            [element_ast_to_html(El) || El <- Elements];
+            arizona_html:to_html([element_ast_to_html(El) || El <- Elements]);
         _Other ->
             % Single element
-            element_ast_to_html(ElementAST)
+            arizona_html:to_html(element_ast_to_html(ElementAST))
     end.
 
 %% --------------------------------------------------------------------

--- a/src/arizona_html.erl
+++ b/src/arizona_html.erl
@@ -45,7 +45,7 @@ values into HTML content.
 %% Types definitions
 %% --------------------------------------------------------------------
 
--nominal html() :: iodata().
+-nominal html() :: binary().
 -type value() :: binary() | iolist() | atom() | number().
 
 %% --------------------------------------------------------------------
@@ -66,7 +66,7 @@ to_html(Value) when is_binary(Value) ->
     Value;
 % Assume it is an iolist()
 to_html(Value) when is_list(Value) ->
-    Value;
+    iolist_to_binary(Value);
 to_html(Value) when is_atom(Value) ->
     atom_to_binary(Value, utf8);
 to_html(Value) when is_integer(Value) ->

--- a/test/arizona_html_SUITE.erl
+++ b/test/arizona_html_SUITE.erl
@@ -72,10 +72,10 @@ to_html_float(Config) when is_list(Config) ->
     ?assertEqual(~"-1.23", arizona_html:to_html(-1.23)).
 
 to_html_iolist(Config) when is_list(Config) ->
-    ct:comment("Lists should be assumed to be iolists and returned as-is"),
-    ?assertEqual([], arizona_html:to_html([])),
-    ?assertEqual([~"hello", ~"world"], arizona_html:to_html([~"hello", ~"world"])),
-    ?assertEqual([~"hello", 32, ~"world"], arizona_html:to_html([~"hello", 32, ~"world"])).
+    ct:comment("Lists should be converted to binary"),
+    ?assertEqual(<<>>, arizona_html:to_html([])),
+    ?assertEqual(~"hello world", arizona_html:to_html([~"hello ", ~"world"])),
+    ?assertEqual(~"hello world", arizona_html:to_html([~"hello", 32, ~"world"])).
 
 %% --------------------------------------------------------------------
 %% Error cases tests

--- a/test/support/e2e/hello_world/arizona_hello_world_view.erl
+++ b/test/support/e2e/hello_world/arizona_hello_world_view.erl
@@ -1,0 +1,52 @@
+-module(arizona_hello_world_view).
+-behaviour(arizona_view).
+-compile({parse_transform, arizona_parse_transform}).
+-export([mount/2]).
+-export([layout/1]).
+-export([render/1]).
+-export([handle_event/3]).
+
+mount(_Arg, Req) ->
+    Bindings = #{id => ~"view"},
+    Path = arizona_request:get_path(Req),
+    Layout = {?MODULE, layout, main_content, #{active_url => Path}},
+    arizona_view:new(?MODULE, Bindings, Layout).
+
+layout(Bindings) ->
+    arizona_template:from_erl([
+        ~"<!DOCTYPE html>",
+        {html, [], [
+            {head, [], [
+                {title, [], ~"Arizona Test Hello World"},
+                {script, [{type, ~"module"}], ~"""
+                import Arizona from '/assets/js/arizona.min.js';
+                globalThis.arizona = new Arizona();
+                arizona.connect('/live');
+                """}
+            ]},
+            {body, [], [
+                arizona_template:render_stateless(arizona_test_components, render_menu, #{
+                    active_url => maps:get(active_url, Bindings)
+                }),
+                arizona_template:render_slot(maps:get(main_content, Bindings))
+            ]}
+        ]}
+    ]).
+
+render(Bindings) ->
+    arizona_template:from_erl(
+        {'div', [{id, arizona_template:get_binding(id, Bindings)}],
+            case arizona_template:find_binding(name, Bindings) of
+                {ok, Name} ->
+                    [~"Hello, ", Name, ~"!"];
+                error ->
+                    arizona_template:from_erl(
+                        {button, [{onclick, ~"arizona.pushEvent('hello_world')"}], ~"Say Hello!"}
+                    )
+            end}
+    ).
+
+handle_event(~"hello_world", _Params, View) ->
+    State = arizona_view:get_state(View),
+    UpdatedState = arizona_stateful:put_binding(name, ~"World", State),
+    {[], arizona_view:update_state(UpdatedState, View)}.

--- a/test/support/e2e/shared/arizona_test_components.erl
+++ b/test/support/e2e/shared/arizona_test_components.erl
@@ -26,6 +26,7 @@ render_menu(Bindings) ->
                         </li>
                         """)
                     end, [
+                        #{url => ~"/hello-world", name => ~"Hello World", desc => ~"Simple event handling"},
                         #{url => ~"/realtime", name => ~"Realtime", desc => ~"PubSub system"},
                         #{url => ~"/counter", name => ~"Counter", desc => ~"Simple state management"},
                         #{url => ~"/todo", name => ~"Todo App", desc => ~"CRUD operations & filtering"},


### PR DESCRIPTION
# Description

When render functions return iolists like `[~"Hello, ", Name, ~"!"]`, the differ was sending them as JSON arrays to the JavaScript client, which couldn't properly apply them as DOM updates.

**Root Cause:**
`arizona_html:to_html/1` was passing through lists unchanged, causing diffs to contain arrays like `["Hello, ", "World", "!"]` instead of flattened strings.

**Solution:**
Convert iolists to binary in `arizona_html:to_html/1`:
```erlang
to_html(Value) when is_list(Value) ->
    iolist_to_binary(Value);
```

This ensures diffs send `"Hello, World!"` instead of `["Hello, ", "World", "!"]`, which the JavaScript client already handles correctly.

---

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
