### PR TITLE
Fix spec variable names in from_html/from_markdown

### DIFF
--- a/src/arizona_template.erl
+++ b/src/arizona_template.erl
@@ -198,15 +198,15 @@ new(Static, Dynamic, DynamicSequence, DynamicAnno, Fingerprint) ->
 from_erl(Term) when is_tuple(Term); is_list(Term) ->
     error(parse_transform_required).
 
--doc #{equiv => from_html(erlang, 0, String, #{})}.
+-doc #{equiv => from_html(erlang, 0, String, #{}, [])}.
 -spec from_html(Payload) -> Template when
     Payload :: {file, Filename} | {priv_file, App, Filename} | HTML,
     Filename :: file:filename_all(),
     App :: atom(),
     HTML :: arizona_html:html(),
     Template :: template().
-from_html(String) ->
-    from_html(erlang, 0, String, #{}, []).
+from_html(Payload) ->
+    from_html(erlang, 0, Payload, #{}, []).
 
 -doc ~"""""
 Compiles a template string into a template record at runtime.
@@ -337,15 +337,15 @@ from_html(Module, Line, Payload, Bindings, CompileOpts) when is_atom(Module), is
         value
     ).
 
--doc #{equiv => from_html(erlang, 0, String, #{})}.
+-doc #{equiv => from_html(erlang, 0, Payload, #{}, [])}.
 -spec from_markdown(Payload) -> Template when
     Payload :: {file, Filename} | {priv_file, App, Filename} | Markdown,
     Filename :: file:filename_all(),
     App :: atom(),
     Markdown :: arizona_markdown:markdown(),
     Template :: template().
-from_markdown(String) ->
-    from_markdown(erlang, 0, String, #{}, []).
+from_markdown(Payload) ->
+    from_markdown(erlang, 0, Payload, #{}, []).
 
 -doc ~"""""
 Compiles a markdown string with Arizona template syntax into a template record at runtime.


### PR DESCRIPTION
# Description

Changed parameter name from `String` to `Payload` in specs for:
- from_html/1
- from_markdown/1

The specs accept multiple payload types (file paths, priv files, or direct content), so `String` was misleading. Using `Payload` matches the actual type spec and is consistent with the 5-arity versions.

---

- [ ] I have performed a self-review of my changes
- [ ] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
