### PR TITLE
Isolate per-dynamic deps and skip unaffected per-item dynamics

### DIFF
--- a/.claude/rules/erlang.md
+++ b/.claude/rules/erlang.md
@@ -120,3 +120,19 @@ Adding `'az-nodiff'` to an element's attribute list marks it as a compile-time d
 | `?send(ViewId, Msg)` | `arizona_live:send(ViewId, Msg)` -- send to specific view (stateful only) |
 | `?send_after(Time, Msg)` | `arizona_live:send_after(?get(id), Time, Msg)` -- delayed send to current view (stateful only) |
 | `?send_after(ViewId, Time, Msg)` | `arizona_live:send_after(ViewId, Time, Msg)` -- delayed send to specific view (stateful only) |
+
+## Where to read bindings
+
+`?get` (and friends) record a dependency for diff tracking. The dependency is
+attributed to whichever dynamic's closure is currently being evaluated. Two
+consequences:
+
+- Read outer bindings in **props expressions**, not in callback or lifecycle
+  bodies. `?stateless(fun bar/1, #{x => ?get(x)})` and
+  `?stateful(handler, #{x => ?get(x)})` record `x` on the outer dynamic
+  correctly. Eager `?get` calls inside a `?stateless` callback body, or
+  inside a stateful handler's `mount/1` / `handle_update/2`, are isolated
+  by the eval wraps and will not record at the outer level.
+- Prefer named fun references (`?stateless(fun bar/1, Props)`,
+  `?stateless(Mod, Fn, Props)`). They cannot close over outer `Bindings`,
+  removing the footgun entirely.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -78,6 +78,47 @@ Diff engine.
 - `diff/4` -- like `diff/3` but skips dynamics whose deps haven't changed (takes `Changed` map):
   `{Ops, NewSnapshot, Views}`
 
+## Dep tracking and per-dynamic isolation
+
+Each dynamic owns a private dep set: `#{key() => true}` of the binding keys
+read while it was evaluated. The diff engine compares each dep set against
+the `Changed` map and skips re-evaluation when they don't intersect.
+
+The mechanism is a single process-dictionary slot, `'$arizona_deps'`:
+
+- `arizona_eval:eval_one_v/2` brackets each dynamic with
+  `erlang:put('$arizona_deps', #{})` at entry and `erlang:erase` at exit.
+- `arizona_template:get/2,3`, `get_lazy/3`, and `track/1` write the read
+  key into the slot.
+- The dynamic's deps are read back at `erlang:erase` and stored on the
+  snapshot (parallel to `d`).
+
+**Per-dynamic isolation invariant:** every nested-template entry point
+runs inside `with_saved_deps/1` (`arizona_eval`), which snapshots the slot
+before entering and restores it after. Without this, an inner template's
+`?get` calls would land in the outer dynamic's slot and pollute its deps.
+Bracketed entry points and what each covers:
+
+- `eval_template` -- the inner template's per-dynamic eval loop
+- `eval_each` -- per-item rendering (list, stream, map sources)
+- `eval_stateful` -- the whole lifecycle: `mount/1` / `handle_update/2`,
+  `render/1`, and the inner per-dynamic eval loop
+- the stateless inline path -- the entire `eval_val_v` recursion for
+  `#{callback := _, props := _}` descriptors, including the callback
+  body and any subsequent unwrapping
+
+Inner *dynamics* re-bracket their own slot via `eval_one_v`, so
+per-inner-dynamic deps are independent of outer.
+
+**Usage convention:** outer-scope `?get` reads belong in the props
+expression of `?stateful`/`?stateless` -- the parse transform places them
+in the outer dynamic's closure, where they track correctly. Eager `?get`
+calls inside a `?stateless` callback body, or inside a stateful's
+`mount/1` / `handle_update/2`, are discarded by the wrap; this is
+intentional -- those reads belong to the inner scope. Idiomatic callbacks
+use a named fun reference (`?stateless(fun bar/1, Props)`), which cannot
+close over outer `Bindings` and therefore avoids the footgun entirely.
+
 ## API -- `arizona_js.erl`
 
 Unified client commands and server effects. All functions return `{arizona_js, [OpCode, ...Args]}`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -86,18 +86,18 @@ the `Changed` map and skips re-evaluation when they don't intersect.
 
 The mechanism is a single process-dictionary slot, `'$arizona_deps'`:
 
-- `arizona_eval:eval_one_v/2` brackets each dynamic with
+- `eval_one_v` (in `arizona_eval`) brackets each dynamic with
   `erlang:put('$arizona_deps', #{})` at entry and `erlang:erase` at exit.
-- `arizona_template:get/2,3`, `get_lazy/3`, and `track/1` write the read
-  key into the slot.
+- `arizona_template:get/2,3`, `arizona_template:get_lazy/3`, and
+  `arizona_template:track/1` write the read key into the slot.
 - The dynamic's deps are read back at `erlang:erase` and stored on the
   snapshot (parallel to `d`).
 
 **Per-dynamic isolation invariant:** every nested-template entry point
-runs inside `with_saved_deps/1` (`arizona_eval`), which snapshots the slot
-before entering and restores it after. Without this, an inner template's
-`?get` calls would land in the outer dynamic's slot and pollute its deps.
-Bracketed entry points and what each covers:
+runs inside a `with_saved_deps` wrapper (in `arizona_eval`), which
+snapshots the slot before entering and restores it after. Without this,
+an inner template's `?get` calls would land in the outer dynamic's slot
+and pollute its deps. Bracketed entry points and what each covers:
 
 - `eval_template` -- the inner template's per-dynamic eval loop
 - `eval_each` -- per-item rendering (list, stream, map sources)
@@ -107,8 +107,8 @@ Bracketed entry points and what each covers:
   `#{callback := _, props := _}` descriptors, including the callback
   body and any subsequent unwrapping
 
-Inner *dynamics* re-bracket their own slot via `eval_one_v`, so
-per-inner-dynamic deps are independent of outer.
+Inner *dynamics* re-bracket their own slot, so per-inner-dynamic deps are
+independent of outer.
 
 **Usage convention:** outer-scope `?get` reads belong in the props
 expression of `?stateful`/`?stateless` -- the parse transform places them

--- a/src/arizona_diff.erl
+++ b/src/arizona_diff.erl
@@ -305,6 +305,14 @@ carry_item_children(ChildViewIds, Old, New) ->
         ChildViewIds
     ).
 
+-doc """
+Returns `true` when any key in `Deps` also appears in `Changed`. Used by
+`diff/4` and the per-item skipping renderer to decide whether a dynamic
+needs re-evaluation.
+""".
+-spec deps_changed(Deps, Changed) -> boolean() when
+    Deps :: map(),
+    Changed :: map().
 deps_changed(Deps, Changed) ->
     map_size(maps:intersect(Deps, Changed)) > 0.
 

--- a/src/arizona_diff.erl
+++ b/src/arizona_diff.erl
@@ -370,8 +370,8 @@ diff_stream_op(Az, {move, Key, AfterKey}, Rest, Source, Tmpl, SnapAcc, OldOrder,
     stream_move(Az, Key, AfterKey, Rest, Source, Tmpl, SnapAcc, OldOrder, Views);
 diff_stream_op(Az, reorder, Rest, Source, Tmpl, SnapAcc, OldOrder, Views) ->
     stream_reorder(Az, Rest, Source, Tmpl, SnapAcc, OldOrder, Views);
-diff_stream_op(Az, reset, Rest, Source, Tmpl, SnapAcc, OldOrder, Views) ->
-    stream_reset(Az, Rest, Source, Tmpl, SnapAcc, OldOrder, Views).
+diff_stream_op(Az, {reset, OldItems}, Rest, Source, Tmpl, SnapAcc, OldOrder, Views) ->
+    stream_reset(Az, OldItems, Rest, Source, Tmpl, SnapAcc, OldOrder, Views).
 
 stream_insert(Az, Key, Item, Pos, Rest, Source, Tmpl, SnapAcc, OldOrder, Views0) ->
     {ItemD, Views1} = arizona_eval:render_stream_item(Key, Item, Tmpl, Views0),
@@ -447,7 +447,7 @@ stream_reorder(Az, Rest, Source, Tmpl, SnapAcc, OldOrder, Views0) ->
         diff_stream_pending(Az, Rest, Source, Tmpl, SnapAcc, VKeys, Views0),
     {MoveOps ++ RestOps, FinalSnap, Views1}.
 
-stream_reset(Az, Rest, Source, Tmpl, SnapAcc, OldOrder, Views0) ->
+stream_reset(Az, OldItems, Rest, Source, Tmpl, SnapAcc, OldOrder, Views0) ->
     VKeys = arizona_template:visible_keys(Source#stream.order, Source#stream.limit),
     VSet = maps:from_keys(VKeys, true),
     RemOps = [
@@ -456,7 +456,7 @@ stream_reset(Az, Rest, Source, Tmpl, SnapAcc, OldOrder, Views0) ->
     ],
     Kept = maps:with(VKeys, SnapAcc),
     {DiffOps, NewSnaps, Views1} =
-        smart_reset_items(Az, VKeys, Kept, Source#stream.items, Tmpl, Views0, #{}),
+        smart_reset_items(Az, VKeys, Kept, OldItems, Source#stream.items, Tmpl, Views0, #{}),
     MoveOps = compute_reorder_ops(Az, OldOrder, VKeys, Kept),
     {RestOps, FinalSnap, Views2} =
         diff_stream_pending(Az, Rest, Source, Tmpl, NewSnaps, VKeys, Views1),
@@ -496,54 +496,52 @@ diff_list_zip(Az, [NewD | NR], [OldD | OR], Views0) ->
 diff_list_zip(_Az, NewTail, OldTail, Views) ->
     {[], NewTail, OldTail, Views}.
 
-smart_reset_items(_Az, [], _Kept, _ItemsMap, _Tmpl, Views, Snaps) ->
+smart_reset_items(_Az, [], _Kept, _OldItems, _ItemsMap, _Tmpl, Views, Snaps) ->
     {[], Snaps, Views};
-smart_reset_items(Az, [K | Rest], Kept, ItemsMap, Tmpl, Views0, Snaps) ->
-    Item = maps:get(K, ItemsMap),
-    {NewD, Views1} = arizona_eval:render_stream_item(K, Item, Tmpl, Views0),
-    NewSnaps = Snaps#{K => NewD},
+smart_reset_items(Az, [K | Rest], Kept, OldItems, ItemsMap, Tmpl, Views0, Snaps) ->
+    NewItem = maps:get(K, ItemsMap),
     case Kept of
         #{K := OldD} ->
+            {NewD, Views1} =
+                render_kept_with_skipping(K, NewItem, OldD, OldItems, Tmpl, Views0),
+            NewSnaps = Snaps#{K => NewD},
             {InnerOps, Views2} = diff_item_dynamics_v(NewD, OldD, Views1),
             case InnerOps of
                 [] ->
                     smart_reset_items(
-                        Az,
-                        Rest,
-                        Kept,
-                        ItemsMap,
-                        Tmpl,
-                        Views2,
-                        NewSnaps
+                        Az, Rest, Kept, OldItems, ItemsMap, Tmpl, Views2, NewSnaps
                     );
                 _ ->
                     PatchOp = [?OP_ITEM_PATCH, Az, arizona_template:to_bin(K), InnerOps],
                     {RestOps, FinalSnaps, Views3} =
                         smart_reset_items(
-                            Az,
-                            Rest,
-                            Kept,
-                            ItemsMap,
-                            Tmpl,
-                            Views2,
-                            NewSnaps
+                            Az, Rest, Kept, OldItems, ItemsMap, Tmpl, Views2, NewSnaps
                         ),
                     {[PatchOp | RestOps], FinalSnaps, Views3}
             end;
         #{} ->
+            {NewD, Views1} = arizona_eval:render_stream_item(K, NewItem, Tmpl, Views0),
+            NewSnaps = Snaps#{K => NewD},
             HTML = arizona_render:zip_item(Tmpl, NewD),
             InsOp = [?OP_INSERT, Az, arizona_template:to_bin(K), -1, HTML],
             {RestOps, FinalSnaps, Views2} =
                 smart_reset_items(
-                    Az,
-                    Rest,
-                    Kept,
-                    ItemsMap,
-                    Tmpl,
-                    Views1,
-                    NewSnaps
+                    Az, Rest, Kept, OldItems, ItemsMap, Tmpl, Views1, NewSnaps
                 ),
             {[InsOp | RestOps], FinalSnaps, Views2}
+    end.
+
+%% Render a kept item via the per-item skipping path when its old source
+%% is recoverable from the captured `OldItems`. Falls back to a full
+%% render if the key wasn't in the pre-reset items map (rare: limit-hidden
+%% then re-shown).
+render_kept_with_skipping(K, NewItem, OldD, OldItems, Tmpl, Views0) ->
+    case OldItems of
+        #{K := OldItem} ->
+            Changed = arizona_stream:compute_item_changed(OldItem, NewItem),
+            arizona_eval:render_stream_item_skipping(K, NewItem, OldD, Changed, Tmpl, Views0);
+        #{} ->
+            arizona_eval:render_stream_item(K, NewItem, Tmpl, Views0)
     end.
 
 apply_limit(

--- a/src/arizona_diff.erl
+++ b/src/arizona_diff.erl
@@ -308,13 +308,28 @@ carry_item_children(ChildViewIds, Old, New) ->
 -doc """
 Returns `true` when any key in `Deps` also appears in `Changed`. Used by
 `diff/4` and the per-item skipping renderer to decide whether a dynamic
-needs re-evaluation.
+needs re-evaluation. Walks the smaller map and probes the larger via
+`is_map_key/2` -- avoids the allocation of `maps:intersect/2`.
 """.
 -spec deps_changed(Deps, Changed) -> boolean() when
     Deps :: map(),
     Changed :: map().
 deps_changed(Deps, Changed) ->
-    map_size(maps:intersect(Deps, Changed)) > 0.
+    case map_size(Deps) =< map_size(Changed) of
+        true -> any_key_in(Deps, Changed);
+        false -> any_key_in(Changed, Deps)
+    end.
+
+any_key_in(Small, Large) ->
+    any_key_in_iter(maps:next(maps:iterator(Small)), Large).
+
+any_key_in_iter(none, _Large) ->
+    false;
+any_key_in_iter({K, _V, Iter}, Large) ->
+    case is_map_key(K, Large) of
+        true -> true;
+        false -> any_key_in_iter(maps:next(Iter), Large)
+    end.
 
 diff_stream(
     Az,

--- a/src/arizona_diff.erl
+++ b/src/arizona_diff.erl
@@ -45,6 +45,7 @@ never reach op-code targets.
 -export([diff/2]).
 -export([diff/3]).
 -export([diff/4]).
+-export([deps_changed/2]).
 
 %% --------------------------------------------------------------------
 %% Ignore xref warnings
@@ -284,7 +285,7 @@ deleted_item_children(Pending, OldItems) ->
 item_child_views(ItemD, Acc) ->
     lists:foldl(
         fun
-            ({_Az, #{view_id := VId}}, A) -> [VId | A];
+            ({_Az, #{view_id := VId}, _Deps}, A) -> [VId | A];
             (_, A) -> A
         end,
         Acc,
@@ -355,8 +356,8 @@ diff_stream_op(Az, {insert, Key, Item, Pos}, Rest, Source, Tmpl, SnapAcc, OldOrd
     stream_insert(Az, Key, Item, Pos, Rest, Source, Tmpl, SnapAcc, OldOrder, Views);
 diff_stream_op(Az, {delete, Key}, Rest, Source, Tmpl, SnapAcc, OldOrder, Views) ->
     stream_delete(Az, Key, Rest, Source, Tmpl, SnapAcc, OldOrder, Views);
-diff_stream_op(Az, {update, Key, NewItem}, Rest, Source, Tmpl, SnapAcc, OldOrder, Views) ->
-    stream_update(Az, Key, NewItem, Rest, Source, Tmpl, SnapAcc, OldOrder, Views);
+diff_stream_op(Az, {update, Key, NewItem, Changed}, Rest, Source, Tmpl, SnapAcc, OldOrder, Views) ->
+    stream_update(Az, Key, NewItem, Changed, Rest, Source, Tmpl, SnapAcc, OldOrder, Views);
 diff_stream_op(Az, {move, Key, AfterKey}, Rest, Source, Tmpl, SnapAcc, OldOrder, Views) ->
     stream_move(Az, Key, AfterKey, Rest, Source, Tmpl, SnapAcc, OldOrder, Views);
 diff_stream_op(Az, reorder, Rest, Source, Tmpl, SnapAcc, OldOrder, Views) ->
@@ -380,14 +381,18 @@ stream_delete(Az, Key, Rest, Source, Tmpl, SnapAcc, OldOrder, Views0) ->
         diff_stream_pending(Az, Rest, Source, Tmpl, NewSnapAcc, OldOrder, Views0),
     {[DelOp | RestOps], FinalSnap, Views1}.
 
-stream_update(Az, Key, NewItem, Rest, Source, Tmpl, SnapAcc, OldOrder, Views0) ->
-    {NewD, Views1} = arizona_eval:render_stream_item(Key, NewItem, Tmpl, Views0),
+stream_update(Az, Key, NewItem, Changed, Rest, Source, Tmpl, SnapAcc, OldOrder, Views0) ->
     case SnapAcc of
         #{Key := OldD} ->
+            {NewD, Views1} =
+                arizona_eval:render_stream_item_skipping(
+                    Key, NewItem, OldD, Changed, Tmpl, Views0
+                ),
             stream_update_existing(
                 Az, Key, NewD, OldD, Rest, Source, Tmpl, SnapAcc, OldOrder, Views1
             );
         #{} ->
+            {NewD, Views1} = arizona_eval:render_stream_item(Key, NewItem, Tmpl, Views0),
             stream_update_missing(Az, Key, NewD, Rest, Source, Tmpl, SnapAcc, OldOrder, Views1)
     end.
 
@@ -476,7 +481,7 @@ diff_list_zip(Az, [NewD | NR], [OldD | OR], Views0) ->
             [] ->
                 RestOps;
             _ ->
-                [{_, OldKey} | _] = OldD,
+                [{_, OldKey, _} | _] = OldD,
                 [[?OP_ITEM_PATCH, Az, arizona_template:to_bin(OldKey), InnerOps] | RestOps]
         end,
     {Ops, NewTail, OldTail, Views2};
@@ -735,11 +740,11 @@ make_op(Az, New, _Old) ->
 
 diff_item_dynamics_v([], [], Views) ->
     {[], Views};
-diff_item_dynamics_v([{Az, _} | NR], [{Az, #{diff := false}} | OR], Views0) ->
+diff_item_dynamics_v([{Az, _, _} | NR], [{Az, #{diff := false}, _} | OR], Views0) ->
     diff_item_dynamics_v(NR, OR, Views0);
-diff_item_dynamics_v([{Az, Same} | NR], [{Az, Same} | OR], Views0) ->
+diff_item_dynamics_v([{Az, Same, _} | NR], [{Az, Same, _} | OR], Views0) ->
     diff_item_dynamics_v(NR, OR, Views0);
-diff_item_dynamics_v([{Az, New} | NR], [{Az, Old} | OR], Views0) ->
+diff_item_dynamics_v([{Az, New, _} | NR], [{Az, Old, _} | OR], Views0) ->
     case {New, Old} of
         {#{t := ?EACH, source := Src, template := Tmpl}, #{t := ?EACH}} ->
             EachDesc = #{source => Src, template => Tmpl},

--- a/src/arizona_eval.erl
+++ b/src/arizona_eval.erl
@@ -159,7 +159,7 @@ threading view state. Returns a `#{Key => ItemD}` map and updated views.
     ItemsMap :: #{term() => term()},
     Template :: map(),
     Views :: {map(), map()},
-    ItemSnaps :: #{term() => [{arizona_template:az(), term()}]},
+    ItemSnaps :: #{term() => [{arizona_template:az(), term(), map()}]},
     Views1 :: {map(), map()}.
 eval_stream_items(Keys, ItemsMap, Tmpl, Views) ->
     eval_stream_items(Keys, ItemsMap, Tmpl, Views, #{}).
@@ -234,7 +234,7 @@ Renders stream items without view tracking. Returns `#{Key => ItemD}`.
     Keys :: [term()],
     ItemsMap :: #{term() => term()},
     Template :: map(),
-    ItemSnaps :: #{term() => [{arizona_template:az(), term()}]}.
+    ItemSnaps :: #{term() => [{arizona_template:az(), term(), map()}]}.
 render_stream_items_simple(Keys, ItemsMap, Tmpl) ->
     render_stream_items_simple(Keys, ItemsMap, Tmpl, #{}).
 
@@ -245,7 +245,7 @@ Renders list items with view tracking. Returns `{[ItemD], Views1}`.
     Items :: [term()],
     Template :: map(),
     Views :: {map(), map()},
-    ItemDs :: [[{arizona_template:az(), term()}]],
+    ItemDs :: [[{arizona_template:az(), term(), map()}]],
     Views1 :: {map(), map()}.
 render_list_items(Items, #{d := DFun}, Views) ->
     render_list_items1(Items, DFun, Views).
@@ -256,7 +256,7 @@ Renders list items without view tracking. Returns `[ItemD]`.
 -spec render_list_items_simple(Items, Template) -> ItemDs when
     Items :: [term()],
     Template :: map(),
-    ItemDs :: [[{arizona_template:az(), term()}]].
+    ItemDs :: [[{arizona_template:az(), term(), map()}]].
 render_list_items_simple(Items, #{d := DFun}) ->
     [[{Az, Val, #{}} || {Az, Val} <- eval_dynamics(DFun(Item))] || Item <- Items].
 
@@ -266,7 +266,7 @@ Renders map entries without view tracking. Returns `[ItemD]`.
 -spec render_map_items_simple(Map, Template) -> ItemDs when
     Map :: map(),
     Template :: map(),
-    ItemDs :: [[{arizona_template:az(), term()}]].
+    ItemDs :: [[{arizona_template:az(), term(), map()}]].
 render_map_items_simple(Map, #{d := DFun}) ->
     maps:fold(
         fun(K, V, Acc) ->

--- a/src/arizona_eval.erl
+++ b/src/arizona_eval.erl
@@ -348,7 +348,10 @@ eval_val_v(#{t := ?EACH, source := #stream{} = Source, template := Tmpl}, Views)
 eval_val_v(#{t := ?EACH, source := Source, template := Tmpl}, Views) when is_map(Source) ->
     eval_each_map(Source, Tmpl, Views);
 eval_val_v(#{callback := Callback, props := Props}, Views) ->
-    eval_val_v(Callback(Props), Views);
+    %% Bracket the whole stateless recursion so eager ?get calls inside the
+    %% callback body (or any unwrapping that follows it) don't leak into the
+    %% outer dynamic's tracked deps.
+    with_saved_deps(fun() -> eval_val_v(Callback(Props), Views) end);
 eval_val_v(#{s := _, d := _} = Tmpl, Views) ->
     eval_template(Tmpl, Views);
 eval_val_v(Val, Views) ->
@@ -364,8 +367,11 @@ with_saved_deps(Fun) ->
 
 eval_stateful(H, Props, {Old, New}) ->
     Id = maps:get(id, Props),
-    {B1, Resets} = mount_or_update_stateful(H, Props, Id, Old),
+    %% Bracket the whole lifecycle. mount/1 and handle_update/2 callbacks
+    %% are user code; their ?get calls would otherwise land in the outer
+    %% dynamic's tracked deps.
     with_saved_deps(fun() ->
+        {B1, Resets} = mount_or_update_stateful(H, Props, Id, Old),
         Tmpl = arizona_handler:call_render(H, B1),
         {ChildTriples, {Old, New1}} = eval_dynamics_v(maps:get(d, Tmpl), {Old, New}),
         {ChildD, ChildDeps} = arizona_template:split_triples(ChildTriples),

--- a/src/arizona_eval.erl
+++ b/src/arizona_eval.erl
@@ -52,6 +52,7 @@ cannot modify framework-owned bindings like `id`. Violations raise
 -export([eval_each_def/1]).
 -export([eval_stream_items/4]).
 -export([render_stream_item/4]).
+-export([render_stream_item_skipping/6]).
 -export([render_stream_items_simple/3]).
 -export([render_list_items/3]).
 -export([render_list_items_simple/2]).
@@ -165,20 +166,66 @@ eval_stream_items(Keys, ItemsMap, Tmpl, Views) ->
 
 -doc """
 Renders a single stream item by evaluating its dynamics with view tracking.
-Returns `{ItemD, Views1}` where `ItemD` is `[{Az, Value}]`.
+Returns `{ItemD, Views1}` where `ItemD` is `[{Az, Value, Deps}]`.
 """.
 -spec render_stream_item(Key, Item, Template, Views) -> {ItemD, Views1} when
     Key :: term(),
     Item :: term(),
     Template :: map(),
     Views :: {map(), map()},
-    ItemD :: [{arizona_template:az(), term()}],
+    ItemD :: [{arizona_template:az(), term(), map()}],
     Views1 :: {map(), map()}.
 render_stream_item(Key, Item, #{d := DFun}, Views0) ->
     Dynamics = DFun(Item, Key),
-    {Triples, Views1} = eval_dynamics_v(Dynamics, Views0),
-    D = [{Az, Val} || {Az, Val, _Deps} <:- Triples],
-    {D, Views1}.
+    eval_dynamics_v(Dynamics, Views0).
+
+-doc """
+Re-renders a stream item using `Changed` (set of fields differing between
+old and new item) and the previous `OldItemD` to skip per-item dynamics
+whose deps don't intersect with `Changed`. Reused dynamics carry their
+old `{Az, Val, Deps}` triple, so the downstream value comparison emits
+no op for them.
+""".
+-spec render_stream_item_skipping(Key, NewItem, OldItemD, Changed, Template, Views) ->
+    {ItemD, Views1}
+when
+    Key :: term(),
+    NewItem :: term(),
+    OldItemD :: [{arizona_template:az(), term(), map()}],
+    Changed :: map(),
+    Template :: map(),
+    Views :: {map(), map()},
+    ItemD :: [{arizona_template:az(), term(), map()}],
+    Views1 :: {map(), map()}.
+render_stream_item_skipping(Key, NewItem, OldItemD, Changed, #{d := DFun}, Views0) ->
+    case map_size(Changed) of
+        0 ->
+            %% No fields differ -- old item triples are reusable as-is.
+            {OldItemD, Views0};
+        _ ->
+            Dynamics = DFun(NewItem, Key),
+            eval_or_reuse_per_item(Dynamics, OldItemD, Changed, Views0)
+    end.
+
+%% Empty per-item deps mean either "static" or "uses pattern destructure"
+%% (e.g. `fun(#{text := T}, _) -> {li, [], T} end`). We can't tell, so we
+%% must re-evaluate to be safe. Skipping is only sound when deps are
+%% explicit and don't intersect Changed.
+eval_or_reuse_per_item([], [], _Changed, Views) ->
+    {[], Views};
+eval_or_reuse_per_item([Def | DR], [{Az, OldVal, OldDeps} | OR], Changed, Views0) ->
+    case can_reuse(OldDeps, Changed) of
+        true ->
+            {Rest, Views1} = eval_or_reuse_per_item(DR, OR, Changed, Views0),
+            {[{Az, OldVal, OldDeps} | Rest], Views1};
+        false ->
+            {NewAz, NewVal, NewDeps, Views1} = eval_one_v_flat(Def, Views0),
+            {Rest, Views2} = eval_or_reuse_per_item(DR, OR, Changed, Views1),
+            {[{NewAz, NewVal, NewDeps} | Rest], Views2}
+    end.
+
+can_reuse(OldDeps, Changed) ->
+    map_size(OldDeps) > 0 andalso not arizona_diff:deps_changed(OldDeps, Changed).
 
 -doc """
 Renders stream items without view tracking. Returns `#{Key => ItemD}`.
@@ -211,7 +258,7 @@ Renders list items without view tracking. Returns `[ItemD]`.
     Template :: map(),
     ItemDs :: [[{arizona_template:az(), term()}]].
 render_list_items_simple(Items, #{d := DFun}) ->
-    [eval_dynamics(DFun(Item)) || Item <- Items].
+    [[{Az, Val, #{}} || {Az, Val} <- eval_dynamics(DFun(Item))] || Item <- Items].
 
 -doc """
 Renders map entries without view tracking. Returns `[ItemD]`.
@@ -222,7 +269,9 @@ Renders map entries without view tracking. Returns `[ItemD]`.
     ItemDs :: [[{arizona_template:az(), term()}]].
 render_map_items_simple(Map, #{d := DFun}) ->
     maps:fold(
-        fun(K, V, Acc) -> [eval_dynamics(DFun(K, V)) | Acc] end,
+        fun(K, V, Acc) ->
+            [[{Az, Val, #{}} || {Az, Val} <- eval_dynamics(DFun(K, V))] | Acc]
+        end,
         [],
         Map
     ).
@@ -421,8 +470,7 @@ render_map_items(Map, #{d := DFun}, Views) ->
         fun(K, V, {Acc, V0}) ->
             Dynamics = DFun(K, V),
             {Triples, V1} = eval_dynamics_v(Dynamics, V0),
-            D = [{Az, Val} || {Az, Val, _Deps} <:- Triples],
-            {[D | Acc], V1}
+            {[Triples | Acc], V1}
         end,
         {[], Views},
         Map
@@ -470,16 +518,15 @@ render_stream_items_simple([K | Rest], ItemsMap, Tmpl, Acc) ->
 
 render_stream_item_simple(Key, Item, #{d := DFun}) ->
     Dynamics = DFun(Item, Key),
-    eval_dynamics(Dynamics).
+    [{Az, Val, #{}} || {Az, Val} <- eval_dynamics(Dynamics)].
 
 render_list_items1([], _DFun, Views) ->
     {[], Views};
 render_list_items1([Item | Rest], DFun, Views0) ->
     Dynamics = DFun(Item),
     {Triples, Views1} = eval_dynamics_v(Dynamics, Views0),
-    D = [{Az, Val} || {Az, Val, _Deps} <:- Triples],
     {RestD, Views2} = render_list_items1(Rest, DFun, Views1),
-    {[D | RestD], Views2}.
+    {[Triples | RestD], Views2}.
 
 -ifdef(TEST).
 
@@ -520,7 +567,7 @@ eval_map_simple_test() ->
     %% Each item has key and value dynamics
     lists:foreach(
         fun(Item) ->
-            [{~"0", Key}, {~"1", Val}] = Item,
+            [{~"0", Key, _}, {~"1", Val, _}] = Item,
             ?assert(is_binary(Key)),
             ?assert(is_binary(Val))
         end,
@@ -543,7 +590,7 @@ eval_map_single_entry_test() ->
         d => fun(K, V) -> [{~"0", fun() -> K end}, {~"1", fun() -> V end}] end,
         f => ~"test"
     },
-    [[{~"0", ~"x"}, {~"1", ~"1"}]] = render_map_items_simple(#{~"x" => ~"1"}, Tmpl).
+    [[{~"0", ~"x", _}, {~"1", ~"1", _}]] = render_map_items_simple(#{~"x" => ~"1"}, Tmpl).
 
 eval_map_with_views_test() ->
     Map = #{~"a" => ~"1"},

--- a/src/arizona_render.erl
+++ b/src/arizona_render.erl
@@ -242,15 +242,15 @@ If the template has a fingerprint, returns a wire-format map keyed by
 """.
 -spec zip_item(Template, Dynamics) -> map() | binary() when
     Template :: map(),
-    Dynamics :: [{arizona_template:az(), term()}].
+    Dynamics :: [{arizona_template:az(), term(), map()}].
 zip_item(#{f := F, s := S}, D) ->
     #{
         ~"f" => F,
         ~"s" => S,
-        ~"d" => [render_fp_val(arizona_template:unwrap_val(V)) || {_Az, V} <:- D]
+        ~"d" => [render_fp_val(arizona_template:unwrap_val(V)) || {_Az, V, _Deps} <:- D]
     };
 zip_item(#{s := S}, D) ->
-    iolist_to_binary(zip(S, [arizona_template:unwrap_val(V) || {_Az, V} <:- D])).
+    iolist_to_binary(zip(S, [arizona_template:unwrap_val(V) || {_Az, V, _Deps} <:- D])).
 
 -doc """
 Renders a snapshot to a wire-format fingerprint payload (if `f` present)
@@ -269,14 +269,14 @@ fingerprinted wire payload (if the template has `f`) or a flat HTML binary.
 """.
 -spec zip_list_fp(Template, Items) -> map() | binary() when
     Template :: map(),
-    Items :: [[{arizona_template:az(), term()}]].
+    Items :: [[{arizona_template:az(), term(), map()}]].
 zip_list_fp(#{f := F, s := S, t := T}, ItemsList) ->
     #{
         ~"t" => T,
         ~"f" => F,
         ~"s" => S,
         ~"d" => [
-            [render_fp_val(arizona_template:unwrap_val(V)) || {_Az, V} <:- D]
+            [render_fp_val(arizona_template:unwrap_val(V)) || {_Az, V, _Deps} <:- D]
          || D <- ItemsList
         ]
     };
@@ -290,7 +290,7 @@ against a template, with the same fingerprint-vs-flat-HTML branching as
 """.
 -spec zip_stream_fp(Template, Items, Order) -> map() | binary() when
     Template :: map(),
-    Items :: #{term() => [{arizona_template:az(), term()}]},
+    Items :: #{term() => [{arizona_template:az(), term(), map()}]},
     Order :: [term()].
 zip_stream_fp(#{f := F, s := S, t := T}, Items, Order) ->
     #{
@@ -300,7 +300,7 @@ zip_stream_fp(#{f := F, s := S, t := T}, Items, Order) ->
         ~"d" => [
             [
                 render_fp_val(arizona_template:unwrap_val(V))
-             || {_Az, V} <:- maps:get(K, Items)
+             || {_Az, V, _Deps} <:- maps:get(K, Items)
             ]
          || K <- Order
         ]
@@ -346,7 +346,7 @@ apply_layouts([{Mod, Fun} | Rest], Inner, Bindings) ->
     render_to_iolist(Tmpl).
 
 zip_stream_item(Statics, ItemD) ->
-    zip(Statics, [arizona_template:unwrap_val(V) || {_Az, V} <:- ItemD]).
+    zip(Statics, [arizona_template:unwrap_val(V) || {_Az, V, _Deps} <:- ItemD]).
 
 %% Az is ignored during SSR (only used for diff targeting), so `undefined` Az
 %% from az-nodiff templates flows through harmlessly.
@@ -427,7 +427,7 @@ render_fp_val(#{t := ?EACH, items := Items, template := #{f := F, t := T, s := S
         ~"f" => F,
         ~"s" => S,
         ~"d" => [
-            [render_fp_val(arizona_template:unwrap_val(V)) || {_Az, V} <:- D]
+            [render_fp_val(arizona_template:unwrap_val(V)) || {_Az, V, _Deps} <:- D]
          || D <- Items
         ]
     };
@@ -435,7 +435,7 @@ render_fp_val(#{t := ?EACH, items := Items, template := #{s := S}}) when
     is_list(Items)
 ->
     [
-        iolist_to_binary(zip(S, [arizona_template:unwrap_val(V) || {_Az, V} <:- D]))
+        iolist_to_binary(zip(S, [arizona_template:unwrap_val(V) || {_Az, V, _Deps} <:- D]))
      || D <- Items
     ];
 render_fp_val(#{
@@ -451,7 +451,7 @@ render_fp_val(#{
         ~"d" => [
             [
                 render_fp_val(arizona_template:unwrap_val(V))
-             || {_Az, V} <:- maps:get(K, Items)
+             || {_Az, V, _Deps} <:- maps:get(K, Items)
             ]
          || K <- Order
         ]

--- a/src/arizona_render.erl
+++ b/src/arizona_render.erl
@@ -89,13 +89,13 @@ op-code targets.
 
 -nominal each_list() :: #{
     t := 0,
-    items := [[{arizona_template:az(), term()}]],
+    items := [[{arizona_template:az(), term(), map()}]],
     template := arizona_template:template()
 }.
 
 -nominal each_stream() :: #{
     t := 0,
-    items := #{term() => [{arizona_template:az(), term()}]},
+    items := #{term() => [{arizona_template:az(), term(), map()}]},
     order := [term()],
     template := arizona_template:template()
 }.

--- a/src/arizona_stream.erl
+++ b/src/arizona_stream.erl
@@ -25,7 +25,7 @@ the differ knows exactly which keys to insert, remove, update, or move.
 ```
 {insert, Key, Item, Pos}
 {delete, Key}
-{update, Key, NewItem}
+{update, Key, NewItem, Changed}  %% Changed :: #{key() => true}, captured at update/3 time
 {move, Key, AfterKey}    %% AfterKey is `null` for first position
 reorder                  %% from sort/2 when order changes
 reset                    %% from reset/1,2
@@ -257,10 +257,36 @@ Replaces the item at `Key` with `NewItem` and queues an update op.
     NewItem :: item(),
     Stream1 :: stream().
 update(#stream{items = Items, pending = Pending} = S, Key, NewItem) ->
+    Changed =
+        case Items of
+            #{Key := OldItem} -> compute_item_changed(OldItem, NewItem);
+            #{} -> #{}
+        end,
     S#stream{
         items = Items#{Key => NewItem},
-        pending = queue:in({update, Key, NewItem}, Pending)
+        pending = queue:in({update, Key, NewItem, Changed}, Pending)
     }.
+
+%% Set of keys that differ between Old and New: added, removed, or value
+%% changed. Items in Arizona are maps; non-map items crash here, which is
+%% correct -- per-item dep tracking only makes sense on maps.
+compute_item_changed(OldItem, NewItem) ->
+    All = maps:merge(OldItem, NewItem),
+    maps:fold(
+        fun(K, _, Acc) ->
+            case OldItem of
+                #{K := V} ->
+                    case NewItem of
+                        #{K := V} -> Acc;
+                        #{} -> Acc#{K => true}
+                    end;
+                #{} ->
+                    Acc#{K => true}
+            end
+        end,
+        #{},
+        All
+    ).
 
 -doc """
 Moves the item with `Key` to a new zero-based position and queues a

--- a/src/arizona_stream.erl
+++ b/src/arizona_stream.erl
@@ -28,7 +28,7 @@ the differ knows exactly which keys to insert, remove, update, or move.
 {update, Key, NewItem, Changed}  %% Changed :: #{key() => true}, captured at update/3 time
 {move, Key, AfterKey}    %% AfterKey is `null` for first position
 reorder                  %% from sort/2 when order changes
-reset                    %% from reset/1,2
+{reset, OldItems}        %% from reset/1,2 -- OldItems captured pre-mutation for per-item skipping
 ```
 
 ## Example
@@ -65,6 +65,7 @@ reset                    %% from reset/1,2
 -export([get_lazy/3]).
 -export([clear_stream_pending/2]).
 -export([stream_keys/1]).
+-export([compute_item_changed/2]).
 
 %% --------------------------------------------------------------------
 %% Ignore xref warnings
@@ -267,9 +268,15 @@ update(#stream{items = Items, pending = Pending} = S, Key, NewItem) ->
         pending = queue:in({update, Key, NewItem, Changed}, Pending)
     }.
 
-%% Set of keys that differ between Old and New: added, removed, or value
-%% changed. Items in Arizona are maps; non-map items crash here, which is
-%% correct -- per-item dep tracking only makes sense on maps.
+-doc """
+Set of keys that differ between two item maps -- added, removed, or value
+changed. Used by `update/3` and the differ's reset path to drive per-item
+dynamic skipping. Items in Arizona are maps; non-map inputs crash here.
+""".
+-spec compute_item_changed(OldItem, NewItem) -> Changed when
+    OldItem :: map(),
+    NewItem :: map(),
+    Changed :: #{term() => true}.
 compute_item_changed(OldItem, NewItem) ->
     All = maps:merge(OldItem, NewItem),
     maps:fold(
@@ -327,11 +334,11 @@ Empties the stream and queues a reset op.
 -spec reset(Stream) -> Stream1 when
     Stream :: stream(),
     Stream1 :: stream().
-reset(#stream{} = S) ->
+reset(#stream{items = OldItems} = S) ->
     S#stream{
         items = #{},
         order = [],
-        pending = queue:from_list([reset]),
+        pending = queue:from_list([{reset, OldItems}]),
         size = 0
     }.
 
@@ -344,14 +351,14 @@ for the actual delta.
     Stream :: stream(),
     NewItems :: [item()],
     Stream1 :: stream().
-reset(#stream{key = KeyFun} = S, NewItems) when is_list(NewItems) ->
+reset(#stream{key = KeyFun, items = OldItems} = S, NewItems) when is_list(NewItems) ->
     Keyed = key_items(KeyFun, NewItems),
     ItemsMap = #{K => V || {K, V} <:- Keyed},
     Order = order_from_keyed(Keyed),
     S#stream{
         items = ItemsMap,
         order = Order,
-        pending = queue:from_list([reset]),
+        pending = queue:from_list([{reset, OldItems}]),
         size = map_size(ItemsMap)
     }.
 

--- a/src/arizona_template.erl
+++ b/src/arizona_template.erl
@@ -182,8 +182,11 @@ can attribute dependencies that bypass binding access.
     Key :: term().
 track(Key) ->
     case erlang:get('$arizona_deps') of
-        undefined -> ok;
-        Deps -> erlang:put('$arizona_deps', Deps#{Key => true})
+        undefined ->
+            ok;
+        Deps ->
+            erlang:put('$arizona_deps', Deps#{Key => true}),
+            ok
     end.
 
 -doc """

--- a/test/arizona_eval_SUITE.erl
+++ b/test/arizona_eval_SUITE.erl
@@ -14,17 +14,27 @@
     deeply_nested_stateless_no_leak_at_any_layer/1,
     stateless_inside_each_no_leak/1,
     stateless_callback_returning_fun_no_leak/1,
-    stateful_mount_eager_read_no_leak/1
+    stateful_mount_eager_read_no_leak/1,
+    render_stream_item_persists_deps/1,
+    render_stream_item_skipping_reuses_unchanged/1,
+    render_stream_item_skipping_full_eval_on_empty_deps/1,
+    render_stream_item_skipping_short_circuits_on_empty_changed/1
 ]).
 
 all() ->
-    [{group, eval_api}, {group, dep_isolation}].
+    [{group, eval_api}, {group, dep_isolation}, {group, per_item_optimization}].
 
 groups() ->
     [
         {eval_api, [parallel], [
             eval_each_def_3tuple,
             eval_val_stateless_descriptor
+        ]},
+        {per_item_optimization, [parallel], [
+            render_stream_item_persists_deps,
+            render_stream_item_skipping_reuses_unchanged,
+            render_stream_item_skipping_full_eval_on_empty_deps,
+            render_stream_item_skipping_short_circuits_on_empty_changed
         ]},
         {dep_isolation, [parallel], [
             stateless_callback_does_not_leak_deps,
@@ -213,6 +223,105 @@ stateful_mount_eager_read_no_leak(Config) when is_list(Config) ->
     {[{<<"0">>, _Val, OuterDeps}], _Views} =
         arizona_eval:eval_dynamics_v([Dyn], {#{}, #{}}),
     ?assertNot(maps:is_key(eager_mount_key, OuterDeps)).
+
+%% --- per-item optimization (?each Levels 1+2) ---
+
+%% Per-item rendering returns 3-tuples carrying deps captured during eval.
+render_stream_item_persists_deps(Config) when is_list(Config) ->
+    Tmpl = #{
+        t => 0,
+        s => [<<"<li>">>, <<"</li>">>],
+        d => fun(Item, _Key) ->
+            [{<<"0">>, fun() -> arizona_template:get(text, Item) end, {?MODULE, ?LINE}}]
+        end,
+        f => <<"x">>
+    },
+    Item = #{text => <<"hello">>},
+    {[{<<"0">>, <<"hello">>, Deps}], _Views} =
+        arizona_eval:render_stream_item(1, Item, Tmpl, {#{}, #{}}),
+    ?assert(maps:is_key(text, Deps)).
+
+%% A dynamic that explicitly tracks `text` is reused (not re-evaluated)
+%% when only an unrelated key changes.
+render_stream_item_skipping_reuses_unchanged(Config) when is_list(Config) ->
+    Counter = counters:new(1, []),
+    Tmpl = #{
+        t => 0,
+        s => [<<"<li>">>, <<"</li>">>],
+        d => fun(Item, _Key) ->
+            [
+                {<<"0">>,
+                    fun() ->
+                        ok = counters:add(Counter, 1, 1),
+                        arizona_template:get(text, Item)
+                    end,
+                    {?MODULE, ?LINE}}
+            ]
+        end,
+        f => <<"x">>
+    },
+    OldItem = #{text => <<"hello">>, other => 1},
+    NewItem = #{text => <<"hello">>, other => 2},
+    {OldD, _} = arizona_eval:render_stream_item(1, OldItem, Tmpl, {#{}, #{}}),
+    1 = counters:get(Counter, 1),
+    Changed = #{other => true},
+    {NewD, _} =
+        arizona_eval:render_stream_item_skipping(1, NewItem, OldD, Changed, Tmpl, {#{}, #{}}),
+    %% Counter still 1 -- the closure was NOT invoked the second time.
+    1 = counters:get(Counter, 1),
+    %% New triple is the exact same triple as before (reused as-is).
+    ?assertEqual(OldD, NewD).
+
+%% A dynamic without explicit ?get tracking (e.g. pattern destructure) has
+%% empty deps -- skipping is unsafe, so re-eval happens on any non-empty
+%% Changed.
+render_stream_item_skipping_full_eval_on_empty_deps(Config) when is_list(Config) ->
+    Tmpl = #{
+        t => 0,
+        s => [<<"<li>">>, <<"</li>">>],
+        d => fun(#{text := Text}, _Key) ->
+            [{<<"0">>, fun() -> Text end, {?MODULE, ?LINE}}]
+        end,
+        f => <<"x">>
+    },
+    OldItem = #{text => <<"old">>},
+    NewItem = #{text => <<"new">>},
+    {OldD, _} = arizona_eval:render_stream_item(1, OldItem, Tmpl, {#{}, #{}}),
+    [{<<"0">>, <<"old">>, EmptyDeps}] = OldD,
+    ?assertEqual(#{}, EmptyDeps),
+    Changed = #{text => true},
+    {NewD, _} =
+        arizona_eval:render_stream_item_skipping(1, NewItem, OldD, Changed, Tmpl, {#{}, #{}}),
+    %% Empty deps -> always re-eval, so we get the new value.
+    [{<<"0">>, <<"new">>, _}] = NewD.
+
+%% When Changed is empty, the whole item snapshot is reused without invoking
+%% any per-item closure.
+render_stream_item_skipping_short_circuits_on_empty_changed(Config) when is_list(Config) ->
+    Counter = counters:new(1, []),
+    Tmpl = #{
+        t => 0,
+        s => [<<"<li>">>, <<"</li>">>],
+        d => fun(Item, _Key) ->
+            [
+                {<<"0">>,
+                    fun() ->
+                        ok = counters:add(Counter, 1, 1),
+                        arizona_template:get(text, Item)
+                    end,
+                    {?MODULE, ?LINE}}
+            ]
+        end,
+        f => <<"x">>
+    },
+    OldItem = #{text => <<"hello">>},
+    {OldD, _} = arizona_eval:render_stream_item(1, OldItem, Tmpl, {#{}, #{}}),
+    1 = counters:get(Counter, 1),
+    {NewD, _} =
+        arizona_eval:render_stream_item_skipping(1, OldItem, OldD, #{}, Tmpl, {#{}, #{}}),
+    %% Empty Changed -> short-circuit, no closure invocation.
+    1 = counters:get(Counter, 1),
+    ?assertEqual(OldD, NewD).
 
 %% A callback that returns a 0-arity fun (which eval_val_v then unwraps via
 %% its is_function/0 clause) must not leak the fun-body's reads into the

--- a/test/arizona_eval_SUITE.erl
+++ b/test/arizona_eval_SUITE.erl
@@ -5,19 +5,41 @@
 -export([all/0, groups/0]).
 -export([
     eval_each_def_3tuple/1,
-    eval_val_stateless_descriptor/1
+    eval_val_stateless_descriptor/1,
+    stateless_callback_does_not_leak_deps/1,
+    stateless_callback_with_no_eager_reads/1,
+    stateless_callback_eager_reads_dropped_outer_reads_kept/1,
+    stateless_callback_multiple_eager_reads_all_dropped/1,
+    adjacent_dynamics_have_independent_deps/1,
+    deeply_nested_stateless_no_leak_at_any_layer/1,
+    stateless_inside_each_no_leak/1,
+    stateless_callback_returning_fun_no_leak/1,
+    stateful_mount_eager_read_no_leak/1
 ]).
 
 all() ->
-    [{group, tests}].
+    [{group, eval_api}, {group, dep_isolation}].
 
 groups() ->
     [
-        {tests, [parallel], [
+        {eval_api, [parallel], [
             eval_each_def_3tuple,
             eval_val_stateless_descriptor
+        ]},
+        {dep_isolation, [parallel], [
+            stateless_callback_does_not_leak_deps,
+            stateless_callback_with_no_eager_reads,
+            stateless_callback_eager_reads_dropped_outer_reads_kept,
+            stateless_callback_multiple_eager_reads_all_dropped,
+            adjacent_dynamics_have_independent_deps,
+            deeply_nested_stateless_no_leak_at_any_layer,
+            stateless_inside_each_no_leak,
+            stateless_callback_returning_fun_no_leak,
+            stateful_mount_eager_read_no_leak
         ]}
     ].
+
+%% --- eval API ---
 
 eval_each_def_3tuple(Config) when is_list(Config) ->
     %% eval_each_def with 3-tuple location
@@ -40,3 +62,170 @@ eval_val_stateless_descriptor(Config) when is_list(Config) ->
     Dyn = {<<"0">>, fun() -> Descriptor end},
     [{<<"0">>, Result}] = arizona_eval:eval_dynamics([Dyn]),
     ?assertMatch(#{s := [<<"<b>">>, <<"</b>">>], d := [{<<"0">>, <<"hello">>}]}, Result).
+
+%% --- dep isolation in nested templates ---
+
+%% A stateless callback that eagerly reads a binding BEFORE returning the
+%% inner template must not pollute the outer dynamic's deps.
+stateless_callback_does_not_leak_deps(Config) when is_list(Config) ->
+    Callback = fun(_Props) ->
+        eager_value = arizona_template:get(eager_key, #{eager_key => eager_value}),
+        #{s => [<<"<b>">>, <<"</b>">>], d => [{<<"0">>, <<"hi">>}], f => <<"t1">>}
+    end,
+    Descriptor = #{callback => Callback, props => #{}},
+    Dyn = {<<"0">>, fun() -> Descriptor end, {?MODULE, ?LINE}},
+    {[{<<"0">>, _Val, OuterDeps}], _Views} =
+        arizona_eval:eval_dynamics_v([Dyn], {#{}, #{}}),
+    ?assertNot(maps:is_key(eager_key, OuterDeps)).
+
+%% Happy-path sanity: a callback that does no eager reads still produces an
+%% empty deps map for the outer dynamic and renders correctly.
+stateless_callback_with_no_eager_reads(Config) when is_list(Config) ->
+    Callback = fun(Props) ->
+        Title = maps:get(title, Props),
+        #{s => [<<"<b>">>, <<"</b>">>], d => [{<<"0">>, Title}], f => <<"t1">>}
+    end,
+    Descriptor = #{callback => Callback, props => #{title => <<"hi">>}},
+    Dyn = {<<"0">>, fun() -> Descriptor end, {?MODULE, ?LINE}},
+    {[{<<"0">>, Val, OuterDeps}], _Views} =
+        arizona_eval:eval_dynamics_v([Dyn], {#{}, #{}}),
+    ?assertEqual(#{}, OuterDeps),
+    ?assertMatch(#{s := [<<"<b>">>, <<"</b>">>]}, Val).
+
+%% Outer-level reads (those happening in the outer dynamic's closure body
+%% before the descriptor is constructed) MUST be tracked. Only callback-body
+%% eager reads should be discarded.
+stateless_callback_eager_reads_dropped_outer_reads_kept(Config) when is_list(Config) ->
+    Dyn =
+        {<<"0">>,
+            fun() ->
+                outer_value = arizona_template:get(outer_key, #{outer_key => outer_value}),
+                Callback = fun(_Props) ->
+                    eager_value = arizona_template:get(eager_key, #{eager_key => eager_value}),
+                    #{
+                        s => [<<"<b>">>, <<"</b>">>],
+                        d => [{<<"0">>, <<"hi">>}],
+                        f => <<"t1">>
+                    }
+                end,
+                #{callback => Callback, props => #{}}
+            end,
+            {?MODULE, ?LINE}},
+    {[{<<"0">>, _Val, OuterDeps}], _Views} =
+        arizona_eval:eval_dynamics_v([Dyn], {#{}, #{}}),
+    ?assert(maps:is_key(outer_key, OuterDeps)),
+    ?assertNot(maps:is_key(eager_key, OuterDeps)).
+
+%% Multiple eager reads in a single callback body are all discarded together.
+stateless_callback_multiple_eager_reads_all_dropped(Config) when is_list(Config) ->
+    Callback = fun(_Props) ->
+        a = arizona_template:get(eager_a, #{eager_a => a}),
+        b = arizona_template:get(eager_b, #{eager_b => b}),
+        c = arizona_template:get(eager_c, #{eager_c => c}),
+        #{s => [<<"<b>">>, <<"</b>">>], d => [{<<"0">>, <<"hi">>}], f => <<"t1">>}
+    end,
+    Descriptor = #{callback => Callback, props => #{}},
+    Dyn = {<<"0">>, fun() -> Descriptor end, {?MODULE, ?LINE}},
+    {[{<<"0">>, _Val, OuterDeps}], _Views} =
+        arizona_eval:eval_dynamics_v([Dyn], {#{}, #{}}),
+    ?assertEqual(#{}, OuterDeps).
+
+%% Two adjacent dynamics: one with a leaky callback, one normal. The leaky
+%% callback must not pollute the second dynamic's deps slot either.
+adjacent_dynamics_have_independent_deps(Config) when is_list(Config) ->
+    LeakyCallback = fun(_Props) ->
+        leak_value = arizona_template:get(leak_key, #{leak_key => leak_value}),
+        #{s => [<<"<b>">>, <<"</b>">>], d => [{<<"0">>, <<"hi">>}], f => <<"t1">>}
+    end,
+    Dyn1 =
+        {<<"0">>, fun() -> #{callback => LeakyCallback, props => #{}} end, {?MODULE, ?LINE}},
+    Dyn2 =
+        {<<"1">>,
+            fun() ->
+                normal_value = arizona_template:get(normal_key, #{normal_key => normal_value}),
+                <<"static-value">>
+            end,
+            {?MODULE, ?LINE}},
+    {[{<<"0">>, _, Deps0}, {<<"1">>, _, Deps1}], _Views} =
+        arizona_eval:eval_dynamics_v([Dyn1, Dyn2], {#{}, #{}}),
+    ?assertEqual(#{}, Deps0),
+    ?assertEqual(#{normal_key => true}, Deps1).
+
+%% Three layers of stateless nesting, each with its own eager read in the
+%% callback body. None of the eager reads should leak to any ancestor's deps.
+deeply_nested_stateless_no_leak_at_any_layer(Config) when is_list(Config) ->
+    InnerMost = fun(_P) ->
+        c = arizona_template:get(inner_c_key, #{inner_c_key => c}),
+        #{s => [<<"<i>">>, <<"</i>">>], d => [{<<"0">>, <<"deep">>}], f => <<"t-c">>}
+    end,
+    Middle = fun(_P) ->
+        b = arizona_template:get(inner_b_key, #{inner_b_key => b}),
+        #{
+            s => [<<"<m>">>, <<"</m>">>],
+            d => [{<<"0">>, fun() -> #{callback => InnerMost, props => #{}} end, {?MODULE, ?LINE}}],
+            f => <<"t-b">>
+        }
+    end,
+    Outer = fun(_P) ->
+        a = arizona_template:get(inner_a_key, #{inner_a_key => a}),
+        #{
+            s => [<<"<o>">>, <<"</o>">>],
+            d => [{<<"0">>, fun() -> #{callback => Middle, props => #{}} end, {?MODULE, ?LINE}}],
+            f => <<"t-a">>
+        }
+    end,
+    Dyn =
+        {<<"0">>, fun() -> #{callback => Outer, props => #{}} end, {?MODULE, ?LINE}},
+    {[{<<"0">>, _Val, OuterDeps}], _Views} =
+        arizona_eval:eval_dynamics_v([Dyn], {#{}, #{}}),
+    ?assertNot(maps:is_key(inner_a_key, OuterDeps)),
+    ?assertNot(maps:is_key(inner_b_key, OuterDeps)),
+    ?assertNot(maps:is_key(inner_c_key, OuterDeps)).
+
+%% A ?each whose item template embeds a stateless with a leaky callback. The
+%% outer dynamic's deps should not contain the per-item callback's eager reads.
+stateless_inside_each_no_leak(Config) when is_list(Config) ->
+    Callback = fun(_Props) ->
+        x = arizona_template:get(eager_each_key, #{eager_each_key => x}),
+        #{s => [<<"<b>">>, <<"</b>">>], d => [{<<"0">>, <<"hi">>}], f => <<"t1">>}
+    end,
+    Items = [#{n => 1}, #{n => 2}],
+    ItemTmpl = #{
+        t => 0,
+        s => [<<"<li>">>],
+        d => fun(_I) ->
+            [{<<"0">>, fun() -> #{callback => Callback, props => #{}} end, {?MODULE, ?LINE}}]
+        end,
+        f => <<"e">>
+    },
+    Dyn =
+        {<<"0">>, fun() -> arizona_template:each(Items, ItemTmpl) end, {?MODULE, ?LINE}},
+    {[{<<"0">>, _Val, OuterDeps}], _Views} =
+        arizona_eval:eval_dynamics_v([Dyn], {#{}, #{}}),
+    ?assertNot(maps:is_key(eager_each_key, OuterDeps)).
+
+%% A stateful handler whose mount/1 callback does an eager binding read
+%% must not pollute the outer dynamic's deps. mount/1 (and handle_update/2)
+%% lifecycle methods run inside eval_stateful's bracket.
+stateful_mount_eager_read_no_leak(Config) when is_list(Config) ->
+    Descriptor = #{stateful => arizona_leaky_mount, props => #{id => ~"leaky"}},
+    Dyn = {<<"0">>, fun() -> Descriptor end, {?MODULE, ?LINE}},
+    {[{<<"0">>, _Val, OuterDeps}], _Views} =
+        arizona_eval:eval_dynamics_v([Dyn], {#{}, #{}}),
+    ?assertNot(maps:is_key(eager_mount_key, OuterDeps)).
+
+%% A callback that returns a 0-arity fun (which eval_val_v then unwraps via
+%% its is_function/0 clause) must not leak the fun-body's reads into the
+%% outer dynamic's deps.
+stateless_callback_returning_fun_no_leak(Config) when is_list(Config) ->
+    Callback = fun(_Props) ->
+        fun() ->
+            late_value = arizona_template:get(late_key, #{late_key => late_value}),
+            #{s => [<<"<b>">>, <<"</b>">>], d => [{<<"0">>, <<"hi">>}], f => <<"t1">>}
+        end
+    end,
+    Descriptor = #{callback => Callback, props => #{}},
+    Dyn = {<<"0">>, fun() -> Descriptor end, {?MODULE, ?LINE}},
+    {[{<<"0">>, _Val, OuterDeps}], _Views} =
+        arizona_eval:eval_dynamics_v([Dyn], {#{}, #{}}),
+    ?assertNot(maps:is_key(late_key, OuterDeps)).

--- a/test/arizona_stream_SUITE.erl
+++ b/test/arizona_stream_SUITE.erl
@@ -43,6 +43,7 @@
     stream_dedup_strips_statics/1,
     stream_delete_nonexistent_key/1,
     stream_deps_skip/1,
+    stream_update_identical_emits_no_ops/1,
     stream_diff_insert/1,
     stream_diff_mixed/1,
     stream_diff_no_change/1,
@@ -110,6 +111,8 @@
     stream_ssr/1,
     stream_to_list_empty/1,
     stream_to_list_preserves_order/1,
+    update_pending_op_carries_changed/1,
+    update_on_missing_key_yields_empty_changed/1,
     stream_to_list/1,
     stream_update_no_change/1,
     stream_update_nonexistent_key/1
@@ -146,7 +149,8 @@ groups() ->
             stream_diff_update,
             stream_diff_reset,
             stream_diff_mixed,
-            stream_deps_skip
+            stream_deps_skip,
+            stream_update_identical_emits_no_ops
         ]},
         %% 12b. Stream edge case tests (unit-level)
         {stream_edge_unit, [parallel], [
@@ -210,7 +214,9 @@ groups() ->
             stream_limit_drop_insert,
             stream_move_op,
             stream_limit_ssr,
-            stream_limit_reset
+            stream_limit_reset,
+            update_pending_op_carries_changed,
+            update_on_missing_key_yields_empty_changed
         ]},
         %% Edge case tests
         {stream_edge_cases, [parallel], [
@@ -449,6 +455,23 @@ stream_deps_skip(Config) when is_list(Config) ->
     {Ops, _, _} = arizona_diff:diff(Tmpl1, Snap0, V0, Changed),
     ?assertEqual([], Ops).
 
+%% Update with an item identical to the existing one -- Changed is empty,
+%% the per-item skipping renderer short-circuits, no closure runs, no ops.
+stream_update_identical_emits_no_ops(Config) when is_list(Config) ->
+    Items = [#{id => 1, text => <<"A">>}],
+    {B0, _} = arizona_todo:mount(#{items => Items}, arizona_req_test_adapter:new(#{})),
+    Tmpl0 = arizona_todo:render(B0),
+    {_, Snap0, V0} = arizona_render:render(Tmpl0, #{}),
+    B1 = arizona_stream:clear_stream_pending(B0, arizona_stream:stream_keys(B0)),
+    %% Update with a value-equal item.
+    {B2, _, _} = arizona_todo:handle_event(
+        <<"update">>, #{<<"id">> => 1, <<"text">> => <<"A">>}, B1
+    ),
+    Tmpl1 = arizona_todo:render(B2),
+    Changed = arizona_live_compute_changed(B1, B2),
+    {Ops, _, _} = arizona_diff:diff(Tmpl1, Snap0, V0, Changed),
+    ?assertEqual([], Ops).
+
 %% =============================================================================
 %% 12b. Stream edge case tests (unit-level)
 %% =============================================================================
@@ -651,7 +674,7 @@ stream_snapshot_after_multiple_cycles(Config) when is_list(Config) ->
     ],
     ?assertEqual([1], FinalOrder),
     #{1 := ItemD} = FinalItems,
-    [{_, {attr, <<"az-key">>, 1}}, {_, <<"A2">>}] = ItemD.
+    [{_, {attr, <<"az-key">>, 1}, _}, {_, <<"A2">>, _}] = ItemD.
 
 stream_empty_pending_deps_changed(Config) when is_list(Config) ->
     %% Mount with 1 item, clear pending, re-render with same stream but Changed = #{items => true}
@@ -1673,6 +1696,27 @@ stream_limit_reset(Config) when is_list(Config) ->
     InsOps = [Op || [?OP_INSERT | _] = Op <- Ops],
     ?assertEqual(2, length(InsOps)).
 
+%% --- update/3 captures Changed in pending op --------------------------------
+update_pending_op_carries_changed(Config) when is_list(Config) ->
+    KeyFun = fun(#{id := Id}) -> Id end,
+    S0 = arizona_stream:new(KeyFun, [#{id => 1, text => <<"old">>, other => v}]),
+    #stream{pending = P1} =
+        arizona_stream:update(S0, 1, #{id => 1, text => <<"new">>, other => v}),
+    %% First op is the initial insert from new/2; the second is our update.
+    [_Insert, {update, 1, _NewItem, Changed}] = queue:to_list(P1),
+    ?assert(maps:is_key(text, Changed)),
+    ?assertNot(maps:is_key(other, Changed)),
+    ?assertNot(maps:is_key(id, Changed)).
+
+%% --- update/3 on a missing key emits empty Changed --------------------------
+update_on_missing_key_yields_empty_changed(Config) when is_list(Config) ->
+    KeyFun = fun(#{id := Id}) -> Id end,
+    S0 = arizona_stream:new(KeyFun),
+    #stream{pending = P1} =
+        arizona_stream:update(S0, 999, #{id => 999, text => <<"new">>}),
+    [{update, 999, _NewItem, Changed}] = queue:to_list(P1),
+    ?assertEqual(#{}, Changed).
+
 %% =============================================================================
 %% Edge case tests
 %% =============================================================================
@@ -1921,8 +1965,8 @@ render_fp_val_stream_items(Config) when is_list(Config) ->
     Snap = #{
         t => 0,
         items => #{
-            1 => [{<<"0">>, <<"A">>}],
-            2 => [{<<"0">>, <<"B">>}]
+            1 => [{<<"0">>, <<"A">>, #{}}],
+            2 => [{<<"0">>, <<"B">>, #{}}]
         },
         template => #{
             t => 0,
@@ -1959,7 +2003,7 @@ render_fp_val_stream_items_no_fp(Config) when is_list(Config) ->
     Snap = #{
         t => 0,
         items => #{
-            1 => [{<<"0">>, <<"A">>}]
+            1 => [{<<"0">>, <<"A">>, #{}}]
         },
         template => #{
             t => 0,

--- a/test/arizona_stream_SUITE.erl
+++ b/test/arizona_stream_SUITE.erl
@@ -113,6 +113,7 @@
     stream_to_list_preserves_order/1,
     update_pending_op_carries_changed/1,
     update_on_missing_key_yields_empty_changed/1,
+    reset_pending_op_carries_old_items/1,
     stream_to_list/1,
     stream_update_no_change/1,
     stream_update_nonexistent_key/1
@@ -216,7 +217,8 @@ groups() ->
             stream_limit_ssr,
             stream_limit_reset,
             update_pending_op_carries_changed,
-            update_on_missing_key_yields_empty_changed
+            update_on_missing_key_yields_empty_changed,
+            reset_pending_op_carries_old_items
         ]},
         %% Edge case tests
         {stream_edge_cases, [parallel], [
@@ -1716,6 +1718,24 @@ update_on_missing_key_yields_empty_changed(Config) when is_list(Config) ->
         arizona_stream:update(S0, 999, #{id => 999, text => <<"new">>}),
     [{update, 999, _NewItem, Changed}] = queue:to_list(P1),
     ?assertEqual(#{}, Changed).
+
+%% --- reset/1,2 captures the pre-mutation items map in the pending op -------
+reset_pending_op_carries_old_items(Config) when is_list(Config) ->
+    KeyFun = fun(#{id := Id}) -> Id end,
+    OldItem1 = #{id => 1, text => <<"A">>},
+    OldItem2 = #{id => 2, text => <<"B">>},
+    S0 = arizona_stream:new(KeyFun, [OldItem1, OldItem2]),
+    %% reset/2 with a fresh set
+    #stream{pending = P1} = arizona_stream:reset(S0, [#{id => 1, text => <<"A2">>}]),
+    %% Pending starts with two inserts (initial population) and ends with reset.
+    Ops1 = queue:to_list(P1),
+    {reset, OldItems1} = lists:last(Ops1),
+    ?assertEqual(#{1 => OldItem1, 2 => OldItem2}, OldItems1),
+    %% reset/1 (full clear) also captures old items
+    #stream{pending = P2} = arizona_stream:reset(S0),
+    Ops2 = queue:to_list(P2),
+    {reset, OldItems2} = lists:last(Ops2),
+    ?assertEqual(#{1 => OldItem1, 2 => OldItem2}, OldItems2).
 
 %% =============================================================================
 %% Edge case tests

--- a/test/support/arizona_leaky_mount.erl
+++ b/test/support/arizona_leaky_mount.erl
@@ -1,0 +1,20 @@
+-module(arizona_leaky_mount).
+-include("arizona_stateful.hrl").
+-export([mount/1, render/1, handle_event/3]).
+
+%% Test fixture: mount/1 does an eager binding read against a synthetic map.
+%% Used to verify that eval_stateful brackets the mount lifecycle so the
+%% read does not leak into the outer dynamic's tracked deps.
+-spec mount(az:bindings()) -> az:mount_ret().
+mount(Bindings) ->
+    eager_value = arizona_template:get(eager_mount_key, #{eager_mount_key => eager_value}),
+    {maps:merge(#{id => ~"leaky", count => 0}, Bindings), #{}}.
+
+-spec render(az:bindings()) -> az:template().
+render(Bindings) ->
+    ?html({'div', [{id, ?get(id)}], [~"leaky"]}).
+
+-spec handle_event(az:event_name(), az:event_payload(), az:bindings()) ->
+    az:handle_event_ret().
+handle_event(_E, _P, Bindings) ->
+    {Bindings, #{}, []}.

--- a/test/support/arizona_leaky_mount.erl
+++ b/test/support/arizona_leaky_mount.erl
@@ -1,6 +1,6 @@
 -module(arizona_leaky_mount).
 -include("arizona_stateful.hrl").
--export([mount/1, render/1, handle_event/3]).
+-export([mount/1, render/1]).
 
 %% Test fixture: mount/1 does an eager binding read against a synthetic map.
 %% Used to verify that eval_stateful brackets the mount lifecycle so the
@@ -13,8 +13,3 @@ mount(Bindings) ->
 -spec render(az:bindings()) -> az:template().
 render(Bindings) ->
     ?html({'div', [{id, ?get(id)}], [~"leaky"]}).
-
--spec handle_event(az:event_name(), az:event_payload(), az:bindings()) ->
-    az:handle_event_ret().
-handle_event(_E, _P, Bindings) ->
-    {Bindings, #{}, []}.


### PR DESCRIPTION
# Description

Closes per-dynamic dep leaks across stateless callbacks and stateful `mount/1`/`handle_update/2`, then persists per-item deps inside `?each` so stream `update/3` and `reset/1,2` only re-evaluate dynamics whose tracked keys actually changed.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
