### PR TITLE
Track latest biome schema to avoid version-bump warnings

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
+    "$schema": "https://biomejs.dev/schemas/latest/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",


### PR DESCRIPTION
# Description

`biome.json` pinned the `$schema` to a specific version, so every CLI bump produced a schema-mismatch info during `make check`. Switching to `latest` makes the URL track whatever biome version is installed and silences the recurring warning.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
