### PR TITLE
Move eqwalizer_support to its own profile

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,9 +1,6 @@
 {erl_opts, [debug_info, warnings_as_errors]}.
 
 {deps, [
-    {eqwalizer_support,
-        {git_subdir, "https://github.com/whatsapp/eqwalizer.git", {branch, "main"},
-            "eqwalizer_support"}},
     {cowboy, "2.14.2"},
     {fs, "11.4.1"}
 ]}.
@@ -83,6 +80,13 @@
             deprecated_functions
         ]},
         {xref_ignores, [{rebar_agent, do, 1}]}
+    ]},
+    {eqwalizer, [
+        {deps, [
+            {eqwalizer_support,
+                {git_subdir, "https://github.com/whatsapp/eqwalizer.git", {branch, "main"},
+                    "eqwalizer_support"}}
+        ]}
     ]}
 ]}.
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,11 +1,6 @@
 {"1.2.0",
 [{<<"cowboy">>,{pkg,<<"cowboy">>,<<"2.14.2">>},0},
  {<<"cowlib">>,{pkg,<<"cowlib">>,<<"2.16.0">>},1},
- {<<"eqwalizer_support">>,
-  {git_subdir,"https://github.com/whatsapp/eqwalizer.git",
-              {ref,"35275e300c5550f974fe0a75044188c8403254fa"},
-              "eqwalizer_support"},
-  0},
  {<<"fs">>,{pkg,<<"fs">>,<<"11.4.1">>},0},
  {<<"ranch">>,{pkg,<<"ranch">>,<<"2.2.0">>},1}]}.
 [


### PR DESCRIPTION
# Description

Move eqwalizer_support to its own profile so hex publish accepts it.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
