### PR TITLE
Carry root bindings across navigate

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -267,8 +267,13 @@ Simplified gen_server wrapper:
   `handle_info/2` are silently dropped. Empty ops+effects are not pushed
 - `navigate/4,5` -- `navigate(Pid, NewHandler, InitBindings, NewReq [, OnMount])`. Mounts new
   handler (applying any `OnMount` hooks with the new `Request`), resets gen_server state
-  (handler, bindings, req, snapshot, views), preserves `transport_pid`, returns
-  `{ok, NewViewId, PageContent}`
+  (handler, req, snapshot, views), preserves `transport_pid` and `sent_fps`, returns
+  `{ok, NewViewId, PageContent}`. The previous root handler's final bindings are carried
+  forward as the floor for the new handler's mount input -- `InitBindings` (route static
+  config + middleware enrichments) overrides on key overlap. Keys the new handler omits
+  from its mount return value are dropped on the next navigate. Stateful children's state
+  (in `views`) is wiped: a child that was alive on the old page is gone unless the new
+  page re-embeds it
 - `apply_on_mount/3` -- folds the `on_mount` hook chain: `apply_on_mount(OnMount, Bindings, Req)`.
   Each hook is `fun((Bindings, az:request()) -> Bindings)` or `{Module, Function}`
 

--- a/e2e/parallel/arizona_page.spec.js
+++ b/e2e/parallel/arizona_page.spec.js
@@ -1030,6 +1030,34 @@ test.describe('SPA navigation', () => {
         await expect(page.locator('main h1')).toHaveText('Welcome');
     });
 
+    test('root binding survives navigate round-trip', async ({ page }) => {
+        // arizona_live carries the previous root handler's final bindings
+        // forward as the floor for the new mount's input -- session-level
+        // state set on one page is visible to the next handler's mount.
+        // The child counters on `/` mount with `count => ?get(count, 0)`
+        // from the root view, so a non-zero root `count` is observable
+        // in the child counter's <p> after a round-trip via /about.
+        await page.goto('/');
+        await page.waitForSelector('#status:has-text("Connected")');
+        // Sanity: counters start at 0
+        await expect(countText(page, 'counter')).toHaveText('Count: 0');
+        // "Add +1 to both" increments root `count` (and pushes to children)
+        await page.click('button[az-click*="add"]');
+        await expect(countText(page, 'counter')).toHaveText('Count: 1');
+        // Navigate to about; arizona_about's mount uses the lazy
+        // `maps:merge(Defaults, Bindings0)` pattern, so it inherits
+        // root's `count` even though about itself doesn't render it.
+        await page.click('a[href="/about"]');
+        await expect(page.locator('main h1')).toHaveText('About');
+        // Navigate back to home. With carry-forward, root mounts with
+        // `count => 1` flowing through the merged input; without it,
+        // the handler default `count => 0` would win and the child
+        // counter would render 0.
+        await page.click('a[href="/"]');
+        await expect(page.locator('main h1')).toHaveText('Welcome');
+        await expect(countText(page, 'counter')).toHaveText('Count: 1');
+    });
+
     test('back after navigate restores prior scroll position', async ({ page }) => {
         // Dedicated scroll test fixtures -- tall enough to scroll.
         await page.goto('/scroll-home');

--- a/src/arizona_live.erl
+++ b/src/arizona_live.erl
@@ -349,7 +349,16 @@ handle_call(
 ) ->
     ok = cancel_pending_timers(),
     ok = arizona_handler:call_unmount(OldH, OldB),
-    {NewViewId, HTML, Snap, B2, V1} = do_mount(NewHandler, NewIB, NewReq, #{}, NewOnMount),
+    %% Carry the previous root handler's final bindings forward as the floor;
+    %% NewIB (route static config + middleware enrichments) overrides on
+    %% overlap. The new handler's `mount/2` receives `OldB ⊕ NewIB`, picks
+    %% what it cares about, and returns its own bindings — values it does
+    %% not include in the return are dropped. Handlers that want to keep
+    %% session-level state (current_user, theme, locale) just include those
+    %% keys in their mount return; everything else is page-local and
+    %% naturally evaporates on the next navigate.
+    Merged = maps:merge(OldB, NewIB),
+    {NewViewId, HTML, Snap, B2, V1} = do_mount(NewHandler, Merged, NewReq, #{}, NewOnMount),
     {PageContent1, Fps1} = dedup_fp_val(page_content(Snap, HTML), Fps0),
     {reply, {ok, NewViewId, PageContent1}, #state{
         handler = NewHandler,

--- a/src/arizona_live.erl
+++ b/src/arizona_live.erl
@@ -19,7 +19,13 @@ WebSocket handler) with the render and diff pipeline.
 3. **Info messages** -- `handle_info/2` invokes the handler's optional
    `handle_info/2` callback, diffs, and pushes the resulting ops.
 4. **Navigate** -- `navigate/4,5` unmounts the old root, cancels pending
-   timers, mounts the new handler, and replies with fresh content.
+   timers, and mounts the new handler. The previous root's final
+   bindings are carried forward as the floor for the new mount's input
+   -- `InitBindings` (route static config + middleware enrichments)
+   overrides on key overlap. Keys the new handler omits from its mount
+   return are dropped on the next navigate, so handlers control what
+   persists by what they return. Stateful children's state (in `views`)
+   is wiped.
 
 ## Process dictionary keys
 

--- a/test/arizona_live_SUITE.erl
+++ b/test/arizona_live_SUITE.erl
@@ -44,6 +44,7 @@
     live_navigate_round_trip/1,
     live_navigate/1,
     live_navigate_then_event/1,
+    live_navigate_carries_root_bindings/1,
     live_page_child_mount/1,
     live_parent_change_child_stable/1,
     live_parent_event_updates_children/1,
@@ -126,7 +127,8 @@ groups() ->
             live_navigate,
             live_navigate_then_event,
             live_navigate_resets_views,
-            live_navigate_round_trip
+            live_navigate_round_trip,
+            live_navigate_carries_root_bindings
         ]},
         {handle_info, [parallel], [
             live_handle_info,
@@ -638,6 +640,38 @@ live_navigate_round_trip(Config) when is_list(Config) ->
         ],
         maps:get(<<"d">>, CounterPayload)
     ).
+
+live_navigate_carries_root_bindings(Config) when is_list(Config) ->
+    %% Navigate carries the previous root handler's final bindings as
+    %% the floor for the new handler's mount input. NewIB (route static
+    %% config + middleware enrichments) overrides on overlap; keys
+    %% present only in OldB pass through to the new mount. The new
+    %% handler picks what it cares about and returns its own bindings —
+    %% values it omits from the return are dropped on the next navigate.
+    %%
+    %% Setup: arizona_root_counter as the root view. It mounts with
+    %% `count => 0` (default) merged under incoming bindings, so any
+    %% incoming `count` value wins. Increment to 3 via a root event,
+    %% then navigate to the same handler — the merge surfaces count=3
+    %% as the new mount's input, the handler's `maps:merge` lets it
+    %% pass through, and the new state has count=3 (not the default 0).
+    {ok, Pid} = arizona_live:start_link(
+        arizona_root_counter, #{}, undefined, [], arizona_req_test_adapter:new()
+    ),
+    {ok, ViewId} = arizona_live:mount(Pid),
+    %% Tick the root counter to 3
+    {ok, _, _} = arizona_live:handle_event(Pid, ViewId, ~"inc", #{}),
+    {ok, _, _} = arizona_live:handle_event(Pid, ViewId, ~"inc", #{}),
+    {ok, _, _} = arizona_live:handle_event(Pid, ViewId, ~"inc", #{}),
+    %% Navigate back to the same handler with no overriding NewIB.
+    {ok, _NewViewId, PageContent} = arizona_live:navigate(
+        Pid, arizona_root_counter, #{}, arizona_req_test_adapter:new()
+    ),
+    %% Dynamics: [id_attr, count]. After the merge `count` should be 3 —
+    %% if the merge weren't happening, the handler's default `count => 0`
+    %% would win and we'd see 0.
+    Dynamics = maps:get(<<"d">>, PageContent),
+    ?assertEqual([<<" id=\"counter\"">>, <<"3">>], Dynamics).
 
 %% =============================================================================
 %% handle_info tests

--- a/test/support/arizona_scroll_about.erl
+++ b/test/support/arizona_scroll_about.erl
@@ -4,10 +4,14 @@
 
 -spec mount(az:bindings(), az:request()) -> az:mount_ret().
 mount(Bindings0, _Req) ->
-    Bindings = maps:merge(
-        #{id => ~"page", title => ~"Scroll About", connected => false},
-        Bindings0
-    ),
+    %% Handler-identity keys (id, title) and per-page boot state
+    %% (connected) are written by the handler; previous-page values
+    %% carried via navigate must not pollute them.
+    Bindings = Bindings0#{
+        id => ~"page",
+        title => ~"Scroll About",
+        connected => false
+    },
     ?connected andalso ?send(arizona_connected),
     {Bindings, #{}}.
 

--- a/test/support/arizona_scroll_home.erl
+++ b/test/support/arizona_scroll_home.erl
@@ -4,10 +4,14 @@
 
 -spec mount(az:bindings(), az:request()) -> az:mount_ret().
 mount(Bindings0, _Req) ->
-    Bindings = maps:merge(
-        #{id => ~"page", title => ~"Scroll Home", connected => false},
-        Bindings0
-    ),
+    %% Handler-identity keys (id, title) and per-page boot state
+    %% (connected) are written by the handler; previous-page values
+    %% carried via navigate must not pollute them.
+    Bindings = Bindings0#{
+        id => ~"page",
+        title => ~"Scroll Home",
+        connected => false
+    },
     ?connected andalso ?send(arizona_connected),
     {Bindings, #{}}.
 


### PR DESCRIPTION
# Description

`arizona_live:navigate/4,5` now merges the previous root handler's final bindings into the new handler's mount input, with the route's `InitBindings` (static config + middleware enrichments) overriding on key overlap. The new handler's `mount/2` decides what to keep by what it returns; keys it omits are dropped on the next navigate.

Stateful children (the `views` map) are still wiped on navigate, this only affects the root view's bindings.

Handlers that store derived or session-level data in their bindings (a sort selection, a wizard step input, a dismissed-banner flag) keep that data visible to the next page's mount without round-tripping through cookies or the URL.

A future middleware pattern that opts out of repeating expensive work when the value is already present in incoming bindings could use this to avoid redundant DB lookups.

## Example

A two-step wizard, each step on its own route:

```erlang
%% step 1
mount(Bindings, _Req) ->
    {Bindings#{
        id => ~"wizard-step-1",
        title => ~"Step 1: Your name"
    }, #{}}.

handle_event(~"submit", #{~"name" := Name}, Bindings) ->
    {Bindings#{user_name => Name}, #{}, [
        arizona_js:navigate(~"/wizard/step-2")
    ]}.
```

```erlang
%% step 2
mount(Bindings, _Req) ->
    %% `user_name` flows in from step 1's final bindings.
    Name = maps:get(user_name, Bindings, ~"there"),
    {#{
        id => ~"wizard-step-2",
        greeting => <<"Hi, ", Name/binary>>
    }, #{}}.
```

Before this change, `user_name` was lost between routes. Step 2 would have to re-read it from a session store, the URL, or a cookie. Now it carries through the live process naturally.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
