### PR TITLE
Document `rebar.config` shell entry so `rebar3 shell` loads `sys.config`

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,17 @@ Add `arizona` to your app's `applications` list in `.app.src`:
 {applications, [kernel, stdlib, cowboy, arizona]}
 ```
 
+Ensure that rebar shell, would consult the config/sys.config file
+
+``
+{shell, [
+    {config, "config/sys.config"},
+    {apps, [ yourapp ,cowboy]}
+]}.
+``
+
+
+
 Then declare routes in `config/sys.config`:
 
 ```erlang

--- a/README.md
+++ b/README.md
@@ -176,17 +176,18 @@ Add `arizona` to your app's `applications` list in `.app.src`:
 {applications, [kernel, stdlib, cowboy, arizona]}
 ```
 
-Ensure that rebar shell, would consult the config/sys.config file
+Ensure `rebar3 shell` loads the config and starts your app by adding
+to `rebar.config`:
 
-``
+```erlang
 {shell, [
     {config, "config/sys.config"},
-    {apps, [ yourapp ,cowboy]}
+    {apps, [yourapp]}
 ]}.
-``
+```
 
-
-
+Replace `yourapp` with your project's app name; `cowboy` and `arizona` are started
+transitively from the `applications` list in `.app.src`.
 Then declare routes in `config/sys.config`:
 
 ```erlang


### PR DESCRIPTION
# Description

Following these instructions, without the reference to 'config/sys.config' in the rebar3 shell profile, the http listener wont start.

# What changed

I modified the quickstart to mention that the rebar3 shell profile requires the 'config' to be set or the http listener wont start.

Maybe this config is a problem only on my end, without this, the cowboy listener wont start.