### PR TITLE
Add CodeQL advanced workflow so docs-only PRs aren't blocked

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,47 @@
+---
+name: CodeQL
+
+"on":
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - "*"
+  workflow_dispatch: {}
+  merge_group:
+  schedule:
+    - cron: "0 6 * * 1"
+
+concurrency:
+  group: ${{github.workflow}}-${{github.ref}}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  analyze:
+    name: Analyze (${{matrix.language}})
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - javascript-typescript
+          - actions
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@14c9a0cbe6373488c2a41f7e75c8dd142bb2aba8 # v3.35.3
+        with:
+          languages: ${{matrix.language}}
+          build-mode: none
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@14c9a0cbe6373488c2a41f7e75c8dd142bb2aba8 # v3.35.3
+        with:
+          category: "/language:${{matrix.language}}"


### PR DESCRIPTION
# Description

Default-setup CodeQL is path-filtered, so it never ran on docs-only PRs (e.g. #497) and the `code_scanning` ruleset rule blocked merge forever.

Switch to advanced setup: a workflow that runs unconditionally on every PR/push/merge-queue entry, covering the same languages default setup already scanned -- `javascript-typescript` and `actions`, the only CodeQL-supported languages in this repo.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
