### PR TITLE
Profile-driven framework optimisations

### DIFF
--- a/.claude/skills/profile/SKILL.md
+++ b/.claude/skills/profile/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: profile
+description: Profile Arizona hot paths with eprof/fprof. Use when investigating performance or picking the next optimization.
+argument-hint: [workload_label]
+allowed-tools: Read, Bash, Grep, Glob
+---
+
+Profile an Arizona workload to find hot paths and propose the next
+optimization. If `$ARGUMENTS` is empty, profile the full curated set
+(`render_view_page`, `render_each_100`, `diff_simple_event`,
+`stream_reorder_100`).
+
+## 1. Run the profile
+
+Pick `--ops` based on the workload's per-op cost so total profile time
+is in the 20–100ms range (enough signal, not so much that the analysis
+itself dominates):
+
+| Workload | Suggested `--ops` |
+|----------|-------------------|
+| `render_view_page` | 1000 |
+| `render_view_with_layout` | 1000 |
+| `render_each_100` | 200 |
+| `stream_reorder_100` | 200 |
+| `diff_simple_event` | 5000 |
+
+```bash
+make prof ARGS="--only $ARGUMENTS --ops 1000 --min-ms 0.5"
+```
+
+The `--min-ms 0.5` threshold filters out rows below 0.5ms total — keeps
+the table readable. Drop to `--min-ms 0.2` if the workload runs short.
+Profile output also lands at `/tmp/arizona_profile_<label>.log`.
+
+## 2. Categorise the top 5–10 rows
+
+Group functions by what they're doing — that's how you pick a target:
+
+- **HTML escape**: `binary:replace/4`, `binary:matches/3`, `binary:do_replace/4`, `binary:part/2` →
+  `arizona_js:escape_attr/1` and friends
+- **JSON encode**: `json:escape_binary/5`, `json:string/7`, `json:do_encode/2`, `json:list_loop/2` →
+  `arizona_socket:encode/1` reply path
+- **List comprehension closures**: anything with `'-Fn/Arity-lc$^N/M-K-'/Arity` or `zlc$` →
+  per-item iteration overhead
+- **Per-dynamic dispatch**: `arizona_eval:eval_one/1`, `eval_val/1`,
+  `arizona_render:render_ssr_one/1`, `render_ssr_val/1`
+- **Tree walks**: `arizona_render:zip/2`, `arizona_template:to_bin/1`,
+  `unwrap_val/1`
+- **OTP framework**: `gen:do_call/4`, `erlang:demonitor/2`,
+  `erlang:integer_to_binary/1` — usually intrinsic, hard to optimize
+- **gen_server roundtrip**: `gen:do_call/4` ≥ 5% in event workloads
+  signals the live process call cost; usually not addressable without
+  re-architecting
+
+Note the totals row for before/after comparison (you'll re-run after
+changes to confirm the win).
+
+## 3. Identify the candidate
+
+Pick the highest-`%` row that's in **Arizona code** (not OTP). For each
+candidate, find the call site and decide whether the cost is:
+
+- **Intrinsic** (algorithmic — the function has to do this work) → not
+  worth optimizing without changing the algorithm
+- **Accidental** (intermediate list, double walk, redundant escape, eager
+  eval where compile-time would do) → fixable
+
+Quick lookup:
+
+```bash
+grep -rn 'function_name' src/ test/support/
+```
+
+Common accidental patterns:
+
+- **Double walk**: `Vals = f(Xs), [g(X, V) || X <- Xs && V <- Vals]` →
+  fuse to `[g(X, f_one(X)) || X <- Xs]` (we did this for
+  `render_ssr_val/1`).
+- **Eager binary build for static input**: `escape(json_encode(Cmd))`
+  where `Cmd` is a literal → fold at compile time in
+  `arizona_parse_transform.erl` (we did this for static `arizona_js`
+  commands).
+- **Map allocation in non-tracking path**: `[{Az, V, #{}} || ...]` where
+  the `#{}` deps map is never read → drop it.
+
+## 4. Deeper detail (optional)
+
+If the eprof flat profile isn't enough — e.g. a function shows 10% but
+you can't see what it's calling — rerun with fprof for OWN/ACC time and
+the call hierarchy:
+
+```bash
+make prof ARGS="--only $ARGUMENTS --tool fprof --ops 200"
+```
+
+fprof output is verbose. Read the `totals` block first, then sort by
+`OWN` time and trace upwards from the heaviest leaf MFAs.
+
+## 5. Cross-check with the wall-clock bench
+
+Before claiming a win, confirm the profile-suggested change hits the
+wall clock too. Use `make bench` (real ns/op, multi-trial stats):
+
+```bash
+make bench ARGS="--only $ARGUMENTS 30"
+```
+
+The bench is intentionally NOT auto-gated (variance from shared CI
+runners). Compare mean ns/op before vs. after by hand.
+
+## 6. Plan the change
+
+State the hypothesis explicitly:
+
+> Function `M:F/A` is N% of `<workload>` total. The cost is accidental
+> because <reason>. Replacing it with `<edit>` should drop it to ~M% and
+> shave ~X% off the total.
+
+Then propose **one** concrete edit. Per the user's preference, don't
+bundle multiple unrelated optimizations — ship one change, re-measure,
+then plan the next.
+
+## Reference files
+
+- Profile script: `scripts/profile.escript`
+- Profiler module: `test/support/arizona_profiler.erl`
+- Workload registry: `scripts/profile.escript` `profilers/0`
+- Bench harness: `test/support/arizona_bench_lib.erl`
+- Bench script: `scripts/bench.escript`
+- Architecture map: `docs/architecture.md`
+
+## Adding a new workload to profile
+
+If the hot path you want lives outside the four curated workloads:
+
+1. Mirror an existing `bench_*` workload from `scripts/bench.escript`
+   (typically the one named identically). The bench setup logic is the
+   right shape for profiling too.
+2. Add a `prof_<label>/2` function in `scripts/profile.escript` that
+   calls `profile_loop/3` with the inner op fun.
+3. Register it in `profilers/0`.
+
+Keep the curated set small — this is for hot-path investigation, not
+exhaustive coverage.

--- a/.claude/skills/profile/SKILL.md
+++ b/.claude/skills/profile/SKILL.md
@@ -19,6 +19,7 @@ itself dominates):
 | Workload | Suggested `--ops` |
 |----------|-------------------|
 | `render_view_page` | 1000 |
+| `render_view_page_dyn_js` | 200 |
 | `render_each_100` | 200 |
 | `render_nested_each` | 200 |
 | `render_stateful_chain` | 1000 |

--- a/.claude/skills/profile/SKILL.md
+++ b/.claude/skills/profile/SKILL.md
@@ -19,10 +19,16 @@ itself dominates):
 | Workload | Suggested `--ops` |
 |----------|-------------------|
 | `render_view_page` | 1000 |
-| `render_view_with_layout` | 1000 |
 | `render_each_100` | 200 |
-| `stream_reorder_100` | 200 |
+| `render_nested_each` | 200 |
+| `render_stateful_chain` | 1000 |
 | `diff_simple_event` | 5000 |
+| `stream_reorder_100` | 200 |
+| `stream_insert_1k` | 50 |
+| `http_get_e2e` | 1000 |
+| `ws_event_e2e` | 1000 |
+| `mount_only` | 500 |
+| `pubsub_broadcast_100` | 100 |
 
 ```bash
 make prof ARGS="--only $ARGUMENTS --ops 1000 --min-ms 0.5"

--- a/.claude/skills/profile/SKILL.md
+++ b/.claude/skills/profile/SKILL.md
@@ -103,6 +103,25 @@ make prof ARGS="--only $ARGUMENTS --tool fprof --ops 200"
 fprof output is verbose. Read the `totals` block first, then sort by
 `OWN` time and trace upwards from the heaviest leaf MFAs.
 
+## 4b. Profile a different commit (A/B comparisons)
+
+To compare a candidate change against a baseline without stashing the
+working tree, profile any commit-ish via `git worktree`:
+
+```bash
+# Profile the parent commit (typical A/B baseline)
+make prof-at REF=HEAD~1 ARGS="--only render_each_100 --ops 200"
+
+# Profile a branch name, tag, or SHA -- all work
+make prof-at REF=main    ARGS="--only render_view_page --ops 1000"
+make prof-at REF=9fe7497 ARGS="--only stream_insert_1k --ops 50"
+```
+
+The worktree is cached under `_build/prof-at-<sha>/` (gitignored), so
+repeat runs of the same commit reuse the compiled artifacts. Cleanup:
+`git worktree remove _build/prof-at-<sha>` (or just `git worktree prune`
+to remove all stale entries).
+
 ## 5. Cross-check with the wall-clock bench
 
 Before claiming a win, confirm the profile-suggested change hits the

--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,13 @@ test-e2e-sequential:
 bench: compile-test
 	./scripts/bench.escript $(ARGS)
 
+# Performance profile (eprof/fprof). Same caveat as bench: developer
+# tool, not auto-gated. Pass extra args via ARGS, e.g.:
+#   make prof ARGS="--only diff_simple_event"
+#   make prof ARGS="--only render_view_page --tool fprof"
+prof: compile-test
+	./scripts/profile.escript $(ARGS)
+
 cover: cover-erl cover-js
 
 cover-erl:

--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,15 @@ bench: compile-test
 prof: compile-test
 	./scripts/profile.escript $(ARGS)
 
+# Profile any commit-ish (branch, tag, SHA, HEAD~N) without touching
+# the working tree, via git worktree cached under _build/prof-at-<sha>/.
+# Use for A/B comparisons against an uncommitted change without manual
+# stash/pop. Examples:
+#   make prof-at REF=HEAD~1 ARGS="--only render_each_100 --ops 200"
+#   make prof-at REF=main   ARGS="--only render_view_page --ops 1000"
+prof-at:
+	./scripts/prof_at.sh $(REF) $(ARGS)
+
 cover: cover-erl cover-js
 
 cover-erl:

--- a/rebar.config
+++ b/rebar.config
@@ -13,7 +13,8 @@
         eunit,
         common_test,
         cowboy,
-        fs
+        fs,
+        tools
     ]},
     {warnings, [
         unknown,
@@ -63,7 +64,8 @@
                 common_test,
                 ranch,
                 cowboy,
-                fs
+                fs,
+                tools
             ]},
             {warnings, [
                 unknown,
@@ -123,6 +125,8 @@
         {"test/support/arizona_bench_each_track.erl", [unnecessary_function_arguments]},
         {"test/support/arizona_bench_many_dyn.erl", [unnecessary_function_arguments]},
         {"test/support/arizona_bench_multi_key.erl", [unnecessary_function_arguments]},
+        {"test/support/arizona_bench_nested_each.erl", [unnecessary_function_arguments]},
+        {"test/support/arizona_bench_chain_a.erl", [unnecessary_function_arguments]},
         {"include/arizona_js.hrl", [single_use_hrl_attrs, single_use_hrls]},
         {"include/arizona_handler.hrl", [single_use_hrl_attrs]},
         {"include/arizona_common.hrl", [unused_macros, single_use_hrl_attrs]},

--- a/scripts/prof_at.sh
+++ b/scripts/prof_at.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# Profile a workload at any git commit without touching the working tree.
+#
+# Uses a `git worktree` under `_build/prof-at-<sha>/` so the current
+# checkout (with its uncommitted edits, build cache, etc.) is left
+# alone. The worktree is cached across runs -- subsequent `prof_at` of
+# the same commit reuses the compiled artifacts.
+#
+# Usage:
+#   ./scripts/prof_at.sh <commit-ish> [profile.escript args...]
+#
+# Examples:
+#   # Profile a workload at the parent of HEAD (typical A/B baseline).
+#   ./scripts/prof_at.sh HEAD~1 --only render_each_100 --ops 200
+#
+#   # Profile a specific SHA.
+#   ./scripts/prof_at.sh 9fe7497 --only render_view_page
+#
+#   # Run all curated workloads at a tag.
+#   ./scripts/prof_at.sh v0.5.0
+#
+# Cleanup:
+#   git worktree remove _build/prof-at-<sha>
+#   git worktree prune
+
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+    echo "usage: $0 <commit-ish> [profile.escript args...]" >&2
+    exit 1
+fi
+
+COMMIT="$1"
+shift
+
+SHA=$(git rev-parse --short "$COMMIT")
+WORKTREE="_build/prof-at-$SHA"
+
+if [ ! -d "$WORKTREE" ]; then
+    echo "==> creating worktree $WORKTREE @ $COMMIT" >&2
+    git worktree add --detach "$WORKTREE" "$COMMIT" >&2
+else
+    echo "==> reusing cached worktree $WORKTREE" >&2
+fi
+
+cd "$WORKTREE"
+rebar3 as test compile >&2
+./scripts/profile.escript "$@"

--- a/scripts/profile.escript
+++ b/scripts/profile.escript
@@ -46,7 +46,14 @@ profilers() ->
         {~"render_view_page", fun prof_render_view_page/2},
         {~"render_each_100", fun prof_render_each_100/2},
         {~"diff_simple_event", fun prof_diff_simple_event/2},
-        {~"stream_reorder_100", fun prof_stream_reorder_100/2}
+        {~"stream_reorder_100", fun prof_stream_reorder_100/2},
+        {~"http_get_e2e", fun prof_http_get_e2e/2},
+        {~"ws_event_e2e", fun prof_ws_event_e2e/2},
+        {~"mount_only", fun prof_mount_only/2},
+        {~"stream_insert_1k", fun prof_stream_insert_1k/2},
+        {~"pubsub_broadcast_100", fun prof_pubsub_broadcast_100/2},
+        {~"render_nested_each", fun prof_render_nested_each/2},
+        {~"render_stateful_chain", fun prof_render_stateful_chain/2}
     ].
 
 filter_workloads(All, []) ->
@@ -148,6 +155,222 @@ prof_stream_reorder_100(Label, Opts) ->
         end
     end,
     profile_loop(Label, Op, Opts).
+
+prof_render_nested_each(Label, Opts) ->
+    %% View renders 10 sections, each with a 10-item `?each` of leaves
+    %% (`arizona_bench_nested_each`). Two levels of `?each` exercise the
+    %% recursive `arizona_render:zip/2` + `arizona_eval:render_list_items_simple/2`
+    %% path that real list-in-list shapes (categories x items, threads x replies)
+    %% hit. Complements `render_each_100`'s flat 100-item case.
+    %%
+    %% Pre-generate the 10x10 dataset once and pass via bindings -- the
+    %% fixture's lazy default would otherwise rebuild 100 binaries per
+    %% render, dominating the profile.
+    Sections = generate_nested_sections(),
+    RenderOpts = #{bindings => #{sections => Sections}},
+    Req = arizona_req_test_adapter:new(),
+    Sample = arizona_render:render_view_to_iolist(arizona_bench_nested_each, Req, RenderOpts),
+    sanity_render(arizona_bench_nested_each, Sample),
+    Op = fun() ->
+        arizona_render:render_view_to_iolist(arizona_bench_nested_each, Req, RenderOpts)
+    end,
+    profile_loop(Label, Op, Opts).
+
+generate_nested_sections() ->
+    [
+        #{
+            id => SectId,
+            title => iolist_to_binary(io_lib:format("Section ~b", [SectId])),
+            items => [
+                #{
+                    id => ItemId,
+                    text => iolist_to_binary(
+                        io_lib:format("Item ~b-~b", [SectId, ItemId])
+                    )
+                }
+             || ItemId <- lists:seq(1, 10)
+            ]
+        }
+     || SectId <- lists:seq(1, 10)
+    ].
+
+prof_render_stateful_chain(Label, Opts) ->
+    %% 3-level stateful chain: view (chain_a) -> stateful (chain_b) ->
+    %% stateful (chain_c) with a 10-item `?each` leaf. Exercises the
+    %% recursive `arizona_render:render_ssr_val/1` propagation through
+    %% nested `?stateful(...)` descriptors -- something the flat
+    %% `render_view_page` (single-level stateful children) can't show.
+    Req = arizona_req_test_adapter:new(),
+    Sample = arizona_render:render_view_to_iolist(arizona_bench_chain_a, Req, #{}),
+    sanity_render(arizona_bench_chain_a, Sample),
+    Op = fun() ->
+        arizona_render:render_view_to_iolist(arizona_bench_chain_a, Req, #{})
+    end,
+    profile_loop(Label, Op, Opts).
+
+prof_http_get_e2e(Label, Opts) ->
+    %% Mirrors bench_http_get_e2e (bench.escript:321). Full HTTP path:
+    %% cowboy parse + arizona_http handler + view mount/render + reply
+    %% writing. Maps to every e2e spec's initial `goto()` -- the cost
+    %% the user pays before any WS event fires.
+    Routes = [
+        {live, <<"/">>, arizona_root_counter, #{layouts => [{arizona_layout, render}]}}
+    ],
+    arizona_bench_lib:with_cowboy(prof_http_e2e, Routes, fun(Port) ->
+        arizona_bench_lib:with_http_socket(Port, fun(Sock) ->
+            sanity_http_get(Sock, Port),
+            Op = fun() ->
+                {200, _} = arizona_bench_lib:http_get(Sock, Port),
+                ok
+            end,
+            profile_loop(Label, Op, Opts)
+        end)
+    end).
+
+prof_ws_event_e2e(Label, Opts) ->
+    %% Mirrors bench_ws_event_e2e (bench.escript:390). Full WS roundtrip:
+    %% one `inc` text frame -> arizona_socket:handle_in -> live dispatch
+    %> -> diff -> reply encode -> WS frame back. Maps to every counter/
+    %% form click in the e2e specs.
+    Routes = [
+        {live, <<"/">>, arizona_root_counter, #{layouts => [{arizona_layout, render}]}},
+        {ws, <<"/ws">>, #{}}
+    ],
+    arizona_bench_lib:with_cowboy(prof_ws_e2e, Routes, fun(Port) ->
+        arizona_bench_lib:with_ws_socket(Port, <<"/">>, fun(Sock) ->
+            Json = iolist_to_binary(json:encode([~"counter", ~"inc", #{}])),
+            sanity_ws_send(Sock, Json),
+            Op = fun() ->
+                ok = arizona_bench_lib:ws_send(Sock, Json),
+                {text, _} = arizona_bench_lib:ws_recv(Sock, 5000),
+                ok
+            end,
+            profile_loop(Label, Op, Opts)
+        end)
+    end).
+
+prof_mount_only(Label, Opts) ->
+    %% Mirrors bench_mount_only (bench.escript:435). Cold WS connect
+    %% cost: gen_server start + handler mount/2 + dep tracking setup.
+    %% Per iteration: spawn a live, kill it synchronously (DOWN wait)
+    %% so steady state is ~1 alive live process -- matches typical
+    %% real-world WS load instead of an artificial backlog.
+    Req = arizona_req_test_adapter:new(),
+    sanity_mount(Req),
+    Op = fun() ->
+        {ok, Sock} = arizona_socket:init(arizona_root_counter, #{}, Req, #{}),
+        arizona_bench_lib:kill_live(element(2, Sock)),
+        ok
+    end,
+    profile_loop(Label, Op, Opts).
+
+prof_stream_insert_1k(Label, Opts) ->
+    %% Mirrors bench_stream_insert_1k (bench.escript:132). Per --ops
+    %% iteration: insert 1000 unique items into a fresh empty stream.
+    %% Maps to the `add_todo` flow in arizona_page.spec.js (and bulk
+    %% data import scenarios more broadly). Catches O(n) regressions
+    %% in `arizona_stream:insert/2`.
+    KeyFun = fun(#{id := Id}) -> Id end,
+    Items = [#{id => I, text => integer_to_binary(I)} || I <- lists:seq(1, 1000)],
+    sanity_stream_insert(KeyFun, Items),
+    Op = fun() ->
+        Stream0 = arizona_stream:new(KeyFun),
+        lists:foldl(fun(I, S) -> arizona_stream:insert(S, I) end, Stream0, Items),
+        ok
+    end,
+    profile_loop(Label, Op, Opts).
+
+prof_pubsub_broadcast_100(Label, Opts) ->
+    %% Mirrors bench_pubsub_broadcast_100 (bench.escript:508). 100
+    %% subscriber procs on one topic; per iteration: one broadcast +
+    %% barrier waiting for all 100 acks. Maps to arizona_chat's
+    %% cross-tab message fan-out (each connected tab is a subscriber).
+    Topic = prof_pubsub_topic,
+    Self = self(),
+    Subs = [
+        spawn_link(fun() -> pubsub_sub_loop(Topic, Self) end)
+     || _ <- lists:seq(1, 100)
+    ],
+    ok = lists:foreach(
+        fun(P) ->
+            receive
+                {ready, P} -> ok
+            end
+        end,
+        Subs
+    ),
+    Op = fun() ->
+        arizona_pubsub:broadcast(Topic, ping),
+        await_acks(100)
+    end,
+    try
+        profile_loop(Label, Op, Opts)
+    after
+        lists:foreach(fun(P) -> exit(P, normal) end, Subs)
+    end.
+
+pubsub_sub_loop(Topic, Reporter) ->
+    ok = arizona_pubsub:subscribe(Topic, self()),
+    Reporter ! {ready, self()},
+    pubsub_sub_recv(Reporter).
+
+pubsub_sub_recv(Reporter) ->
+    receive
+        ping ->
+            Reporter ! ack,
+            pubsub_sub_recv(Reporter);
+        _ ->
+            pubsub_sub_recv(Reporter)
+    end.
+
+await_acks(0) ->
+    ok;
+await_acks(N) ->
+    receive
+        ack -> await_acks(N - 1)
+    end.
+
+sanity_http_get(Sock, Port) ->
+    case arizona_bench_lib:http_get(Sock, Port) of
+        {200, Body} when byte_size(Body) > 0 ->
+            ok;
+        Other ->
+            io:format("error: GET returned ~p~n", [Other]),
+            halt(1)
+    end.
+
+sanity_ws_send(Sock, Json) ->
+    ok = arizona_bench_lib:ws_send(Sock, Json),
+    case arizona_bench_lib:ws_recv(Sock, 5000) of
+        {text, Reply} when byte_size(Reply) > 0 ->
+            ok;
+        Other ->
+            io:format("error: WS send returned ~p~n", [Other]),
+            halt(1)
+    end.
+
+sanity_mount(Req) ->
+    case arizona_socket:init(arizona_root_counter, #{}, Req, #{}) of
+        {ok, Sock} when is_pid(element(2, Sock)) ->
+            arizona_bench_lib:kill_live(element(2, Sock));
+        Other ->
+            io:format("error: mount returned ~p~n", [Other]),
+            halt(1)
+    end.
+
+sanity_stream_insert(KeyFun, Items) ->
+    Stream = lists:foldl(
+        fun(I, S) -> arizona_stream:insert(S, I) end,
+        arizona_stream:new(KeyFun),
+        Items
+    ),
+    case length(arizona_stream:to_list(Stream)) of
+        1000 ->
+            ok;
+        Other ->
+            io:format("error: expected 1000 stream items, got ~p~n", [Other]),
+            halt(1)
+    end.
 
 sanity_render(Module, Sample) ->
     case iolist_size(Sample) > 0 of

--- a/scripts/profile.escript
+++ b/scripts/profile.escript
@@ -1,0 +1,294 @@
+#!/usr/bin/env escript
+%%% Performance profiler for Arizona.
+%%%
+%%% Companion to `scripts/bench.escript`. Whereas bench reports per-op
+%%% wall-clock stats (good for catching regressions), profile runs each
+%%% workload once under eprof or fprof and dumps a per-MFA breakdown
+%%% (good for finding hot paths to optimize).
+%%%
+%%% Run via `make prof` (or `./scripts/profile.escript`). Like bench,
+%%% never wired into ci/precommit -- this is a developer tool.
+%%%
+%%% Usage: ./profile.escript [--only LABEL ...] [--tool eprof|fprof]
+%%%                          [--ops N] [--min-ms F] [--out-dir DIR]
+%%%   --only LABEL    restrict to specific workload(s) by label; repeatable.
+%%%                   Unknown labels exit 1. Default: all profilable workloads.
+%%%   --tool          eprof (default) | fprof. fprof gives a richer call tree
+%%%                   (OWN/ACC time, callers) at higher trace cost.
+%%%   --ops N         ops per profiling pass (default 1000). One pass, no
+%%%                   warmup, no multi-trial averaging -- profile fidelity is
+%%%                   what matters, not statistical confidence in timing.
+%%%   --min-ms F      hide MFAs whose total time < F ms in the eprof analysis
+%%%                   (default 1.0). fprof analysis ignores this.
+%%%   --out-dir DIR   directory for profile-<label>.log (default /tmp).
+
+-mode(compile).
+
+-define(DEFAULT_OPS, 1000).
+-define(DEFAULT_MIN_MS, 1.0).
+-define(DEFAULT_OUT_DIR, "/tmp").
+
+main(Args) ->
+    Opts = parse_args(Args),
+    ProjectDir = project_dir(),
+    ok = setup_code_paths(ProjectDir),
+    {ok, _} = application:ensure_all_started(arizona),
+
+    All = profilers(),
+    Selected = filter_workloads(All, maps:get(only, Opts, [])),
+    lists:foreach(
+        fun({Label, Fun}) -> Fun(Label, Opts) end,
+        Selected
+    ).
+
+profilers() ->
+    [
+        {~"render_view_page", fun prof_render_view_page/2},
+        {~"render_each_100", fun prof_render_each_100/2},
+        {~"diff_simple_event", fun prof_diff_simple_event/2},
+        {~"stream_reorder_100", fun prof_stream_reorder_100/2}
+    ].
+
+filter_workloads(All, []) ->
+    All;
+filter_workloads(All, Labels) ->
+    Known = [L || {L, _} <- All],
+    Unknown = [L || L <- Labels, not lists:member(L, Known)],
+    case Unknown of
+        [] ->
+            ok;
+        _ ->
+            io:format("error: unknown workload(s): ~p~n", [Unknown]),
+            io:format("available: ~p~n", [Known]),
+            halt(1)
+    end,
+    [{L, F} || {L, F} <- All, lists:member(L, Labels)].
+
+%% ---------------------------------------------------------------------------
+%% Workloads
+%% ---------------------------------------------------------------------------
+
+%% Each workload mirrors a `bench.escript` workload but inlines the loop
+%% so the profiler captures only the unit of work, not the bench harness's
+%% timing/stats machinery.
+
+prof_render_view_page(Label, Opts) ->
+    %% Mirrors bench_render_view_page (bench.escript:107). Renders
+    %% arizona_page (route-level view with three embedded arizona_counter
+    %% stateful children). Exercises the multi-child snapshot path:
+    %% arizona_template:stateful, arizona_render:make_ssr_child_snap, and
+    %% child-view fingerprint propagation.
+    Req = arizona_req_test_adapter:new(),
+    Sample = arizona_render:render_view_to_iolist(arizona_page, Req, #{}),
+    sanity_render(arizona_page, Sample),
+    Op = fun() ->
+        arizona_render:render_view_to_iolist(arizona_page, Req, #{})
+    end,
+    profile_loop(Label, Op, Opts).
+
+prof_render_each_100(Label, Opts) ->
+    %% Mirrors bench_render_each_100 (bench.escript:115). Renders
+    %% arizona_about with a 100-element `tags` binding -- exercises
+    %% arizona_eval:render_list_items, arizona_render:zip_list_fp, and
+    %% the per-item iteration path real apps rely on.
+    Tags = [iolist_to_binary(io_lib:format("tag~b", [I])) || I <- lists:seq(1, 100)],
+    Bindings = #{bindings => #{tags => Tags}},
+    Req = arizona_req_test_adapter:new(),
+    Sample = arizona_render:render_view_to_iolist(arizona_about, Req, Bindings),
+    sanity_render(arizona_about, Sample),
+    Op = fun() ->
+        arizona_render:render_view_to_iolist(arizona_about, Req, Bindings)
+    end,
+    profile_loop(Label, Op, Opts).
+
+prof_diff_simple_event(Label, Opts) ->
+    %% Mirrors bench_diff_simple_event (bench.escript:489). Mount once,
+    %% then loop `inc` events on arizona_root_counter. Each event mutates
+    %% the `count` binding, so arizona_diff:diff/4 emits one OP_TEXT op.
+    %% Exercises full WS event roundtrip: arizona_socket:handle_in +
+    %% handler dispatch + diff + reply encode.
+    Req = arizona_req_test_adapter:new(),
+    {ok, Socket} = arizona_socket:init(arizona_root_counter, #{}, Req, #{}),
+    Json = iolist_to_binary(json:encode([~"counter", ~"inc", #{}])),
+    sanity_handle_in(Json, Socket),
+    Op = fun() ->
+        case arizona_socket:handle_in(Json, Socket) of
+            {ok, _} -> ok;
+            {reply, _, _} -> ok
+        end
+    end,
+    profile_loop(Label, Op, Opts).
+
+prof_stream_reorder_100(Label, Opts) ->
+    %% Mirrors bench_stream_reorder_100 (bench.escript:313). Mount
+    %% arizona_datatable seeded with a 100-row stream, then loop sort
+    %% events. Each sort flips asc<->desc, producing a full reverse --
+    %% the LIS reorder worst case (1 item stays put, 99 emit MOVE ops).
+    Items = [
+        #{
+            id => I,
+            name => iolist_to_binary(io_lib:format("name~b", [I])),
+            age => 20 + I rem 50
+        }
+     || I <- lists:seq(1, 100)
+    ],
+    Stream = arizona_stream:new(fun(#{id := Id}) -> Id end, Items),
+    Req = arizona_req_test_adapter:new(),
+    {ok, Socket} = arizona_socket:init(
+        arizona_datatable, #{rows => Stream}, Req, #{}
+    ),
+    Json = iolist_to_binary(
+        json:encode([~"page", ~"sort", #{~"col" => ~"id"}])
+    ),
+    sanity_handle_in(Json, Socket),
+    Op = fun() ->
+        case arizona_socket:handle_in(Json, Socket) of
+            {ok, _} -> ok;
+            {reply, _, _} -> ok
+        end
+    end,
+    profile_loop(Label, Op, Opts).
+
+sanity_render(Module, Sample) ->
+    case iolist_size(Sample) > 0 of
+        true ->
+            ok;
+        false ->
+            io:format("error: render_view_to_iolist ~p returned empty~n", [Module]),
+            halt(1)
+    end.
+
+sanity_handle_in(Json, Socket) ->
+    case arizona_socket:handle_in(Json, Socket) of
+        {ok, _} ->
+            ok;
+        {reply, _, _} ->
+            ok;
+        Other ->
+            io:format("error: handle_in returned unexpected ~p~n", [Other]),
+            halt(1)
+    end.
+
+%% ---------------------------------------------------------------------------
+%% Profile harness
+%% ---------------------------------------------------------------------------
+
+profile_loop(Label, OpFun, Opts) ->
+    Tool = maps:get(tool, Opts, eprof),
+    Ops = maps:get(ops, Opts, ?DEFAULT_OPS),
+    MinMs = maps:get(min_ms, Opts, ?DEFAULT_MIN_MS),
+    OutDir = maps:get(out_dir, Opts, ?DEFAULT_OUT_DIR),
+    LabelStr = binary_to_list(Label),
+    LogPath = filename:join(OutDir, "arizona_profile_" ++ LabelStr ++ ".log"),
+    erlang:garbage_collect(self()),
+    case Tool of
+        eprof ->
+            ok = arizona_profiler:start(),
+            run_n(OpFun, Ops),
+            ok = arizona_profiler:stop_and_dump(LogPath, MinMs);
+        fprof ->
+            TracePath = LogPath ++ ".trace",
+            ok = arizona_profiler:start_fprof(TracePath),
+            run_n(OpFun, Ops),
+            ok = arizona_profiler:stop_fprof_and_dump(TracePath, LogPath)
+    end,
+    print_result(Label, Tool, MinMs, LogPath).
+
+run_n(_Fun, 0) ->
+    ok;
+run_n(Fun, N) ->
+    Fun(),
+    run_n(Fun, N - 1).
+
+print_result(Label, eprof, MinMs, Path) ->
+    io:format(
+        "~nprofile (eprof, ~s, total time, rows >= ~.2f ms) -> ~s~n",
+        [Label, MinMs, Path]
+    ),
+    print_file(Path);
+print_result(Label, fprof, _MinMs, Path) ->
+    io:format("~nprofile (fprof, ~s, OWN time, sort=own) -> ~s~n", [Label, Path]),
+    print_file(Path).
+
+print_file(Path) ->
+    case file:read_file(Path) of
+        {ok, Bin} ->
+            io:put_chars(Bin),
+            io:nl();
+        {error, Reason} ->
+            io:format("  could not read ~s: ~p~n", [Path, Reason])
+    end.
+
+%% ---------------------------------------------------------------------------
+%% Args + paths
+%% ---------------------------------------------------------------------------
+
+parse_args(Args) ->
+    parse_args(Args, #{only => []}).
+
+parse_args([], Opts) ->
+    Opts#{only => lists:reverse(maps:get(only, Opts))};
+parse_args(["--only", Label | Rest], Opts) ->
+    Only = [list_to_binary(Label) | maps:get(only, Opts)],
+    parse_args(Rest, Opts#{only => Only});
+parse_args(["--tool", "eprof" | Rest], Opts) ->
+    parse_args(Rest, Opts#{tool => eprof});
+parse_args(["--tool", "fprof" | Rest], Opts) ->
+    parse_args(Rest, Opts#{tool => fprof});
+parse_args(["--tool", Other | _Rest], _Opts) ->
+    io:format("error: --tool must be eprof or fprof, got ~s~n", [Other]),
+    halt(1);
+parse_args(["--ops", NStr | Rest], Opts) ->
+    parse_args(Rest, Opts#{ops => list_to_integer(NStr)});
+parse_args(["--min-ms", FStr | Rest], Opts) ->
+    parse_args(Rest, Opts#{min_ms => list_to_float_lenient(FStr)});
+parse_args(["--out-dir", Dir | Rest], Opts) ->
+    parse_args(Rest, Opts#{out_dir => Dir});
+parse_args([Other | _Rest], _Opts) ->
+    io:format("error: unknown arg ~s~n", [Other]),
+    halt(1).
+
+list_to_float_lenient(Str) ->
+    case string:to_float(Str) of
+        {Float, ""} ->
+            Float;
+        _ ->
+            float(list_to_integer(Str))
+    end.
+
+setup_code_paths(BaseDir) ->
+    %% Prefer the test profile's lib dir so test/support/ modules
+    %% (arizona_profiler, arizona_req_test_adapter, fixtures) are
+    %% available. Fall back to default if test profile isn't compiled.
+    Candidates = [
+        filename:join([BaseDir, "_build", "test", "lib"]),
+        filename:join([BaseDir, "_build", "default", "lib"])
+    ],
+    LibDir =
+        case lists:filter(fun filelib:is_dir/1, Candidates) of
+            [Found | _] ->
+                Found;
+            [] ->
+                io:format("error: no compiled libs found; run 'rebar3 as test compile' first~n"),
+                halt(1)
+        end,
+    {ok, Libs} = file:list_dir(LibDir),
+    lists:foreach(
+        fun(Lib) ->
+            EbinDir = filename:join([LibDir, Lib, "ebin"]),
+            case filelib:is_dir(EbinDir) of
+                true -> code:add_pathz(EbinDir);
+                false -> ok
+            end,
+            TestDir = filename:join([LibDir, Lib, "test"]),
+            case filelib:is_dir(TestDir) of
+                true -> code:add_pathz(TestDir);
+                false -> ok
+            end
+        end,
+        Libs
+    ),
+    ok.
+
+project_dir() ->
+    filename:dirname(filename:absname(filename:dirname(escript:script_name()))).

--- a/scripts/profile.escript
+++ b/scripts/profile.escript
@@ -239,6 +239,9 @@ prof_http_get_e2e(Label, Opts) ->
     %% cowboy parse + arizona_http handler + view mount/render + reply
     %% writing. Maps to every e2e spec's initial `goto()` -- the cost
     %% the user pays before any WS event fires.
+    %%
+    %% Uses `profile_loop_server/4` so eprof traces only cowboy/arizona
+    %% pids; the `gen_tcp` send/recv work in `self()` runs un-traced.
     Routes = [
         {live, <<"/">>, arizona_root_counter, #{layouts => [{arizona_layout, render}]}}
     ],
@@ -249,15 +252,19 @@ prof_http_get_e2e(Label, Opts) ->
                 {200, _} = arizona_bench_lib:http_get(Sock, Port),
                 ok
             end,
-            profile_loop(Label, Op, Opts)
+            profile_loop_server(Label, Op, Opts, server_pids())
         end)
     end).
 
 prof_ws_event_e2e(Label, Opts) ->
     %% Mirrors bench_ws_event_e2e (bench.escript:390). Full WS roundtrip:
     %% one `inc` text frame -> arizona_socket:handle_in -> live dispatch
-    %> -> diff -> reply encode -> WS frame back. Maps to every counter/
+    %% -> diff -> reply encode -> WS frame back. Maps to every counter/
     %% form click in the e2e specs.
+    %%
+    %% Uses `profile_loop_server/4` so the harness's per-frame WS mask
+    %% (`ws_mask`/`crypto:strong_rand_bytes_nif`) and `port_command`
+    %% calls don't drown out the server-side rows.
     Routes = [
         {live, <<"/">>, arizona_root_counter, #{layouts => [{arizona_layout, render}]}},
         {ws, <<"/ws">>, #{}}
@@ -271,9 +278,32 @@ prof_ws_event_e2e(Label, Opts) ->
                 {text, _} = arizona_bench_lib:ws_recv(Sock, 5000),
                 ok
             end,
-            profile_loop(Label, Op, Opts)
+            profile_loop_server(Label, Op, Opts, server_pids())
         end)
     end).
+
+%% Snapshot of the running cowboy/ranch/arizona processes -- everything
+%% reachable through the supervisor tree by the time the listener is up.
+%% Excludes the test driver in `self()` (and its peers in the escript)
+%% so the per-op `gen_tcp:send`/`recv` in the bench harness is invisible
+%% to eprof. Connection processes spawned per-request are still caught
+%% via `set_on_spawn => true` because their parent listener is in this
+%% seed list.
+server_pids() ->
+    [
+        P
+     || P <- processes(),
+        is_server_initial_call(proc_lib:initial_call(P))
+    ].
+
+is_server_initial_call({Mod, _, _}) ->
+    ModStr = atom_to_list(Mod),
+    lists:any(
+        fun(Prefix) -> lists:prefix(Prefix, ModStr) end,
+        ["arizona_", "cowboy_", "ranch_"]
+    );
+is_server_initial_call(_) ->
+    false.
 
 prof_mount_only(Label, Opts) ->
     %% Mirrors bench_mount_only (bench.escript:435). Cold WS connect
@@ -423,6 +453,19 @@ sanity_handle_in(Json, Socket) ->
 %% ---------------------------------------------------------------------------
 
 profile_loop(Label, OpFun, Opts) ->
+    profile_loop_with(Label, OpFun, Opts, fun arizona_profiler:start/0).
+
+%% Like profile_loop/3 but seeds eprof with `SeedPids` instead of
+%% `[self()]`. Used by the e2e workloads (`prof_http_get_e2e/2`,
+%% `prof_ws_event_e2e/2`) that drive a real cowboy listener from the
+%% same BEAM -- seeding only server-side pids keeps the harness's
+%% gen_tcp work out of the trace. fprof falls back to default seeds
+%% (set_on_spawn from `self()`) -- explicit seeds aren't wired there
+%% yet, but eprof is the default and dominant tool.
+profile_loop_server(Label, OpFun, Opts, SeedPids) ->
+    profile_loop_with(Label, OpFun, Opts, fun() -> arizona_profiler:start(SeedPids) end).
+
+profile_loop_with(Label, OpFun, Opts, StartFun) ->
     Tool = maps:get(tool, Opts, eprof),
     Ops = maps:get(ops, Opts, ?DEFAULT_OPS),
     MinMs = maps:get(min_ms, Opts, ?DEFAULT_MIN_MS),
@@ -432,7 +475,7 @@ profile_loop(Label, OpFun, Opts) ->
     erlang:garbage_collect(self()),
     case Tool of
         eprof ->
-            ok = arizona_profiler:start(),
+            ok = StartFun(),
             run_n(OpFun, Ops),
             ok = arizona_profiler:stop_and_dump(LogPath, MinMs);
         fprof ->

--- a/scripts/profile.escript
+++ b/scripts/profile.escript
@@ -55,7 +55,10 @@ profilers() ->
         {~"render_nested_each", fun prof_render_nested_each/2},
         {~"render_stateful_chain", fun prof_render_stateful_chain/2},
         {~"render_view_page_dyn_js", fun prof_render_view_page_dyn_js/2},
-        {~"mixed_todo_session", fun prof_mixed_todo_session/2}
+        {~"mixed_todo_session", fun prof_mixed_todo_session/2},
+        {~"stream_with_child_100", fun prof_stream_with_child_100/2},
+        {~"stream_insert_at_100", fun prof_stream_insert_at_100/2},
+        {~"navigate_e2e", fun prof_navigate_e2e/2}
     ].
 
 filter_workloads(All, []) ->
@@ -439,6 +442,116 @@ await_acks(N) ->
         ack -> await_acks(N - 1)
     end.
 
+prof_stream_with_child_100(Label, Opts) ->
+    %% Stream + nested stateful children. Pre-mounts arizona_stream_with_child
+    %% with 100 items; the fixture wraps each stream item in two
+    %% `?stateful(arizona_counter, ...)` children. Each
+    %% `arizona_live:mount_and_render/1` call performs a fresh mount +
+    %% render -- the live process replaces its bindings/snapshot/views
+    %% per call -- so per op we walk 100 stream-item triples through
+    %% `zip_stream_item/2` *and* invoke `render_ssr_val/1` for 200
+    %% stateful descriptors. Exercises the intersection of streams and
+    %% nested SSR that neither `render_each_100` (flat list, no
+    %% stateful) nor `render_stateful_chain` (3-level chain, no
+    %% stream) covers.
+    %%
+    %% `render_view_to_iolist/3` can't drive this -- inline stateful
+    %% descriptors inside `?each` aren't unfolded by the standalone
+    %% render path; only the live process's SSR snapshot path handles
+    %% them. So we route through `mount_and_render/1` and seed eprof
+    %% with the live pid (`server_pids/0` plus the bench infra would
+    %% pull in the wrong tree -- we just want this one process).
+    Items = [
+        #{id => I, label => integer_to_binary(I)}
+     || I <- lists:seq(1, 100)
+    ],
+    Stream = arizona_stream:new(fun(#{id := Id}) -> Id end, Items),
+    Bindings = #{items => Stream},
+    Req = arizona_req_test_adapter:new(),
+    {ok, Pid} = arizona_live:start_link(
+        arizona_stream_with_child, Bindings, self(), [], Req
+    ),
+    sanity_mount_and_render(Pid),
+    Op = fun() ->
+        {ok, _, _} = arizona_live:mount_and_render(Pid),
+        ok
+    end,
+    try
+        profile_loop_server(Label, Op, Opts, [Pid])
+    after
+        arizona_bench_lib:kill_live(Pid)
+    end.
+
+prof_stream_insert_at_100(Label, Opts) ->
+    %% Position-explicit stream insert. `stream_insert_1k` exercises
+    %% the bulk `arizona_stream:insert/2` path (O(1) back-buffer cons
+    %% + pending queue). `arizona_stream:insert/3` is the
+    %% position-aware variant: each call flattens the order list
+    %% (`flat_order/1`, Front++reverse(Back)) and walks it to the
+    %% insertion point (`order_insert_at/3`) -- both O(N). Maps to UI
+    %% flows like drag-drop reorder where the new index isn't always
+    %% the tail.
+    %%
+    %% Per op: start from an empty stream, do 100 `insert/3` calls at
+    %% rotating positions. The pre-seeded variant would dominate the
+    %% trace with `new/2`'s key/order/pending construction (each op
+    %% rebuilds the 100-item seed); doing 100 inserts per op puts the
+    %% work into the path we actually want to see.
+    KeyFun = fun(#{id := Id}) -> Id end,
+    Op = fun() ->
+        S0 = arizona_stream:new(KeyFun),
+        lists:foldl(
+            fun(I, S) -> arizona_stream:insert(S, #{id => I}, I rem 11) end,
+            S0,
+            lists:seq(1, 100)
+        ),
+        ok
+    end,
+    profile_loop(Label, Op, Opts).
+
+prof_navigate_e2e(Label, Opts) ->
+    %% Full SPA navigate roundtrip: WS frame -> arizona_socket:handle_in
+    %% -> handle_navigate/3 -> route resolve -> arizona_live:navigate/5
+    %% (unmount old view, mount new) -> diff producing OP_REPLACE ->
+    %% encode -> WS frame back. E2e specs cover navigation but no
+    %% workload profiles its cost. Both routes serve `arizona_root_counter`
+    %% (a tiny navigate-safe view -- no timers, mount preserves
+    %% Bindings0's `id` so the framework's restricted-key check
+    %% passes); the cowboy_router path differs between calls, so
+    %% route resolution + unmount/remount + OP_REPLACE encode all
+    %% run on each iteration.
+    Routes = [
+        {live, <<"/">>, arizona_root_counter, #{layouts => [{arizona_layout, render}]}},
+        {live, <<"/two">>, arizona_root_counter, #{layouts => [{arizona_layout, render}]}},
+        {ws, <<"/ws">>, #{}}
+    ],
+    arizona_bench_lib:with_cowboy(prof_navigate_e2e, Routes, fun(Port) ->
+        arizona_bench_lib:with_ws_socket(Port, <<"/">>, fun(Sock) ->
+            JsonAway = iolist_to_binary(
+                json:encode([~"navigate", #{~"path" => ~"/two", ~"qs" => ~""}])
+            ),
+            JsonHome = iolist_to_binary(
+                json:encode([~"navigate", #{~"path" => ~"/", ~"qs" => ~""}])
+            ),
+            sanity_ws_send(Sock, JsonAway),
+            sanity_ws_send(Sock, JsonHome),
+            Counter = counters:new(1, []),
+            Op = fun() ->
+                N = counters:get(Counter, 1),
+                ok = counters:add(Counter, 1, 1),
+                Frame =
+                    case N band 1 of
+                        0 -> JsonAway;
+                        1 -> JsonHome
+                    end,
+                ok = arizona_bench_lib:ws_send(Sock, Frame),
+                {text, _} = arizona_bench_lib:ws_recv(Sock, 5000),
+                ok
+            end,
+            profile_loop_server(Label, Op, Opts, server_pids())
+        end)
+    end).
+
 sanity_http_get(Sock, Port) ->
     case arizona_bench_lib:http_get(Sock, Port) of
         {200, Body} when byte_size(Body) > 0 ->
@@ -478,6 +591,17 @@ sanity_stream_insert(KeyFun, Items) ->
             ok;
         Other ->
             io:format("error: expected 1000 stream items, got ~p~n", [Other]),
+            halt(1)
+    end.
+
+sanity_mount_and_render(Pid) ->
+    case arizona_live:mount_and_render(Pid) of
+        {ok, ViewId, PageContent} when
+            is_binary(ViewId), (is_binary(PageContent) orelse is_map(PageContent))
+        ->
+            ok;
+        Other ->
+            io:format("error: mount_and_render returned ~p~n", [Other]),
             halt(1)
     end.
 

--- a/scripts/profile.escript
+++ b/scripts/profile.escript
@@ -54,7 +54,8 @@ profilers() ->
         {~"pubsub_broadcast_100", fun prof_pubsub_broadcast_100/2},
         {~"render_nested_each", fun prof_render_nested_each/2},
         {~"render_stateful_chain", fun prof_render_stateful_chain/2},
-        {~"render_view_page_dyn_js", fun prof_render_view_page_dyn_js/2}
+        {~"render_view_page_dyn_js", fun prof_render_view_page_dyn_js/2},
+        {~"mixed_todo_session", fun prof_mixed_todo_session/2}
     ].
 
 filter_workloads(All, []) ->
@@ -156,6 +157,58 @@ prof_stream_reorder_100(Label, Opts) ->
         end
     end,
     profile_loop(Label, Op, Opts).
+
+prof_mixed_todo_session(Label, Opts) ->
+    %% Real-world-ish session: arizona_page (3 counters + todos stream
+    %% + form), pre-mounted with 10 seed todos, then per op cycles
+    %% through 4 representative event types in round-robin order:
+    %%   1. counter `inc`   -- per-child text update + diff
+    %%   2. page `add_todo` -- stream insert + diff with new ITEM_PATCH
+    %%   3. page `update_todo` (id 1) -- stream update with per-item dep
+    %%      tracking
+    %%   4. page `add`      -- parent broadcast, all child counters
+    %%      receive handle_update
+    %%
+    %% Surfaces hot paths the synthetic single-event workloads miss:
+    %% mixed-mode dispatch, stream lifecycle interactions, multi-key
+    %% changed maps, and the handle_call -> diff -> encode -> reply
+    %% pipeline under varied input shapes.
+    Req = arizona_req_test_adapter:new(),
+    {ok, Socket} = arizona_socket:init(arizona_page, #{}, Req, #{}),
+    %% Pre-populate 10 todos so update_todo always hits an existing id.
+    Socket1 = lists:foldl(
+        fun(_I, S) ->
+            Json = iolist_to_binary(
+                json:encode([~"page", ~"add_todo", #{}])
+            ),
+            socket_handle_in(Json, S)
+        end,
+        Socket,
+        lists:seq(1, 10)
+    ),
+    Events = {
+        iolist_to_binary(json:encode([~"counter", ~"inc", #{}])),
+        iolist_to_binary(json:encode([~"page", ~"add_todo", #{}])),
+        iolist_to_binary(
+            json:encode([~"page", ~"update_todo", #{~"id" => 1, ~"value" => ~"updated"}])
+        ),
+        iolist_to_binary(json:encode([~"page", ~"add", #{}]))
+    },
+    Counter = counters:new(1, []),
+    Op = fun() ->
+        N = counters:get(Counter, 1),
+        ok = counters:add(Counter, 1, 1),
+        Json = element((N rem 4) + 1, Events),
+        socket_handle_in(Json, Socket1),
+        ok
+    end,
+    profile_loop(Label, Op, Opts).
+
+socket_handle_in(Json, Socket) ->
+    case arizona_socket:handle_in(Json, Socket) of
+        {ok, S} -> S;
+        {reply, _, S} -> S
+    end.
 
 prof_render_view_page_dyn_js(Label, Opts) ->
     %% Renders `arizona_page` with a pre-populated 100-item todos stream

--- a/scripts/profile.escript
+++ b/scripts/profile.escript
@@ -53,7 +53,8 @@ profilers() ->
         {~"stream_insert_1k", fun prof_stream_insert_1k/2},
         {~"pubsub_broadcast_100", fun prof_pubsub_broadcast_100/2},
         {~"render_nested_each", fun prof_render_nested_each/2},
-        {~"render_stateful_chain", fun prof_render_stateful_chain/2}
+        {~"render_stateful_chain", fun prof_render_stateful_chain/2},
+        {~"render_view_page_dyn_js", fun prof_render_view_page_dyn_js/2}
     ].
 
 filter_workloads(All, []) ->
@@ -153,6 +154,31 @@ prof_stream_reorder_100(Label, Opts) ->
             {ok, _} -> ok;
             {reply, _, _} -> ok
         end
+    end,
+    profile_loop(Label, Op, Opts).
+
+prof_render_view_page_dyn_js(Label, Opts) ->
+    %% Renders `arizona_page` with a pre-populated 100-item todos stream
+    %% so the per-item dynamic `arizona_js:push_event(~"update_todo",
+    %% #{~"id" => Id})` etc. fire on every render. The static-JS fold
+    %% (commit 5fbe876) eliminates `escape_attr/1` for literal commands;
+    %% this workload exists so we still profile (and guard regressions
+    %% on) the dynamic-arg branch real apps with `?get`-driven JS
+    %% payloads will hit. Each render produces ~300 escape_attr calls
+    %% (100 todos x 3 dynamic JS attrs).
+    Todos = arizona_stream:new(
+        fun(#{id := Id}) -> Id end,
+        [
+            #{id => I, text => iolist_to_binary(io_lib:format("Todo ~b", [I]))}
+         || I <- lists:seq(1, 100)
+        ]
+    ),
+    RenderOpts = #{bindings => #{todos => Todos}},
+    Req = arizona_req_test_adapter:new(),
+    Sample = arizona_render:render_view_to_iolist(arizona_page, Req, RenderOpts),
+    sanity_render(arizona_page, Sample),
+    Op = fun() ->
+        arizona_render:render_view_to_iolist(arizona_page, Req, RenderOpts)
     end,
     profile_loop(Label, Op, Opts).
 

--- a/src/arizona.hrl
+++ b/src/arizona.hrl
@@ -13,11 +13,18 @@
 %% Type constants
 -define(EACH, 0).
 
-%% Stream record -- internal, handlers use API functions only
+%% Stream record -- internal, handlers use API functions only.
+%% `order` uses a 2-list buffer to keep `insert/2` (the bulk-append hot
+%% path) at O(1) instead of O(N): Front holds the materialized
+%% display order, Back holds recently-appended keys NEWEST-first
+%% (cons'd to). Logical order = Front ++ lists:reverse(Back). All
+%% operations except `insert/2` flush the buffer (Back -> []) before
+%% they need the full ordered list. `arizona_template:visible_keys/2`
+%% is the only external-facing reader and handles flushing internally.
 -record(stream, {
     key      :: fun((term()) -> term()),
     items    :: #{term() => term()},      %% Key => Item (O(log n) lookup)
-    order    :: [term()],                 %% Keys in display order
+    order    :: {[term()], [term()]},     %% {Front, BackRev} -- see header note
     pending  :: queue:queue(),            %% Ops in insertion order (O(1) amortized append)
     limit    :: pos_integer() | infinity, %% Max visible items
     on_limit :: halt | drop,              %% Limit mode

--- a/src/arizona_cowboy_server.erl
+++ b/src/arizona_cowboy_server.erl
@@ -86,12 +86,8 @@ terms. Called by the dev hot reloader after a successful recompile.
 -spec recompile_routes() -> ok.
 recompile_routes() ->
     Terms = persistent_term:get(),
-    lists:foreach(
-        fun
-            ({{?ROUTES_KEY, _}, Routes}) ->
-                arizona_cowboy_router:compile_routes(Routes);
-            (_) ->
-                ok
-        end,
-        Terms
-    ).
+    [
+        arizona_cowboy_router:compile_routes(Routes)
+     || {{?ROUTES_KEY, _}, Routes} <- Terms
+    ],
+    ok.

--- a/src/arizona_diff.erl
+++ b/src/arizona_diff.erl
@@ -253,16 +253,7 @@ carry_skipped_view(#{view_id := VId}, {Old, New}) ->
         #{} -> {Old, New}
     end;
 carry_skipped_view(#{child_views := ChildIds}, {Old, New}) ->
-    lists:foldl(
-        fun(Id, {O, N}) ->
-            case O of
-                #{Id := View} -> {O, N#{Id => View}};
-                #{} -> {O, N}
-            end
-        end,
-        {Old, New},
-        ChildIds
-    );
+    {Old, maps:merge(New, maps:with(ChildIds, Old))};
 carry_skipped_view(_Old, Views) ->
     Views.
 
@@ -294,16 +285,7 @@ item_child_views(ItemD, Acc) ->
 
 %% Copy child views from OldViews to NewViews for children not already present.
 carry_item_children(ChildViewIds, Old, New) ->
-    lists:foldl(
-        fun(Id, Acc) ->
-            case Old of
-                #{Id := View} -> Acc#{Id => View};
-                #{} -> Acc
-            end
-        end,
-        New,
-        ChildViewIds
-    ).
+    maps:merge(New, maps:with(ChildViewIds, Old)).
 
 -doc """
 Returns `true` when any key in `Deps` also appears in `Changed`. Used by

--- a/src/arizona_diff.erl
+++ b/src/arizona_diff.erl
@@ -704,7 +704,7 @@ lis_backtrack(Idx, Parent, Acc) ->
         end,
     lis_backtrack(Next, Parent, Acc#{Idx => true}).
 
-compute_reorder_ops(_Az, OldOrder, NewOrder, _Kept) when OldOrder =:= NewOrder ->
+compute_reorder_ops(_Az, OldOrder, OldOrder, _Kept) ->
     [];
 compute_reorder_ops(Az, OldOrder, NewOrder, Kept) ->
     KeptOld = [K || K <- OldOrder, is_map_key(K, Kept)],

--- a/src/arizona_diff.erl
+++ b/src/arizona_diff.erl
@@ -467,7 +467,7 @@ stream_reset(Az, OldItems, Rest, Source, Tmpl, SnapAcc, OldOrder, Views0) ->
     VSet = maps:from_keys(VKeys, true),
     RemOps = [
         [?OP_REMOVE, Az, arizona_template:to_bin(K)]
-     || K := _ <:- SnapAcc, not is_map_key(K, VSet)
+     || K := _ <- SnapAcc, not is_map_key(K, VSet)
     ],
     Kept = maps:with(VKeys, SnapAcc),
     {DiffOps, NewSnaps, Views1} =
@@ -578,7 +578,7 @@ apply_limit(
     KeepOnly = maps:with(VKeys, SnapItems),
     DropOps = [
         [?OP_REMOVE, Az, arizona_template:to_bin(K)]
-     || K := _ <:- SnapItems, not is_map_key(K, KeepOnly)
+     || K := _ <- SnapItems, not is_map_key(K, KeepOnly)
     ],
     {DropOps, #{t => ?EACH, items => KeepOnly, order => VKeys, template => Tmpl}, Views};
 apply_limit(
@@ -597,9 +597,9 @@ apply_limit(
     VSet = maps:from_keys(VKeys, true),
     RemOps = [
         [?OP_REMOVE, Az, arizona_template:to_bin(K)]
-     || K := _ <:- SnapItems, not is_map_key(K, VSet)
+     || K := _ <- SnapItems, not is_map_key(K, VSet)
     ],
-    Pruned = #{K => V || K := V <:- SnapItems, is_map_key(K, VSet)},
+    Pruned = #{K => V || K := V <- SnapItems, is_map_key(K, VSet)},
     {InsOps, Final, Views1} = snap_add_missing(
         Az,
         VKeys,

--- a/src/arizona_diff.erl
+++ b/src/arizona_diff.erl
@@ -566,7 +566,11 @@ apply_limit(
     SnapItems,
     Views
 ) ->
-    {[], #{t => ?EACH, items => SnapItems, order => Order, template => Tmpl}, Views};
+    %% Flush the {Front, BackRev} buffer to a flat list -- the snapshot's
+    %% `order` is consumed by `arizona_render:zip/2` as a list iterator,
+    %% not by `visible_keys/2`, so we need to materialise here.
+    FlatOrder = arizona_template:visible_keys(Order, infinity),
+    {[], #{t => ?EACH, items => SnapItems, order => FlatOrder, template => Tmpl}, Views};
 apply_limit(
     Az,
     #stream{limit = Limit, on_limit = halt, order = Order},

--- a/src/arizona_diff.erl
+++ b/src/arizona_diff.erl
@@ -257,31 +257,19 @@ carry_skipped_view(#{child_views := ChildIds}, {Old, New}) ->
 carry_skipped_view(_Old, Views) ->
     Views.
 
-%% Extract child view IDs from deleted stream items only.
+%% Extract child view IDs from deleted stream items only. The result is
+%% used in list subtraction (`OldChildViews -- Deleted`), so order doesn't
+%% matter -- safe to use a flat comp instead of a fold-with-prepend.
 deleted_item_children(Pending, OldItems) ->
-    lists:foldl(
-        fun
-            ({delete, Key}, Acc) ->
-                case OldItems of
-                    #{Key := ItemD} -> item_child_views(ItemD, Acc);
-                    #{} -> Acc
-                end;
-            (_, Acc) ->
-                Acc
-        end,
-        [],
-        queue:to_list(Pending)
-    ).
-
-item_child_views(ItemD, Acc) ->
-    lists:foldl(
-        fun
-            ({_Az, #{view_id := VId}, _Deps}, A) -> [VId | A];
-            (_, A) -> A
-        end,
-        Acc,
-        ItemD
-    ).
+    [
+        VId
+     || {delete, Key} <- queue:to_list(Pending),
+        {_Az, #{view_id := VId}, _Deps} <-
+            case OldItems of
+                #{Key := ItemD} -> ItemD;
+                #{} -> []
+            end
+    ].
 
 %% Copy child views from OldViews to NewViews for children not already present.
 carry_item_children(ChildViewIds, Old, New) ->

--- a/src/arizona_eval.erl
+++ b/src/arizona_eval.erl
@@ -282,24 +282,23 @@ was changed by the handler's mount callback.
     Props :: map(),
     Handler :: module().
 check_restricted_keys(Bindings, Props, Handler) ->
-    lists:foreach(
-        fun(Key) ->
-            case Props of
+    [check_restricted_key(Key, Bindings, Props, Handler) || Key <- ?RESTRICTED_KEYS],
+    ok.
+
+check_restricted_key(Key, Bindings, Props, Handler) ->
+    case Props of
+        #{Key := Expected} ->
+            case Bindings of
                 #{Key := Expected} ->
-                    case Bindings of
-                        #{Key := Expected} ->
-                            ok;
-                        #{Key := _} ->
-                            error(restricted_key_modified, [Key, Handler], [
-                                {error_info, #{module => ?MODULE}}
-                            ])
-                    end;
-                #{} ->
-                    ok
-            end
-        end,
-        ?RESTRICTED_KEYS
-    ).
+                    ok;
+                #{Key := _} ->
+                    error(restricted_key_modified, [Key, Handler], [
+                        {error_info, #{module => ?MODULE}}
+                    ])
+            end;
+        #{} ->
+            ok
+    end.
 
 -doc """
 Formats `restricted_key_modified` errors into a human-readable message

--- a/src/arizona_eval.erl
+++ b/src/arizona_eval.erl
@@ -258,7 +258,7 @@ Renders list items without view tracking. Returns `[ItemD]`.
     Template :: map(),
     ItemDs :: [[{arizona_template:az(), term(), map()}]].
 render_list_items_simple(Items, #{d := DFun}) ->
-    [[{Az, Val, #{}} || {Az, Val} <- eval_dynamics(DFun(Item))] || Item <- Items].
+    [[eval_one_triple(D) || D <- DFun(Item)] || Item <- Items].
 
 -doc """
 Renders map entries without view tracking. Returns `[ItemD]`.
@@ -268,13 +268,7 @@ Renders map entries without view tracking. Returns `[ItemD]`.
     Template :: map(),
     ItemDs :: [[{arizona_template:az(), term(), map()}]].
 render_map_items_simple(Map, #{d := DFun}) ->
-    maps:fold(
-        fun(K, V, Acc) ->
-            [[{Az, Val, #{}} || {Az, Val} <- eval_dynamics(DFun(K, V))] | Acc]
-        end,
-        [],
-        Map
-    ).
+    [[eval_one_triple(D) || D <- DFun(K, V)] || K := V <:- Map].
 
 -doc """
 Asserts that `Bindings` did not modify any framework-restricted keys
@@ -336,6 +330,21 @@ eval_one({Az, {attr, Name, Fun}}) when is_function(Fun, 0) ->
     {Az, {attr, Name, eval_val(Fun())}};
 eval_one({Az, Spec}) ->
     {Az, eval_val(Spec)}.
+
+%% Like eval_one/1 but builds the 3-tuple `{Az, Val, #{}}` directly,
+%% used by the per-item snapshot paths (render_list_items_simple,
+%% render_map_items_simple, render_stream_item_simple). They previously
+%% chained `[{Az, Val, #{}} || {Az, Val} <- eval_dynamics(...)]`, which
+%% allocated an intermediate 2-tuple list and re-walked it. The simple
+%% snapshot path doesn't track deps, so the empty map literal is shared.
+eval_one_triple({Az, {attr, Name, Fun}, _Loc}) when is_function(Fun, 0) ->
+    {Az, {attr, Name, eval_val(Fun())}, #{}};
+eval_one_triple({Az, Spec, _Loc}) ->
+    {Az, eval_val(Spec), #{}};
+eval_one_triple({Az, {attr, Name, Fun}}) when is_function(Fun, 0) ->
+    {Az, {attr, Name, eval_val(Fun())}, #{}};
+eval_one_triple({Az, Spec}) ->
+    {Az, eval_val(Spec), #{}}.
 
 eval_val(Fun) when is_function(Fun, 0) ->
     eval_val(Fun());
@@ -517,8 +526,7 @@ render_stream_items_simple([K | Rest], ItemsMap, Tmpl, Acc) ->
     render_stream_items_simple(Rest, ItemsMap, Tmpl, Acc#{K => D}).
 
 render_stream_item_simple(Key, Item, #{d := DFun}) ->
-    Dynamics = DFun(Item, Key),
-    [{Az, Val, #{}} || {Az, Val} <- eval_dynamics(Dynamics)].
+    [eval_one_triple(D) || D <- DFun(Item, Key)].
 
 render_list_items1([], _DFun, Views) ->
     {[], Views};

--- a/src/arizona_eval.erl
+++ b/src/arizona_eval.erl
@@ -268,7 +268,7 @@ Renders map entries without view tracking. Returns `[ItemD]`.
     Template :: map(),
     ItemDs :: [[{arizona_template:az(), term(), map()}]].
 render_map_items_simple(Map, #{d := DFun}) ->
-    [[eval_one_triple(D) || D <- DFun(K, V)] || K := V <:- Map].
+    [[eval_one_triple(D) || D <- DFun(K, V)] || K := V <- Map].
 
 -doc """
 Asserts that `Bindings` did not modify any framework-restricted keys

--- a/src/arizona_js.erl
+++ b/src/arizona_js.erl
@@ -297,10 +297,24 @@ encode_key(Key) when is_atom(Key) -> [Key];
 encode_key(Keys) when is_list(Keys) -> Keys;
 encode_key(Pattern) when is_binary(Pattern) -> Pattern.
 
+%% Tail-recursive byte walker. Replaces the previous 3x `binary:replace/4`
+%% chain. For the typical short JS-attribute payload, a single pass over
+%% the bytes (with BEAM's binary-append optimization) beats the BIF chain
+%% by ~3x. Compiled-pattern + persistent_term was tried and lost to the
+%% lookup overhead -- single-byte patterns have nothing to compile.
 escape_attr(Bin) ->
-    B1 = binary:replace(Bin, ~"&", ~"&amp;", [global]),
-    B2 = binary:replace(B1, ~"\"", ~"&quot;", [global]),
-    binary:replace(B2, ~"<", ~"&lt;", [global]).
+    escape_attr(Bin, <<>>).
+
+escape_attr(<<>>, Acc) ->
+    Acc;
+escape_attr(<<"&", Rest/binary>>, Acc) ->
+    escape_attr(Rest, <<Acc/binary, "&amp;">>);
+escape_attr(<<"\"", Rest/binary>>, Acc) ->
+    escape_attr(Rest, <<Acc/binary, "&quot;">>);
+escape_attr(<<"<", Rest/binary>>, Acc) ->
+    escape_attr(Rest, <<Acc/binary, "&lt;">>);
+escape_attr(<<C, Rest/binary>>, Acc) ->
+    escape_attr(Rest, <<Acc/binary, C>>).
 
 -ifdef(TEST).
 

--- a/src/arizona_js.erl
+++ b/src/arizona_js.erl
@@ -297,24 +297,66 @@ encode_key(Key) when is_atom(Key) -> [Key];
 encode_key(Keys) when is_list(Keys) -> Keys;
 encode_key(Pattern) when is_binary(Pattern) -> Pattern.
 
-%% Tail-recursive byte walker. Replaces the previous 3x `binary:replace/4`
-%% chain. For the typical short JS-attribute payload, a single pass over
-%% the bytes (with BEAM's binary-append optimization) beats the BIF chain
-%% by ~3x. Compiled-pattern + persistent_term was tried and lost to the
-%% lookup overhead -- single-byte patterns have nothing to compile.
-escape_attr(Bin) ->
-    escape_attr(Bin, <<>>).
+%% SWAR (SIMD Within A Register) byte scanner. Matches a 56-bit (7-byte)
+%% word at a time and uses bitwise arithmetic to validate that none of
+%% the 7 bytes is `&`, `"`, or `<` -- the only chars we need to escape.
+%% On match, advances 7 bytes via a Skip/Len counter without copying
+%% anything; the iolist Acc only grows when an escape is actually
+%% emitted. For typical JS payloads (~30-50 bytes, mostly safe) this
+%% beats the per-byte recursion by ~20%%. Inspired by erlang/otp#10938
+%% which lands an equivalent SWAR scan in OTP 29's `json` module.
+%%
+%% 56 bits is the largest value that fits in a BEAM small (59-bit on
+%% 64-bit), so all band/bxor/+/- guard ops compile to bare native
+%% instructions without bignum fallbacks.
+%%
+%% The simplified Mycroft trick `((V - 0x01..) band 0x80..) =:= 0`
+%% (no `bnot`) only works when bytes are < 0x80. The leading
+%% `(W band 0x80..) =:= 0` check gates the rest via short-circuit
+%% andalso, and XOR with constants < 0x80 preserves the high-bit-clear
+%% invariant. False positives from borrow propagation are harmless --
+%% we just fall through to the byte-by-byte path.
+-define(SWAR_M01, 16#01010101010101).
+-define(SWAR_M80, 16#80808080808080).
+-define(SWAR_AMP7, 16#26262626262626).
+-define(SWAR_QUOT7, 16#22222222222222).
+-define(SWAR_LT7, 16#3C3C3C3C3C3C3C).
 
-escape_attr(<<>>, Acc) ->
-    Acc;
-escape_attr(<<"&", Rest/binary>>, Acc) ->
-    escape_attr(Rest, <<Acc/binary, "&amp;">>);
-escape_attr(<<"\"", Rest/binary>>, Acc) ->
-    escape_attr(Rest, <<Acc/binary, "&quot;">>);
-escape_attr(<<"<", Rest/binary>>, Acc) ->
-    escape_attr(Rest, <<Acc/binary, "&lt;">>);
-escape_attr(<<C, Rest/binary>>, Acc) ->
-    escape_attr(Rest, <<Acc/binary, C>>).
+-define(swar_no_zero_byte(V),
+    (((V) - ?SWAR_M01) band ?SWAR_M80) =:= 0
+).
+
+-define(swar_safe(W),
+    ((W) band ?SWAR_M80) =:= 0 andalso
+        ?swar_no_zero_byte((W) bxor ?SWAR_AMP7) andalso
+        ?swar_no_zero_byte((W) bxor ?SWAR_QUOT7) andalso
+        ?swar_no_zero_byte((W) bxor ?SWAR_LT7)
+).
+
+escape_attr(Bin) ->
+    escape_attr(Bin, [], Bin, 0, 0).
+
+escape_attr(Bin, Acc, Orig, Skip, Len) ->
+    case Bin of
+        <<W:56, Rest/binary>> when ?swar_safe(W) ->
+            escape_attr(Rest, Acc, Orig, Skip, Len + 7);
+        <<>> when Acc =:= [], Skip =:= 0 ->
+            %% Common case: no escapes anywhere -- return original unchanged.
+            Orig;
+        <<>> ->
+            iolist_to_binary([Acc, binary:part(Orig, Skip, Len)]);
+        <<"&", Rest/binary>> ->
+            Prefix = binary:part(Orig, Skip, Len),
+            escape_attr(Rest, [Acc, Prefix, ~"&amp;"], Orig, Skip + Len + 1, 0);
+        <<"\"", Rest/binary>> ->
+            Prefix = binary:part(Orig, Skip, Len),
+            escape_attr(Rest, [Acc, Prefix, ~"&quot;"], Orig, Skip + Len + 1, 0);
+        <<"<", Rest/binary>> ->
+            Prefix = binary:part(Orig, Skip, Len),
+            escape_attr(Rest, [Acc, Prefix, ~"&lt;"], Orig, Skip + Len + 1, 0);
+        <<_C, Rest/binary>> ->
+            escape_attr(Rest, Acc, Orig, Skip, Len + 1)
+    end.
 
 -ifdef(TEST).
 

--- a/src/arizona_live.erl
+++ b/src/arizona_live.erl
@@ -477,7 +477,7 @@ process_root_change(
     Tmpl = arizona_handler:call_render(H, B1),
     Changed = compute_changed(B0, B1),
     {Ops, Snap1, V1} = arizona_diff:diff(Tmpl, Snap0, V0, Changed),
-    RemovedViews = maps:without(maps:keys(V1), V0),
+    RemovedViews = #{K => V || K := V <- V0, not is_map_key(K, V1)},
     ok = unmount_removed_views(RemovedViews),
     {Ops1, Fps1} = dedup_fps(Ops, Fps0),
     B3 = clear_streams_and_apply_resets(B1, Resets),
@@ -523,15 +523,17 @@ flush_view_messages() ->
     end.
 
 compute_changed(OldBindings, NewBindings) ->
-    maps:filter(
-        fun(K, V) ->
-            case OldBindings of
-                #{K := V} -> false;
-                #{} -> true
-            end
-        end,
-        NewBindings
-    ).
+    #{K => V || K := V <- NewBindings, key_changed(K, V, OldBindings)}.
+
+%% True iff `K` is missing from `OldBindings`, or `OldBindings`
+%% holds a different value for it. Pattern-bind `V` from `NewBindings`
+%% and reuse it as the literal in the `OldBindings` match to confirm
+%% equality.
+key_changed(K, V, OldBindings) ->
+    case OldBindings of
+        #{K := V} -> false;
+        #{} -> true
+    end.
 
 push(undefined, _Ops, _Effects) ->
     ok;

--- a/src/arizona_parse_transform.erl
+++ b/src/arizona_parse_transform.erl
@@ -965,13 +965,7 @@ extract_directives([Attr | Rest], Opts) ->
     end.
 
 opts_to_map_fields(Opts, Line) ->
-    maps:fold(
-        fun(K, V, Acc) ->
-            [{map_field_assoc, Line, {atom, Line, K}, {atom, Line, V}} | Acc]
-        end,
-        [],
-        Opts
-    ).
+    [{map_field_assoc, Line, {atom, Line, K}, {atom, Line, V}} || K := V <- Opts].
 
 atom_to_html_binary(Atom) ->
     binary:replace(atom_to_binary(Atom), <<"_">>, <<"-">>, [global]).

--- a/src/arizona_parse_transform.erl
+++ b/src/arizona_parse_transform.erl
@@ -574,15 +574,26 @@ compile_attr({tuple, _, [NameAST, ValueAST]}, ElemAz, State0, _ElemLine) when
         true ->
             ValBin = extract_binary_value(ValueAST),
             buf_append(State0, <<" ", NameBin/binary, "=\"", ValBin/binary, "\"">>);
-        false when State0#state.nodiff ->
-            Module = State0#state.module,
-            DynAST = make_nodiff_attr_dynamic_ast(NameBin, ValueAST, Module, line(ValueAST)),
-            flush(State0, DynAST);
         false ->
-            Module = State0#state.module,
-            AzBin = integer_to_binary(ElemAz),
-            DynAST = make_attr_dynamic_ast(AzBin, NameBin, ValueAST, Module, line(ValueAST)),
-            flush(State0, DynAST)
+            case try_fold_arizona_js(ValueAST) of
+                {ok, FoldedBin} ->
+                    buf_append(
+                        State0, <<" ", NameBin/binary, "=\"", FoldedBin/binary, "\"">>
+                    );
+                error when State0#state.nodiff ->
+                    Module = State0#state.module,
+                    DynAST = make_nodiff_attr_dynamic_ast(
+                        NameBin, ValueAST, Module, line(ValueAST)
+                    ),
+                    flush(State0, DynAST);
+                error ->
+                    Module = State0#state.module,
+                    AzBin = integer_to_binary(ElemAz),
+                    DynAST = make_attr_dynamic_ast(
+                        AzBin, NameBin, ValueAST, Module, line(ValueAST)
+                    ),
+                    flush(State0, DynAST)
+            end
     end;
 compile_attr({atom, _, Name}, _ElemAz, State0, _ElemLine) ->
     NameBin = atom_to_html_binary(Name),
@@ -801,6 +812,33 @@ is_static_binary({bin, _, Elements}) ->
     );
 is_static_binary(_) ->
     false.
+
+%% Try to fold an attribute value AST that is a literal `arizona_js`
+%% command (or literal list of commands) into the final
+%% HTML-attribute-safe encoded binary at compile time. Returns
+%% `{ok, Bin}` on success; `error` if the value isn't foldable (any
+%% non-literal sub-expression, unknown shape, or `arizona_js` not
+%% loaded). Falling through to the runtime dynamic path is always safe.
+try_fold_arizona_js(ExprAST) ->
+    try
+        Term = eval_arizona_js_expr(ExprAST),
+        {ok, arizona_js:encode(Term)}
+    catch
+        _:_ -> error
+    end.
+
+%% Evaluate an `arizona_js:Fn(literal-args)` call AST or a literal list
+%% of such calls into the runtime term it would yield. Throws on any
+%% non-literal sub-expression -- `try_fold_arizona_js/1` catches it.
+eval_arizona_js_expr(
+    {call, _, {remote, _, {atom, _, arizona_js}, {atom, _, Fn}}, ArgsAST}
+) ->
+    Args = [erl_syntax:concrete(A) || A <- ArgsAST],
+    apply(arizona_js, Fn, Args);
+eval_arizona_js_expr({nil, _}) ->
+    [];
+eval_arizona_js_expr({cons, _, H, T}) ->
+    [eval_arizona_js_expr(H) | eval_arizona_js_expr(T)].
 
 is_element_tuple({tuple, _, [_, Second]}) ->
     is_list_ast(Second);

--- a/src/arizona_pubsub.erl
+++ b/src/arizona_pubsub.erl
@@ -96,8 +96,7 @@ Sends `Data` as a mailbox message to every subscriber of `Channel`.
     Channel :: channel(),
     Data :: term().
 broadcast(Channel, Data) ->
-    _ = [Pid ! Data || Pid <- subscribers(Channel)],
-    ok.
+    send_each(subscribers(Channel), Data).
 
 -doc """
 Like `broadcast/2` but skips `From` -- useful when the publisher is
@@ -108,8 +107,25 @@ also a subscriber and shouldn't echo to itself.
     Channel :: channel(),
     Data :: term().
 broadcast_from(From, Channel, Data) ->
-    _ = [Pid ! Data || Pid <- subscribers(Channel), Pid =/= From],
-    ok.
+    send_each_skip(subscribers(Channel), Data, From).
+
+%% Tail-recursive send loop -- the previous `[Pid ! Data || Pid <- Subs]`
+%% form allocated a result list (one cons cell per subscriber) just to
+%% discard it via `_ = ...`. For high-fanout broadcasts (chat, presence,
+%% etc.) that's pure heap pressure.
+send_each([], _Data) ->
+    ok;
+send_each([Pid | Rest], Data) ->
+    Pid ! Data,
+    send_each(Rest, Data).
+
+send_each_skip([], _Data, _From) ->
+    ok;
+send_each_skip([From | Rest], Data, From) ->
+    send_each_skip(Rest, Data, From);
+send_each_skip([Pid | Rest], Data, From) ->
+    Pid ! Data,
+    send_each_skip(Rest, Data, From).
 
 -doc """
 Returns the list of pids currently subscribed to `Channel`.

--- a/src/arizona_render.erl
+++ b/src/arizona_render.erl
@@ -219,22 +219,23 @@ streams) recursively.
 zip([S], []) ->
     [S];
 zip([S | Statics], [D | Dynamics]) ->
-    Val =
-        case D of
-            #{t := ?EACH, items := Items, template := Tmpl} when is_list(Items) ->
-                #{s := ItemS} = Tmpl,
-                [zip_stream_item(ItemS, ItemD) || ItemD <- Items];
-            #{t := ?EACH, items := Items, order := Order, template := Tmpl} ->
-                #{s := ItemS} = Tmpl,
-                [zip_stream_item(ItemS, maps:get(K, Items)) || K <- Order];
-            #{s := InnerS, d := InnerD} ->
-                zip(InnerS, [arizona_template:unwrap_val(V) || {_Az, V} <:- InnerD]);
-            V when is_binary(V) ->
-                V;
-            V ->
-                arizona_template:to_bin(V)
-        end,
-    [S, Val | zip(Statics, Dynamics)].
+    [S, render_dyn(D) | zip(Statics, Dynamics)].
+
+%% Pre-unwrapped value path -- factored out of zip/2's body so zip_t/2
+%% (the triple-walking variant used by zip_stream_item/2) can share the
+%% same dispatch without duplicating the case clauses.
+render_dyn(#{t := ?EACH, items := Items, template := Tmpl}) when is_list(Items) ->
+    #{s := ItemS} = Tmpl,
+    [zip_stream_item(ItemS, ItemD) || ItemD <- Items];
+render_dyn(#{t := ?EACH, items := Items, order := Order, template := Tmpl}) ->
+    #{s := ItemS} = Tmpl,
+    [zip_stream_item(ItemS, maps:get(K, Items)) || K <- Order];
+render_dyn(#{s := InnerS, d := InnerD}) ->
+    zip(InnerS, [arizona_template:unwrap_val(V) || {_Az, V} <:- InnerD]);
+render_dyn(V) when is_binary(V) ->
+    V;
+render_dyn(V) ->
+    arizona_template:to_bin(V).
 
 -doc """
 Renders a single each-item snapshot.
@@ -347,8 +348,18 @@ apply_layouts([{Mod, Fun} | Rest], Inner, Bindings) ->
     Tmpl = Mod:Fun(Bindings#{inner_content => Wrapped}),
     render_to_iolist(Tmpl).
 
-zip_stream_item(Statics, ItemD) ->
-    zip(Statics, [arizona_template:unwrap_val(V) || {_Az, V, _Deps} <:- ItemD]).
+%% Triple walker -- like zip/2 but consumes `[{Az, V, Deps}]` directly
+%% (the snapshot shape `arizona_eval:render_list_items_simple/2` and
+%% friends produce). Inlines unwrap_val/1's `{attr, Name, V}` case via
+%% render_v/1, eliminating the per-item LC walk that previously
+%% preceded zip/2.
+zip_stream_item([S], []) ->
+    [S];
+zip_stream_item([S | Statics], [{_Az, V, _Deps} | DRest]) ->
+    [S, render_v(V) | zip_stream_item(Statics, DRest)].
+
+render_v({attr, Name, V}) -> arizona_template:render_attr(Name, V);
+render_v(V) -> render_dyn(V).
 
 %% Az is ignored during SSR (only used for diff targeting), so `undefined` Az
 %% from az-nodiff templates flows through harmlessly.

--- a/src/arizona_render.erl
+++ b/src/arizona_render.erl
@@ -231,7 +231,7 @@ render_dyn(#{t := ?EACH, items := Items, order := Order, template := Tmpl}) ->
     #{s := ItemS} = Tmpl,
     [zip_stream_item(ItemS, maps:get(K, Items)) || K <- Order];
 render_dyn(#{s := InnerS, d := InnerD}) ->
-    zip(InnerS, [arizona_template:unwrap_val(V) || {_Az, V} <:- InnerD]);
+    zip_d(InnerS, InnerD);
 render_dyn(V) when is_binary(V) ->
     V;
 render_dyn(V) ->
@@ -357,6 +357,15 @@ zip_stream_item([S], []) ->
     [S];
 zip_stream_item([S | Statics], [{_Az, V, _Deps} | DRest]) ->
     [S, render_v(V) | zip_stream_item(Statics, DRest)].
+
+%% Pair walker -- like zip_stream_item/2 but consumes `[{Az, V}]` 2-tuples
+%% (the snapshot d-list shape used by nested `?stateful`/`?stateless`
+%% templates). Used by render_dyn/1's `#{s, d}` clause to skip the LC
+%% walk that previously extracted values for zip/2.
+zip_d([S], []) ->
+    [S];
+zip_d([S | Statics], [{_Az, V} | DRest]) ->
+    [S, render_v(V) | zip_d(Statics, DRest)].
 
 render_v({attr, Name, V}) -> arizona_template:render_attr(Name, V);
 render_v(V) -> render_dyn(V).

--- a/src/arizona_render.erl
+++ b/src/arizona_render.erl
@@ -398,12 +398,11 @@ render_ssr_val(#{callback := Callback, props := Props}) ->
     Tmpl = Callback(Props),
     render_ssr_val(Tmpl);
 render_ssr_val(#{s := Statics, d := Dynamics} = Tmpl) ->
-    Vals = render_ssr_dynamics(Dynamics),
     Snap0 = #{
         s => Statics,
         d => [
-            {arizona_template:dyn_az(D), Val}
-         || D <- Dynamics && Val <- Vals
+            {arizona_template:dyn_az(D), render_ssr_one(D)}
+         || D <- Dynamics
         ]
     },
     arizona_template:maybe_propagate(Tmpl, Snap0);

--- a/src/arizona_render.erl
+++ b/src/arizona_render.erl
@@ -229,6 +229,8 @@ zip([S | Statics], [D | Dynamics]) ->
                 [zip_stream_item(ItemS, maps:get(K, Items)) || K <- Order];
             #{s := InnerS, d := InnerD} ->
                 zip(InnerS, [arizona_template:unwrap_val(V) || {_Az, V} <:- InnerD]);
+            V when is_binary(V) ->
+                V;
             V ->
                 arizona_template:to_bin(V)
         end,

--- a/src/arizona_socket.erl
+++ b/src/arizona_socket.erl
@@ -270,6 +270,25 @@ encode_reply(Ops, Effects, Socket) ->
 unwrap_effects(Effects) ->
     [Cmd || {arizona_js, Cmd} <:- Effects].
 
+%% Fast path for the three reply shapes produced by encode_reply/3. Hand
+%% writes the outer `{"o":...}` / `{"e":...}` / both wrapper, skipping
+%% OTP json's per-key map walk and the per-call escape on the constant
+%% `<<"o">>`/`<<"e">>` keys. The inner Ops/Effects list still goes
+%% through one `json:encode/1` call so the json module's amortised list
+%% walk handles many-op replies (e.g. stream reorders) without the
+%% per-element call setup we'd pay if we hand-iterated.
+encode(#{?OPS := Ops, ?EFFECTS := Effects}) ->
+    [
+        <<"{\"o\":">>,
+        json:encode(Ops),
+        <<",\"e\":">>,
+        json:encode(Effects),
+        $}
+    ];
+encode(#{?OPS := Ops}) ->
+    [<<"{\"o\":">>, json:encode(Ops), $}];
+encode(#{?EFFECTS := Effects}) ->
+    [<<"{\"e\":">>, json:encode(Effects), $}];
 encode(Map) ->
     json:encode(Map).
 

--- a/src/arizona_socket.erl
+++ b/src/arizona_socket.erl
@@ -309,14 +309,20 @@ flatten_ops(ViewId, [Op | Rest]) ->
 %% produced by `flatten_ops/2` and emits the JSON array with the scoped
 %% target inline as iodata. ViewId and Az are known safe (alphanumeric
 %% + dash + colon), so we can skip `json:escape_binary/5` on them.
-%% Falls back to `json:encode_value/2` for everything else (untagged
-%% replace ops, effects, payload values).
+%% Op codes are bounded 0..9 (see `?OP_*` in `arizona.hrl`) so the
+%% binary form is just `OpCode + $0` -- skips an `integer_to_binary/1`
+%% BIF call per op. Falls back to `json:encode_value/2` for everything
+%% else (untagged replace ops, effects, payload values).
 op_encoder({ViewId, [OpCode, Target | RestArgs]}, E) when
-    is_integer(OpCode), is_binary(ViewId), is_binary(Target)
+    is_integer(OpCode),
+    OpCode >= 0,
+    OpCode =< 9,
+    is_binary(ViewId),
+    is_binary(Target)
 ->
     [
         $[,
-        integer_to_binary(OpCode),
+        OpCode + $0,
         <<",\"">>,
         ViewId,
         $:,

--- a/src/arizona_socket.erl
+++ b/src/arizona_socket.erl
@@ -292,17 +292,23 @@ encode(#{?EFFECTS := Effects}) ->
 encode(Map) ->
     json:encode(Map).
 
-scope_ops(ViewId, Ops) ->
-    lists:append([scope_op(ViewId, Op) || Op <- Ops]).
-
-scope_op(_ParentViewId, [ChildViewId, ChildOps]) when is_binary(ChildViewId) ->
-    %% Recursive child diff -- flatten with child's own view id
-    scope_ops(ChildViewId, ChildOps);
-scope_op(ViewId, [?OP_ITEM_PATCH, Target, Key, InnerOps]) ->
-    %% ITEM_PATCH: scope the target, inner ops are item-relative (not scoped)
-    [[?OP_ITEM_PATCH, <<ViewId/binary, ":", Target/binary>>, Key, InnerOps]];
-scope_op(ViewId, [OpCode, Target | Rest]) when is_integer(OpCode) ->
-    [[OpCode, <<ViewId/binary, ":", Target/binary>> | Rest]].
+%% Direct recursion instead of `lists:append([scope_op(...) || ...])`:
+%% saves the per-op singleton list allocation and the trailing
+%% `lists:append/1` flatten pass. The simple OpCode and OP_ITEM_PATCH
+%% cases cons the new op directly onto the scoped tail. The child-diff
+%% case is the only one that still needs `++` (the recursive scope_ops
+%% can return many ops), but it's rare in practice.
+scope_ops(_ViewId, []) ->
+    [];
+scope_ops(_ParentViewId, [[ChildViewId, ChildOps] | Rest]) when is_binary(ChildViewId) ->
+    scope_ops(ChildViewId, ChildOps) ++ scope_ops(_ParentViewId, Rest);
+scope_ops(ViewId, [[?OP_ITEM_PATCH, Target, Key, InnerOps] | Rest]) ->
+    [
+        [?OP_ITEM_PATCH, <<ViewId/binary, ":", Target/binary>>, Key, InnerOps]
+        | scope_ops(ViewId, Rest)
+    ];
+scope_ops(ViewId, [[OpCode, Target | RestArgs] | Rest]) when is_integer(OpCode) ->
+    [[OpCode, <<ViewId/binary, ":", Target/binary>> | RestArgs] | scope_ops(ViewId, Rest)].
 
 -ifdef(TEST).
 
@@ -310,7 +316,7 @@ scope_op_replace_test() ->
     ReplOp = [8, ~"page", ~"<main>new</main>"],
     ?assertEqual(
         [[8, ~"root:page", ~"<main>new</main>"]],
-        scope_op(~"root", ReplOp)
+        scope_ops(~"root", [ReplOp])
     ).
 
 stream_scope_ops_test() ->
@@ -318,25 +324,25 @@ stream_scope_ops_test() ->
     InsOp = [5, ~"0", ~"1", -1, ~"<li>A</li>"],
     ?assertEqual(
         [[5, ~"page:0", ~"1", -1, ~"<li>A</li>"]],
-        scope_op(~"page", InsOp)
+        scope_ops(~"page", [InsOp])
     ),
     %% REMOVE
     RemOp = [6, ~"0", ~"1"],
     ?assertEqual(
         [[6, ~"page:0", ~"1"]],
-        scope_op(~"page", RemOp)
+        scope_ops(~"page", [RemOp])
     ),
     %% ITEM_PATCH
     PatchOp = [7, ~"0", ~"1", [[0, ~"0", ~"New"]]],
     ?assertEqual(
         [[7, ~"page:0", ~"1", [[0, ~"0", ~"New"]]]],
-        scope_op(~"page", PatchOp)
+        scope_ops(~"page", [PatchOp])
     ),
     %% MOVE
     MoveOp = [9, ~"0", ~"1", 0],
     ?assertEqual(
         [[9, ~"page:0", ~"1", 0]],
-        scope_op(~"page", MoveOp)
+        scope_ops(~"page", [MoveOp])
     ).
 
 -endif.

--- a/src/arizona_socket.erl
+++ b/src/arizona_socket.erl
@@ -187,8 +187,7 @@ otherwise. The client reconnects on its own.
     Info :: term(),
     Socket :: socket().
 handle_info({arizona_push, Ops, Effects}, #socket{view_id = ViewId} = Socket) ->
-    ScopedOps = scope_ops(ViewId, Ops),
-    encode_reply(ScopedOps, Effects, Socket);
+    encode_reply(flatten_ops(ViewId, Ops), Effects, Socket);
 handle_info({'EXIT', Pid, Reason}, #socket{pid = Pid} = Socket) when Reason =/= normal ->
     logger:error("Live process ~p crashed: ~p", [Pid, Reason]),
     close_crash(Socket);
@@ -256,7 +255,7 @@ replace_ops(ViewId, PageHTML) ->
 
 dispatch_event(Pid, ViewId, Event, Payload) ->
     {ok, Ops, Effects} = arizona_live:handle_event(Pid, ViewId, Event, Payload),
-    {scope_ops(ViewId, Ops), Effects}.
+    {flatten_ops(ViewId, Ops), Effects}.
 
 encode_reply([], [], Socket) ->
     {ok, Socket};
@@ -273,76 +272,107 @@ unwrap_effects(Effects) ->
 %% Fast path for the three reply shapes produced by encode_reply/3. Hand
 %% writes the outer `{"o":...}` / `{"e":...}` / both wrapper, skipping
 %% OTP json's per-key map walk and the per-call escape on the constant
-%% `<<"o">>`/`<<"e">>` keys. The inner Ops/Effects list still goes
-%% through one `json:encode/1` call so the json module's amortised list
-%% walk handles many-op replies (e.g. stream reorders) without the
-%% per-element call setup we'd pay if we hand-iterated.
+%% `<<"o">>`/`<<"e">>` keys. The Ops list goes through `json:encode/2`
+%% with `op_encoder/2` -- the custom encoder emits `"<ViewId>:<Az>"`
+%% inline as iodata, skipping the per-op binary concat (and per-target
+%% `escape_binary/5` walk) that the previous `scope_ops` did. Effects
+%% keep the default encoder -- they're plain JSON values.
 encode(#{?OPS := Ops, ?EFFECTS := Effects}) ->
     [
         <<"{\"o\":">>,
-        json:encode(Ops),
+        json:encode(Ops, fun op_encoder/2),
         <<",\"e\":">>,
         json:encode(Effects),
         $}
     ];
 encode(#{?OPS := Ops}) ->
-    [<<"{\"o\":">>, json:encode(Ops), $}];
+    [<<"{\"o\":">>, json:encode(Ops, fun op_encoder/2), $}];
 encode(#{?EFFECTS := Effects}) ->
     [<<"{\"e\":">>, json:encode(Effects), $}];
 encode(Map) ->
     json:encode(Map).
 
-%% Direct recursion instead of `lists:append([scope_op(...) || ...])`:
-%% saves the per-op singleton list allocation and the trailing
-%% `lists:append/1` flatten pass. The simple OpCode and OP_ITEM_PATCH
-%% cases cons the new op directly onto the scoped tail. The child-diff
-%% case is the only one that still needs `++` (the recursive scope_ops
-%% can return many ops), but it's rare in practice.
-scope_ops(_ViewId, []) ->
+%% Pre-flatten parent + child-view ops into tagged tuples ready for
+%% `op_encoder/2`. Each tuple's ViewId is the owning view; the encoder
+%% emits the scoped target inline at JSON write time -- no binary
+%% concat, no per-target escape_binary call. `replace_ops/2` produces
+%% UNTAGGED ops (the target IS the ViewId), so they bypass the encoder
+%% special case and go through default JSON encoding.
+flatten_ops(_ViewId, []) ->
     [];
-scope_ops(_ParentViewId, [[ChildViewId, ChildOps] | Rest]) when is_binary(ChildViewId) ->
-    scope_ops(ChildViewId, ChildOps) ++ scope_ops(_ParentViewId, Rest);
-scope_ops(ViewId, [[?OP_ITEM_PATCH, Target, Key, InnerOps] | Rest]) ->
+flatten_ops(ParentViewId, [[ChildViewId, ChildOps] | Rest]) when is_binary(ChildViewId) ->
+    flatten_ops(ChildViewId, ChildOps) ++ flatten_ops(ParentViewId, Rest);
+flatten_ops(ViewId, [Op | Rest]) ->
+    [{ViewId, Op} | flatten_ops(ViewId, Rest)].
+
+%% Custom JSON encoder. Pattern-matches the `{ViewId, RawOp}` tag
+%% produced by `flatten_ops/2` and emits the JSON array with the scoped
+%% target inline as iodata. ViewId and Az are known safe (alphanumeric
+%% + dash + colon), so we can skip `json:escape_binary/5` on them.
+%% Falls back to `json:encode_value/2` for everything else (untagged
+%% replace ops, effects, payload values).
+op_encoder({ViewId, [OpCode, Target | RestArgs]}, E) when
+    is_integer(OpCode), is_binary(ViewId), is_binary(Target)
+->
     [
-        [?OP_ITEM_PATCH, <<ViewId/binary, ":", Target/binary>>, Key, InnerOps]
-        | scope_ops(ViewId, Rest)
+        $[,
+        integer_to_binary(OpCode),
+        <<",\"">>,
+        ViewId,
+        $:,
+        Target,
+        <<"\"">>,
+        encode_rest(RestArgs, E),
+        $]
     ];
-scope_ops(ViewId, [[OpCode, Target | RestArgs] | Rest]) when is_integer(OpCode) ->
-    [[OpCode, <<ViewId/binary, ":", Target/binary>> | RestArgs] | scope_ops(ViewId, Rest)].
+op_encoder(V, E) ->
+    json:encode_value(V, E).
+
+encode_rest([], _E) -> [];
+encode_rest([H | T], E) -> [$,, E(H, E) | encode_rest(T, E)].
 
 -ifdef(TEST).
 
-scope_op_replace_test() ->
-    ReplOp = [8, ~"page", ~"<main>new</main>"],
+flatten_ops_tags_test() ->
+    %% flatten_ops emits {ViewId, RawOp} tuples; the per-target scoping
+    %% happens in op_encoder/2 at JSON write time, not here.
+    Op = [5, ~"0", ~"1", -1, ~"<li>A</li>"],
+    ?assertEqual([{~"page", Op}], flatten_ops(~"page", [Op])).
+
+flatten_ops_child_diff_test() ->
+    %% Child-view diff: [ChildViewId, ChildOps] flattens with the child's
+    %% ViewId tag, parent ops keep the parent's tag.
+    ChildOp = [0, ~"f7-0", ~"99"],
+    ParentOp = [0, ~"f12-0", ~"42"],
     ?assertEqual(
-        [[8, ~"root:page", ~"<main>new</main>"]],
-        scope_ops(~"root", [ReplOp])
+        [{~"counter", ChildOp}, {~"page", ParentOp}],
+        flatten_ops(~"page", [[~"counter", [ChildOp]], ParentOp])
     ).
 
-stream_scope_ops_test() ->
+encode_replace_op_test() ->
+    %% Replace ops are UNTAGGED -- target IS the ViewId. Default JSON
+    %% encoding, no scoping.
+    Bytes = iolist_to_binary(encode(#{?OPS => [[8, ~"page", ~"<main>new</main>"]]})),
+    ?assertEqual(~"{\"o\":[[8,\"page\",\"<main>new</main>\"]]}", Bytes).
+
+encode_stream_ops_test() ->
+    %% Tagged ops go through op_encoder/2 -- inline `<ViewId>:<Az>` emit.
     %% INSERT
     InsOp = [5, ~"0", ~"1", -1, ~"<li>A</li>"],
-    ?assertEqual(
-        [[5, ~"page:0", ~"1", -1, ~"<li>A</li>"]],
-        scope_ops(~"page", [InsOp])
-    ),
+    InsBytes = iolist_to_binary(encode(#{?OPS => flatten_ops(~"page", [InsOp])})),
+    ?assertEqual(~"{\"o\":[[5,\"page:0\",\"1\",-1,\"<li>A</li>\"]]}", InsBytes),
     %% REMOVE
     RemOp = [6, ~"0", ~"1"],
-    ?assertEqual(
-        [[6, ~"page:0", ~"1"]],
-        scope_ops(~"page", [RemOp])
-    ),
-    %% ITEM_PATCH
+    RemBytes = iolist_to_binary(encode(#{?OPS => flatten_ops(~"page", [RemOp])})),
+    ?assertEqual(~"{\"o\":[[6,\"page:0\",\"1\"]]}", RemBytes),
+    %% ITEM_PATCH -- inner ops are item-relative (NOT scoped by op_encoder
+    %% because they're not tagged tuples).
     PatchOp = [7, ~"0", ~"1", [[0, ~"0", ~"New"]]],
-    ?assertEqual(
-        [[7, ~"page:0", ~"1", [[0, ~"0", ~"New"]]]],
-        scope_ops(~"page", [PatchOp])
-    ),
+    PatchBytes = iolist_to_binary(encode(#{?OPS => flatten_ops(~"page", [PatchOp])})),
+    ?assertEqual(~"{\"o\":[[7,\"page:0\",\"1\",[[0,\"0\",\"New\"]]]]}", PatchBytes),
     %% MOVE
     MoveOp = [9, ~"0", ~"1", 0],
-    ?assertEqual(
-        [[9, ~"page:0", ~"1", 0]],
-        scope_ops(~"page", [MoveOp])
-    ).
+    MoveBytes = iolist_to_binary(encode(#{?OPS => flatten_ops(~"page", [MoveOp])})),
+    ?assertEqual(~"{\"o\":[[9,\"page:0\",\"1\",0]]}", MoveBytes).
 
 -endif.

--- a/src/arizona_stream.erl
+++ b/src/arizona_stream.erl
@@ -284,21 +284,21 @@ dynamic skipping. Items in Arizona are maps; non-map inputs crash here.
     Changed :: #{term() => true}.
 compute_item_changed(OldItem, NewItem) ->
     All = maps:merge(OldItem, NewItem),
-    maps:fold(
-        fun(K, _, Acc) ->
-            case OldItem of
-                #{K := V} ->
-                    case NewItem of
-                        #{K := V} -> Acc;
-                        #{} -> Acc#{K => true}
-                    end;
-                #{} ->
-                    Acc#{K => true}
-            end
-        end,
-        #{},
-        All
-    ).
+    #{K => true || K := _ <- All, key_changed(K, OldItem, NewItem)}.
+
+%% True iff `K` is missing from `OldItem` or `NewItem`, or both maps
+%% hold different values for it. Pattern-bind `V` from `OldItem` and
+%% reuse it as the literal in the `NewItem` match to confirm equality.
+key_changed(K, OldItem, NewItem) ->
+    case OldItem of
+        #{K := V} ->
+            case NewItem of
+                #{K := V} -> false;
+                #{} -> true
+            end;
+        #{} ->
+            true
+    end.
 
 -doc """
 Moves the item with `Key` to a new zero-based position and queues a

--- a/src/arizona_stream.erl
+++ b/src/arizona_stream.erl
@@ -125,7 +125,7 @@ new(KeyFun) when is_function(KeyFun, 1) ->
     #stream{
         key = KeyFun,
         items = #{},
-        order = [],
+        order = {[], []},
         pending = queue:new(),
         limit = infinity,
         on_limit = halt,
@@ -161,7 +161,7 @@ new(KeyFun, Items, Opts) when is_function(KeyFun, 1), is_list(Items), is_map(Opt
     #stream{
         key = KeyFun,
         items = ItemsMap,
-        order = Order,
+        order = {Order, []},
         pending = Pending,
         limit = Limit,
         on_limit = OnLimit,
@@ -179,16 +179,19 @@ insert(
     #stream{
         key = KeyFun,
         items = Items,
-        order = Order,
+        order = {Front, Back},
         pending = Pending,
         size = Size
     } = S,
     Item
 ) ->
     Key = KeyFun(Item),
+    %% O(1): cons to BackRev instead of `Front ++ [Key]`. The buffer is
+    %% flushed by the next non-insert/2 operation (or by visible_keys
+    %% on read). For 1000 sequential inserts this turns O(N^2) into O(N).
     S#stream{
         items = Items#{Key => Item},
-        order = Order ++ [Key],
+        order = {Front, [Key | Back]},
         pending = queue:in({insert, Key, Item, -1}, Pending),
         size = Size + 1
     }.
@@ -213,9 +216,10 @@ insert(
     Pos
 ) ->
     Key = KeyFun(Item),
+    Flat = flat_order(Order),
     S#stream{
         items = Items#{Key => Item},
-        order = order_insert_at(Order, Key, Pos),
+        order = {order_insert_at(Flat, Key, Pos), []},
         pending = queue:in({insert, Key, Item, Pos}, Pending),
         size = Size + 1
     }.
@@ -239,9 +243,10 @@ delete(
 ) ->
     case maps:take(Key, Items) of
         {_, NewItems} ->
+            Flat = flat_order(Order),
             S#stream{
                 items = NewItems,
-                order = order_delete(Order, Key),
+                order = {order_delete(Flat, Key), []},
                 pending = queue:in({delete, Key}, Pending),
                 size = Size - 1
             };
@@ -317,11 +322,12 @@ move(
 ) ->
     case Items of
         #{Key := _} ->
-            Order1 = order_delete(Order, Key),
+            Flat = flat_order(Order),
+            Order1 = order_delete(Flat, Key),
             Order2 = order_insert_at(Order1, Key, min(NewPos, Size - 1)),
             AfterKey = key_before(Key, Order2),
             S#stream{
-                order = Order2,
+                order = {Order2, []},
                 pending = queue:in({move, Key, AfterKey}, Pending)
             };
         #{} ->
@@ -337,7 +343,7 @@ Empties the stream and queues a reset op.
 reset(#stream{items = OldItems} = S) ->
     S#stream{
         items = #{},
-        order = [],
+        order = {[], []},
         pending = queue:from_list([{reset, OldItems}]),
         size = 0
     }.
@@ -357,7 +363,7 @@ reset(#stream{key = KeyFun, items = OldItems} = S, NewItems) when is_list(NewIte
     Order = order_from_keyed(Keyed),
     S#stream{
         items = ItemsMap,
-        order = Order,
+        order = {Order, []},
         pending = queue:from_list([{reset, OldItems}]),
         size = map_size(ItemsMap)
     }.
@@ -374,18 +380,19 @@ sort(
     #stream{items = Items, order = Order, pending = Pending} = S,
     CompareFun
 ) ->
+    Flat = flat_order(Order),
     NewOrder = lists:sort(
         fun(K1, K2) ->
             CompareFun(maps:get(K1, Items), maps:get(K2, Items))
         end,
-        Order
+        Flat
     ),
-    case NewOrder =:= Order of
+    case NewOrder =:= Flat of
         true ->
-            S;
+            S#stream{order = {Flat, []}};
         false ->
             S#stream{
-                order = NewOrder,
+                order = {NewOrder, []},
                 pending = queue:in(reorder, Pending)
             }
     end.
@@ -396,7 +403,7 @@ Returns all items in display order as a list.
 -spec to_list(Stream) -> [item()] when
     Stream :: stream().
 to_list(#stream{items = Items, order = Order}) ->
-    [maps:get(K, Items) || K <- Order].
+    [maps:get(K, Items) || K <- flat_order(Order)].
 
 -doc """
 Returns the item at `Key`. Errors with `{badkey, Key}` if not present.
@@ -460,6 +467,12 @@ stream_keys(Bindings) when is_map(Bindings) ->
 %% --------------------------------------------------------------------
 %% Internal functions
 %% --------------------------------------------------------------------
+
+%% Flush the {Front, BackRev} order buffer to a flat oldest-first list.
+%% Called by every operation that needs the full ordered keys; only
+%% `insert/2` (the bulk-append hot path) leaves the buffer non-empty.
+flat_order({Front, []}) -> Front;
+flat_order({Front, Back}) -> Front ++ lists:reverse(Back).
 
 key_items(_KeyFun, []) -> [];
 key_items(KeyFun, [I | Rest]) -> [{KeyFun(I), I} | key_items(KeyFun, Rest)].

--- a/src/arizona_template.erl
+++ b/src/arizona_template.erl
@@ -363,13 +363,19 @@ split_triples([{Az, Val, Deps} | Rest]) ->
     {[{Az, Val} | RestD], [Deps | RestDeps]}.
 
 -doc """
-Returns the visible portion of a stream order list given a `Limit`.
+Returns the visible portion of a stream order buffer given a `Limit`.
 
-`infinity` returns the full order; an integer truncates with `lists:sublist/2`.
+The order is the `arizona_stream` record's `{Front, BackRev}` 2-list
+buffer (Back holds recently-appended keys NEWEST-first). This function
+flushes the buffer to a flat oldest-first list and applies the limit.
+`infinity` returns the full order; an integer truncates via
+`lists:sublist/2`.
 """.
 -spec visible_keys(Order, Limit) -> Order1 when
-    Order :: [term()],
+    Order :: {[term()], [term()]},
     Limit :: pos_integer() | infinity,
     Order1 :: [term()].
-visible_keys(Order, infinity) -> Order;
-visible_keys(Order, Limit) -> lists:sublist(Order, Limit).
+visible_keys({Front, []}, infinity) -> Front;
+visible_keys({Front, Back}, infinity) -> Front ++ lists:reverse(Back);
+visible_keys({Front, []}, Limit) -> lists:sublist(Front, Limit);
+visible_keys({Front, Back}, Limit) -> lists:sublist(Front ++ lists:reverse(Back), Limit).

--- a/test/arizona_SUITE.erl
+++ b/test/arizona_SUITE.erl
@@ -374,12 +374,11 @@ stateful_bindings_sync(Config) when is_list(Config) ->
     CSnap = maps:get(snapshot, CView),
     %% Bindings count matches snapshot dynamic value
     ?assertEqual(5, maps:get(count, CBindings)),
-    %% Snapshot d: [{az0,{attr,id,val}}, {az1,{attr,az-click,cmd}},
-    %%              {az2,{attr,az-click,cmd}}, {az3,count_val}]
+    %% Snapshot d: [{az0,{attr,id,val}}, {az1,count_val}]
+    %% Static `arizona_js:push_event(~"inc"/~"dec")` calls fold to statics
+    %% at compile time, so they don't appear in dynamics.
     [
         {_, {attr, <<"id">>, _}},
-        {_, {attr, <<"az-click">>, _}},
-        {_, {attr, <<"az-click">>, _}},
         {_, CountVal}
     ] = maps:get(d, CSnap),
     ?assertEqual(5, CountVal).
@@ -448,19 +447,20 @@ stateless_diff(Config) when is_list(Config) ->
     ?assertMatch([[?OP_TEXT, <<"0">>, #{<<"f">> := _, <<"s">> := _, <<"d">> := _}]], Ops),
     [[_, _, Payload]] = Ops,
     ?assert(is_binary(maps:get(<<"f">>, Payload))),
-    %% Statics contain fingerprint-scoped az values, just check key fragments
+    %% Statics contain fingerprint-scoped az values, just check key fragments.
+    %% Static `arizona_js:push_event(~"inc"/~"dec")` attrs fold into the
+    %% counter's statics at compile time, so the s/d split has fewer
+    %% segments than it would if everything were dynamic.
     Statics = maps:get(<<"s">>, Payload),
-    ?assertEqual(5, length(Statics)),
+    ?assertEqual(3, length(Statics)),
     StaticsBin = iolist_to_binary(Statics),
-    %% Attr names are no longer baked into statics -- check az-view and Count:
     ?assertNotEqual(nomatch, binary:match(StaticsBin, <<"az-view">>)),
     ?assertNotEqual(nomatch, binary:match(StaticsBin, <<"Count: ">>)),
-    %% Dynamics now carry full attribute strings via unwrap_val
+    %% Dynamics now carry full attribute strings via unwrap_val. The two
+    %% `az-click` attributes folded to statics, so only id and count remain.
     ?assertEqual(
         [
             <<" id=\"sl\"">>,
-            <<" az-click=\"[0,&quot;inc&quot;]\"">>,
-            <<" az-click=\"[0,&quot;dec&quot;]\"">>,
             <<"5">>
         ],
         maps:get(<<"d">>, Payload)
@@ -526,8 +526,10 @@ deps_count_tracks_correctly(Config) when is_list(Config) ->
     {B, _} = arizona_counter:mount(#{}),
     Tmpl = arizona_counter:render(B),
     {_, Snap, _} = arizona_render:render(Tmpl, #{}),
-    %% Deps: #{id} for id attr, #{} for az-click inc/dec, #{count} for text
-    ?assertEqual([#{id => true}, #{}, #{}, #{count => true}], maps:get(deps, Snap)).
+    %% Deps: #{id} for id attr, #{count} for text. The two az-click attrs
+    %% with literal `arizona_js:push_event` are folded to statics at
+    %% compile time, so they don't produce dynamics or deps.
+    ?assertEqual([#{id => true}, #{count => true}], maps:get(deps, Snap)).
 
 deps_dedup_and_multi_key(Config) when is_list(Config) ->
     %% A dynamic that reads the same key twice should have one entry (dedup),
@@ -551,8 +553,11 @@ deps_dedup_and_multi_key(Config) when is_list(Config) ->
     ?assertEqual([#{a => true}, #{a => true, b => true}], maps:get(deps, Snap)).
 
 deps_page_tracks_correctly(Config) when is_list(Config) ->
-    %% Verify page deps: id, title, az-click (static), theme, count (counter1),
-    %% count (counter2), counter3 (static), connected (status), form statics, todos
+    %% Verify page deps. Static `arizona_js:push_event` calls (the page's
+    %% "add", "add_todo" form submit, "clear_todos", "reorder_todo" attrs)
+    %% fold to statics at compile time, so they don't produce dynamics.
+    %% Remaining dynamics: id, title, theme, counter1 (count), counter2
+    %% (count), counter3 (literal), connected (status), todos.
     {B, _} = arizona_page:mount(#{}, arizona_req_test_adapter:new(#{})),
     Tmpl = arizona_page:render(B),
     {_, Snap, _} = arizona_render:render(Tmpl, #{}),
@@ -560,15 +565,11 @@ deps_page_tracks_correctly(Config) when is_list(Config) ->
         [
             #{id => true},
             #{title => true},
-            #{},
             #{theme => true},
             #{count => true},
             #{count => true},
             #{},
             #{connected => true},
-            #{},
-            #{},
-            #{},
             #{todos => true}
         ],
         maps:get(deps, Snap)

--- a/test/arizona_cowboy_ws_SUITE.erl
+++ b/test/arizona_cowboy_ws_SUITE.erl
@@ -755,7 +755,7 @@ ws_encode_binary(Payload) ->
 ws_encode_frame(Opcode, Payload) ->
     Len = byte_size(Payload),
     Mask = crypto:strong_rand_bytes(4),
-    Masked = ws_mask(Payload, Mask, 0, <<>>),
+    Masked = ws_mask(Payload, Mask),
     case Len of
         L when L < 126 ->
             <<1:1, 0:3, Opcode:4, 1:1, L:7, Mask/binary, Masked/binary>>;
@@ -765,11 +765,16 @@ ws_encode_frame(Opcode, Payload) ->
             <<1:1, 0:3, Opcode:4, 1:1, 127:7, L:64, Mask/binary, Masked/binary>>
     end.
 
-ws_mask(<<>>, _Mask, _I, Acc) ->
+%% Rotate the 4 mask bytes through the recursive args -- O(N) instead
+%% of the previous O(N^2) version that rebuilt a 32-byte mask binary
+%% per input byte.
+ws_mask(Payload, <<M0, M1, M2, M3>>) ->
+    ws_mask(Payload, M0, M1, M2, M3, <<>>).
+
+ws_mask(<<>>, _, _, _, _, Acc) ->
     Acc;
-ws_mask(<<B, Rest/binary>>, Mask, I, Acc) ->
-    <<_:I/binary, M, _/binary>> = <<Mask/binary, Mask/binary, Mask/binary, Mask/binary>>,
-    ws_mask(Rest, Mask, (I + 1) rem 4, <<Acc/binary, (B bxor M)>>).
+ws_mask(<<B, Rest/binary>>, M0, M1, M2, M3, Acc) ->
+    ws_mask(Rest, M1, M2, M3, M0, <<Acc/binary, (B bxor M0)>>).
 
 %% Decode a server frame (unmasked)
 ws_decode(<<_Fin:1, _Rsv:3, 8:4, _M:1, Len:7, Rest/binary>>) when Len < 126 ->

--- a/test/arizona_live_SUITE.erl
+++ b/test/arizona_live_SUITE.erl
@@ -625,17 +625,18 @@ live_navigate_round_trip(Config) when is_list(Config) ->
         Pid, arizona_page, #{title => <<"Welcome">>}, arizona_req_test_adapter:new()
     ),
     ?assert(is_binary(maps:get(<<"f">>, PageContent))),
-    %% Counter child dynamics should show count 0
+    %% Counter child dynamics should show count 0. Static
+    %% `arizona_js:push_event` attrs fold to statics at compile time on
+    %% both the page and the counter, so the index of counter1 in the
+    %% page's dynamics list is 4 (id, title, theme, counter1, ...) and
+    %% the counter's own dynamics shrink from [id, az_inc, az_dec, count]
+    %% to [id, count].
     Dynamics = maps:get(<<"d">>, PageContent),
-    %% First counter child is at index 5
-    %% (1=id, 2=title, 3=az-click add, 4=theme, 5=counter)
-    CounterPayload = lists:nth(5, Dynamics),
+    CounterPayload = lists:nth(4, Dynamics),
     ?assert(is_binary(maps:get(<<"f">>, CounterPayload))),
     ?assertEqual(
         [
             <<" id=\"counter\"">>,
-            <<" az-click=\"[0,&quot;inc&quot;]\"">>,
-            <<" az-click=\"[0,&quot;dec&quot;]\"">>,
             <<"0">>
         ],
         maps:get(<<"d">>, CounterPayload)

--- a/test/support/arizona_bench_chain_a.erl
+++ b/test/support/arizona_bench_chain_a.erl
@@ -1,0 +1,24 @@
+-module(arizona_bench_chain_a).
+-moduledoc """
+Bench fixture: top-level view that embeds one `arizona_bench_chain_b`
+stateful child. First link in a 3-level stateful chain
+(view -> chain_b -> chain_c -> ?each leaves) used to profile the
+recursive `arizona_render:render_ssr_val/1` propagation through
+nested stateful descriptors.
+""".
+-include("arizona_view.hrl").
+
+-export([mount/2]).
+-export([render/1]).
+
+-spec mount(az:bindings(), az:request()) -> az:mount_ret().
+mount(Bindings0, _Req) ->
+    {maps:merge(#{id => ~"chain_a"}, Bindings0), #{}}.
+
+-spec render(az:bindings()) -> az:template().
+render(Bindings) ->
+    ?html(
+        {main, [{id, ?get(id)}], [
+            ?stateful(arizona_bench_chain_b, #{id => ~"chain_b"})
+        ]}
+    ).

--- a/test/support/arizona_bench_chain_b.erl
+++ b/test/support/arizona_bench_chain_b.erl
@@ -1,0 +1,29 @@
+-module(arizona_bench_chain_b).
+-moduledoc """
+Bench fixture: middle stateful link in the 3-level chain
+(view -> chain_b -> chain_c -> leaves). Embeds a `chain_c` stateful
+child and adds a static heading -- enough mass to force a real child
+snapshot allocation at this level.
+""".
+-include("arizona_stateful.hrl").
+
+-export([mount/1]).
+-export([render/1]).
+-export([handle_update/2]).
+
+-spec mount(az:bindings()) -> az:mount_ret().
+mount(Bindings) ->
+    {maps:merge(#{id => ~"chain_b"}, Bindings), #{}}.
+
+-spec handle_update(az:bindings(), az:bindings()) -> az:handle_update_ret().
+handle_update(Props, Bindings) ->
+    {maps:merge(Bindings, Props), #{}}.
+
+-spec render(az:bindings()) -> az:template().
+render(Bindings) ->
+    ?html(
+        {'div', [{id, ?get(id)}, {class, ~"level-b"}], [
+            {h2, [], [~"Level B"]},
+            ?stateful(arizona_bench_chain_c, #{id => ~"chain_c"})
+        ]}
+    ).

--- a/test/support/arizona_bench_chain_c.erl
+++ b/test/support/arizona_bench_chain_c.erl
@@ -1,0 +1,63 @@
+-module(arizona_bench_chain_c).
+-moduledoc """
+Bench fixture: leaf stateful in the 3-level chain
+(view -> chain_b -> chain_c -> leaves). Renders a 10-item `?each`
+list, so the profile exercises both stateful-chain propagation AND
+list iteration at the leaf -- the realistic shape of nested
+section/row components in real apps.
+""".
+-include("arizona_stateful.hrl").
+
+-export([mount/1]).
+-export([render/1]).
+-export([handle_update/2]).
+
+-spec mount(az:bindings()) -> az:mount_ret().
+mount(Bindings) ->
+    %% Lazy default: only generate the 10 leaf items if no override was
+    %% passed. Eager maps:merge would re-run default_items()/0 on every
+    %% mount even when items were provided.
+    Bindings1 = maps:merge(#{id => ~"chain_c"}, Bindings),
+    Bindings2 =
+        case Bindings1 of
+            #{items := _} -> Bindings1;
+            _ -> Bindings1#{items => default_items()}
+        end,
+    {Bindings2, #{}}.
+
+-spec handle_update(az:bindings(), az:bindings()) -> az:handle_update_ret().
+handle_update(Props, Bindings) ->
+    {maps:merge(Bindings, Props), #{}}.
+
+-spec render(az:bindings()) -> az:template().
+render(Bindings) ->
+    ?html(
+        {'div', [{id, ?get(id)}, {class, ~"level-c"}], [
+            {h2, [], [~"Level C"]},
+            {ul, [], [
+                ?each(
+                    fun(Item) ->
+                        {li, [], [arizona_template:get(text, Item)]}
+                    end,
+                    ?get(items)
+                )
+            ]}
+        ]}
+    ).
+
+%% Literal default to avoid per-mount io_lib:format overhead -- the
+%% stateful chain re-mounts on every SSR render, so any computation in
+%% the default would dominate the profile.
+default_items() ->
+    [
+        #{id => 1, text => ~"Item 1"},
+        #{id => 2, text => ~"Item 2"},
+        #{id => 3, text => ~"Item 3"},
+        #{id => 4, text => ~"Item 4"},
+        #{id => 5, text => ~"Item 5"},
+        #{id => 6, text => ~"Item 6"},
+        #{id => 7, text => ~"Item 7"},
+        #{id => 8, text => ~"Item 8"},
+        #{id => 9, text => ~"Item 9"},
+        #{id => 10, text => ~"Item 10"}
+    ].

--- a/test/support/arizona_bench_lib.erl
+++ b/test/support/arizona_bench_lib.erl
@@ -674,7 +674,7 @@ ws_recv(Sock, Timeout) ->
 ws_encode_text(Payload) ->
     Len = byte_size(Payload),
     Mask = crypto:strong_rand_bytes(4),
-    Masked = ws_mask(Payload, Mask, 0, <<>>),
+    Masked = ws_mask(Payload, Mask),
     case Len of
         L when L < 126 ->
             <<1:1, 0:3, 1:4, 1:1, L:7, Mask/binary, Masked/binary>>;
@@ -684,11 +684,18 @@ ws_encode_text(Payload) ->
             <<1:1, 0:3, 1:4, 1:1, 127:7, L:64, Mask/binary, Masked/binary>>
     end.
 
-ws_mask(<<>>, _Mask, _I, Acc) ->
+%% Rotate the 4 mask bytes through the recursive args so each byte XOR
+%% picks `M0` directly. The previous version rebuilt a 32-byte
+%% (4 mask) binary per input byte and used a binary slice with offset
+%% `I` to extract the right mask byte -- O(N^2) for an N-byte payload.
+%% This version is O(N) and dropped `ws_mask` from 30%% of `ws_event_e2e`.
+ws_mask(Payload, <<M0, M1, M2, M3>>) ->
+    ws_mask(Payload, M0, M1, M2, M3, <<>>).
+
+ws_mask(<<>>, _, _, _, _, Acc) ->
     Acc;
-ws_mask(<<B, Rest/binary>>, Mask, I, Acc) ->
-    <<_:I/binary, M, _/binary>> = <<Mask/binary, Mask/binary, Mask/binary, Mask/binary>>,
-    ws_mask(Rest, Mask, (I + 1) rem 4, <<Acc/binary, (B bxor M)>>).
+ws_mask(<<B, Rest/binary>>, M0, M1, M2, M3, Acc) ->
+    ws_mask(Rest, M1, M2, M3, M0, <<Acc/binary, (B bxor M0)>>).
 
 ws_decode(<<_Fin:1, _Rsv:3, Opcode:4, 0:1, Len:7, Rest/binary>>) when Len < 126 ->
     Payload = binary:part(Rest, 0, Len),

--- a/test/support/arizona_bench_nested_each.erl
+++ b/test/support/arizona_bench_nested_each.erl
@@ -1,0 +1,65 @@
+-module(arizona_bench_nested_each).
+-moduledoc """
+Bench fixture: 10 sections, each containing 10 items, rendered via two
+levels of `?each`. Exercises nested list-comprehension rendering --
+`arizona_eval:render_list_items_simple/2` runs at the section level,
+then again at each section's item level. Total: 100 leaf renders, but
+through a tree shape rather than a flat 100-item list.
+""".
+-include("arizona_view.hrl").
+
+-export([mount/2]).
+-export([render/1]).
+
+-spec mount(az:bindings(), az:request()) -> az:mount_ret().
+mount(Bindings0, _Req) ->
+    %% Lazy default for `sections` -- the bench workload pre-generates
+    %% the 10x10 data once and passes it via bindings, so we never want
+    %% to recompute `default_sections()` on hot-path renders. Eager
+    %% maps:merge would evaluate it regardless.
+    Bindings1 = maps:merge(#{id => ~"page"}, Bindings0),
+    Bindings =
+        case Bindings1 of
+            #{sections := _} -> Bindings1;
+            _ -> Bindings1#{sections => default_sections()}
+        end,
+    {Bindings, #{}}.
+
+-spec render(az:bindings()) -> az:template().
+render(Bindings) ->
+    ?html(
+        {main, [{id, ?get(id)}], [
+            ?each(
+                fun(Section) ->
+                    {'div', [{class, ~"section"}], [
+                        {h2, [], [arizona_template:get(title, Section)]},
+                        {ul, [], [
+                            ?each(
+                                fun(Item) ->
+                                    {li, [], [arizona_template:get(text, Item)]}
+                                end,
+                                arizona_template:get(items, Section)
+                            )
+                        ]}
+                    ]}
+                end,
+                ?get(sections)
+            )
+        ]}
+    ).
+
+default_sections() ->
+    [
+        #{
+            id => SectId,
+            title => iolist_to_binary(io_lib:format("Section ~b", [SectId])),
+            items => [
+                #{
+                    id => ItemId,
+                    text => iolist_to_binary(io_lib:format("Item ~b-~b", [SectId, ItemId]))
+                }
+             || ItemId <- lists:seq(1, 10)
+            ]
+        }
+     || SectId <- lists:seq(1, 10)
+    ].

--- a/test/support/arizona_profiler.erl
+++ b/test/support/arizona_profiler.erl
@@ -62,7 +62,7 @@ single-print of the log file content with our own ordering.
 stop_and_dump(Path, MinMs) ->
     profiling_stopped = eprof:stop_profiling(),
     ok = eprof:log(Path),
-    MinUs = trunc(MinMs * 1000),
+    MinUs = float(trunc(MinMs * 1000)),
     EprofPid = whereis(eprof),
     {group_leader, OldGl} = erlang:process_info(EprofPid, group_leader),
     Sink = spawn(fun sink_loop/0),

--- a/test/support/arizona_profiler.erl
+++ b/test/support/arizona_profiler.erl
@@ -15,6 +15,7 @@ profile isn't enough.
 """.
 
 -export([start/0]).
+-export([start/1]).
 -export([stop_and_dump/2]).
 -export([start_fprof/1]).
 -export([stop_fprof_and_dump/2]).
@@ -28,9 +29,20 @@ profile isn't enough.
 
 -spec start() -> ok.
 start() ->
+    start([self()]).
+
+%% Variant for e2e workloads that want to exclude the test-driver process
+%% (running in `self()`) from the profile. Pass server-side pids only --
+%% e.g. cowboy listener + `arizona_sup` descendants -- and `set_on_spawn`
+%% will still catch per-request connection processes spawned beneath
+%% them. The driver's `gen_tcp:send`/`recv` work in `self()` then runs
+%% un-traced, so `port_command`/`ws_mask`/`crypto:strong_rand_bytes_nif`
+%% no longer drown out the server-side rows.
+-spec start([pid()]) -> ok.
+start(SeedPids) ->
     {ok, _} = eprof:start(),
     profiling = eprof:start_profiling(
-        [self()], {'_', '_', '_'}, [{set_on_spawn, true}]
+        SeedPids, {'_', '_', '_'}, [{set_on_spawn, true}]
     ),
     ok.
 

--- a/test/support/arizona_profiler.erl
+++ b/test/support/arizona_profiler.erl
@@ -1,0 +1,112 @@
+-module(arizona_profiler).
+-moduledoc """
+eprof/fprof wrapper for `scripts/profile.escript`.
+
+Profile workloads run in-process: the escript is both the load driver
+and the system under load. Seeds profiling with `[self()]` plus
+`set_on_spawn => true`, so processes spawned during the workload
+(the live `gen_server` from `arizona_socket:init/4`, cowboy connection
+processes, pubsub subscribers) get auto-traced.
+
+eprof is the default tool — fast, gives total time per MFA. fprof is
+opt-in via `start_fprof/1` + `stop_fprof_and_dump/2` for the richer
+call-tree analysis (OWN/ACC time, callers/callees) when eprof's flat
+profile isn't enough.
+""".
+
+-export([start/0]).
+-export([stop_and_dump/2]).
+-export([start_fprof/1]).
+-export([stop_fprof_and_dump/2]).
+
+%% The `sink_loop/0` receive is indefinite by design -- it waits for
+%% io_request messages from the eprof gen_server (forwarded while we
+%% own its group_leader) and for an explicit `stop` from the caller
+%% once analyze returns. Adding a timeout would be arbitrary or risk
+%% dropping io_request messages mid-analyze.
+-elvis([{elvis_style, no_receive_without_timeout, disable}]).
+
+-spec start() -> ok.
+start() ->
+    {ok, _} = eprof:start(),
+    profiling = eprof:start_profiling(
+        [self()], {'_', '_', '_'}, [{set_on_spawn, true}]
+    ),
+    ok.
+
+-doc """
+Stop eprof, write the analysis log to `Path`, and filter out MFAs
+whose total time is below `MinMs` milliseconds.
+
+`eprof:analyze/2` writes to BOTH the log file (via `eprof:log/1`) and
+the eprof gen_server's stdout. The analyze runs inside the eprof
+process, so we swap in a sink group_leader on that process for the
+duration of the call. That keeps the caller's stdout free for a clean
+single-print of the log file content with our own ordering.
+""".
+-spec stop_and_dump(Path, MinMs) -> ok when
+    Path :: file:filename(),
+    MinMs :: float().
+stop_and_dump(Path, MinMs) ->
+    profiling_stopped = eprof:stop_profiling(),
+    ok = eprof:log(Path),
+    MinUs = trunc(MinMs * 1000),
+    EprofPid = whereis(eprof),
+    {group_leader, OldGl} = erlang:process_info(EprofPid, group_leader),
+    Sink = spawn(fun sink_loop/0),
+    true = group_leader(Sink, EprofPid),
+    try
+        eprof:analyze(total, [{filter, [{time, MinUs}]}])
+    after
+        true = group_leader(OldGl, EprofPid),
+        Sink ! stop
+    end,
+    stopped = eprof:stop(),
+    ok.
+
+sink_loop() ->
+    receive
+        {io_request, From, ReplyAs, _Req} ->
+            From ! {io_reply, ReplyAs, ok},
+            sink_loop();
+        stop ->
+            ok
+    end.
+
+-doc """
+Start an `fprof` trace seeded with `[self()]` and `set_on_spawn`.
+`TraceFile` is the binary trace output; pass it to
+`stop_fprof_and_dump/2` along with the desired analysis output path.
+""".
+-spec start_fprof(TraceFile) -> ok when
+    TraceFile :: file:filename().
+start_fprof(TraceFile) ->
+    ok = fprof:trace([
+        start,
+        {procs, [self()]},
+        {file, TraceFile},
+        verbose
+    ]),
+    ok.
+
+-doc """
+Stop the fprof trace, profile, and write the totals analysis to
+`AnalysisPath`. Output groups results in a `totals` section followed
+by per-MFA blocks with `OWN` (exclusive) and `ACC` (inclusive) time.
+""".
+-spec stop_fprof_and_dump(TraceFile, AnalysisPath) -> ok when
+    TraceFile :: file:filename(),
+    AnalysisPath :: file:filename().
+stop_fprof_and_dump(TraceFile, AnalysisPath) ->
+    fprof:trace(stop),
+    ok = fprof:profile([{file, TraceFile}]),
+    ok = fprof:analyse([
+        {dest, AnalysisPath},
+        {cols, 120},
+        {totals, true},
+        {sort, own},
+        no_callers,
+        no_details
+    ]),
+    ok = fprof:stop(),
+    ok.


### PR DESCRIPTION
# Description

Profile-driven sweep across the SSR render, diff, stream, and JSON-encode hot paths. Adds an eprof/fprof harness and 15 workloads so the next round of perf work has scaffolding.

## Headline wins (vs `main`)

| | |
|---|---|
| `render_view_page` SSR | **4.2×** |
| `stream:insert/2` | **O(N²) → O(1)** amortised |
| `stream_reorder_100` JSON encode | **38%** |
| `escape_attr/1` JS escape | **20%** |
| `render_each_100`, `diff_simple_event` | **~15%** each |
| `pubsub_broadcast/2` | **8%** |

## Tooling

- `make prof` — eprof/fprof harness over one or all workloads
- `make prof-at REF=<sha>` — A/B vs any commit via cached git worktree
- `/profile` skill — codifies the analyse-and-optimise loop

----

- [ ] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
