### PR TITLE
Make framework errors actionable

### DIFF
--- a/.claude/rules/erlang.md
+++ b/.claude/rules/erlang.md
@@ -39,6 +39,29 @@ Rule of thumb:
 - Embeddable components → `arizona_stateful.hrl` (`mount/1`, instantiated via `?stateful(Handler, Props)`)
 - Pure template modules → `arizona_stateless.hrl`
 
+## Mount bindings -- construct, don't merge
+
+Every handler's `mount/1` (stateful) or `mount/2` (view) must build a fresh map
+literal rather than `maps:merge`-ing or `Bindings#{...}`-updating the input.
+With `arizona_live:navigate/4` the input may carry arbitrary keys from
+previously visited pages; merging passes them through and lets foreign keys
+collide with handler-owned defaults (e.g. one page's `next_id` overriding
+another's, dup-inserting on a stream). Pull each accepted override out
+explicitly via `maps:get/3`.
+
+```erlang
+%% Bad -- foreign keys carry through:
+mount(Bindings, _Req) ->
+    {maps:merge(#{id => ~"page", count => 0}, Bindings), #{}}.
+
+%% Good -- handler owns its keys, accepts a typed override:
+mount(Bindings, _Req) ->
+    {#{
+         id => ~"page",
+         count => maps:get(count, Bindings, 0)
+     }, #{}}.
+```
+
 ## Parse transform element forms
 
 | Form | Example | Description |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -552,6 +552,15 @@ value. Using `?get(id)` ensures the template renders the same value the parent p
 the server uses for tracking. `id` is a restricted key -- the handler's mount callback cannot
 override the value passed by the parent in Props.
 
+**Dispatcher error tagging.** Each `arizona_handler:call_*` wrapper catches `error:undef` and
+`error:function_clause` only when the failing stack frame is the user's exact callback, and
+re-raises with a structured reason carrying an `error_info` annotation: `{missing_callback, Mod,
+Name, Arity}`, `{unhandled_event, Mod, Event, Bindings}`, `{unhandled_info, Mod, Info, Bindings}`,
+`{unhandled_update, Mod, Props, Bindings}`, `{unhandled_unmount, Mod, Bindings}`, or
+`{render_no_clause, Mod, Bindings}`. `arizona_handler:format_error/2` turns each into a sentence
+that names the offending module/event and (when known) the view id. Errors raised from inside a
+callback's body propagate untagged.
+
 `handle_event/3` effects: a list of `arizona_js:cmd()` tuples, built using functions in
 `arizona_js.erl`. Same commands used in template attributes. Common effects:
 

--- a/e2e/parallel/arizona_page.spec.js
+++ b/e2e/parallel/arizona_page.spec.js
@@ -1035,32 +1035,28 @@ test.describe('SPA navigation', () => {
         await expect(page.locator('main h1')).toHaveText('Welcome');
     });
 
-    test('root binding survives navigate round-trip', async ({ page }) => {
-        // arizona_live carries the previous root handler's final bindings
-        // forward as the floor for the new mount's input -- session-level
-        // state set on one page is visible to the next handler's mount.
-        // The child counters on `/` mount with `count => ?get(count, 0)`
-        // from the root view, so a non-zero root `count` is observable
-        // in the child counter's <p> after a round-trip via /about.
+    test('root binding does not survive navigate round-trip without explicit forwarding', async ({
+        page,
+    }) => {
+        // arizona_live's navigate-carry feature still flows the previous
+        // root's final bindings into the next mount's input, but the
+        // example handlers (per the construct-don't-merge rule in
+        // .claude/rules/erlang.md) build a fresh map and only accept
+        // overrides they explicitly enumerate. arizona_about does not
+        // forward `count`, so a round-trip via /about resets it to the
+        // arizona_page default of 0.
         await page.goto('/');
         await page.waitForSelector('#status:has-text("Connected")');
-        // Sanity: counters start at 0
         await expect(countText(page, 'counter')).toHaveText('Count: 0');
-        // "Add +1 to both" increments root `count` (and pushes to children)
         await page.click('button[az-click*="add"]');
         await expect(countText(page, 'counter')).toHaveText('Count: 1');
-        // Navigate to about; arizona_about's mount uses the lazy
-        // `maps:merge(Defaults, Bindings0)` pattern, so it inherits
-        // root's `count` even though about itself doesn't render it.
         await page.click('a[href="/about"]');
         await expect(page.locator('main h1')).toHaveText('About');
-        // Navigate back to home. With carry-forward, root mounts with
-        // `count => 1` flowing through the merged input; without it,
-        // the handler default `count => 0` would win and the child
-        // counter would render 0.
         await page.click('a[href="/"]');
         await expect(page.locator('main h1')).toHaveText('Welcome');
-        await expect(countText(page, 'counter')).toHaveText('Count: 1');
+        // Count resets because neither arizona_about nor arizona_page
+        // explicitly forwards the carried `count` key in their mount.
+        await expect(countText(page, 'counter')).toHaveText('Count: 0');
     });
 
     test('back after navigate restores prior scroll position', async ({ page }) => {

--- a/src/arizona_error.erl
+++ b/src/arizona_error.erl
@@ -4,18 +4,18 @@ Helpers for error reporting.
 
 Two utilities consumed across the framework:
 
-- `closest/2` -- did-you-mean suggestions for `format_error/2` clauses
-  that report a missing key. Used by `arizona_template:format_error/2`
-  and `arizona_stream:format_error/2`.
+- `did_you_mean/2` -- "did you mean?" suggestion for `format_error/2`
+  clauses that report a missing key. Used by
+  `arizona_template:format_error/2` and `arizona_stream:format_error/2`.
 - `raise_or_propagate/7` -- the catch-clause helper that lets a
   dispatcher re-tag a failure originating at the user's exact callback
   while propagating any other failure untouched. Used by every
   `arizona_handler:call_*` wrapper.
 """.
 
--export([closest/2]).
+-export([did_you_mean/2]).
 -export([raise_or_propagate/7]).
--ignore_xref([closest/2]).
+-ignore_xref([did_you_mean/2]).
 -ignore_xref([raise_or_propagate/7]).
 
 -doc """
@@ -23,13 +23,13 @@ Returns the candidate closest to `Target` by Levenshtein edit distance, or
 `undefined` when nothing is close enough. The threshold scales with the
 target length so very short keys must match almost exactly.
 """.
--spec closest(Target, Candidates) -> Match | undefined when
+-spec did_you_mean(Target, Candidates) -> Match | undefined when
     Target :: term(),
     Candidates :: [term()],
     Match :: term().
-closest(_Target, []) ->
+did_you_mean(_Target, []) ->
     undefined;
-closest(Target, Candidates) ->
+did_you_mean(Target, Candidates) ->
     TargetBin = to_bin(Target),
     Threshold = max(2, byte_size(TargetBin) div 4),
     Scored = [{distance(TargetBin, to_bin(C)), C} || C <- Candidates],

--- a/src/arizona_error.erl
+++ b/src/arizona_error.erl
@@ -1,14 +1,22 @@
--module(arizona_error_hint).
+-module(arizona_error).
 -moduledoc """
-Helpers for error messages: did-you-mean suggestions.
+Helpers for error reporting.
 
-Used by `arizona_template:format_error/2` and `arizona_stream:format_error/2`
-to append `Did you mean 'X'?` when a missing key looks like a typo of an
-available key.
+Two utilities consumed across the framework:
+
+- `closest/2` -- did-you-mean suggestions for `format_error/2` clauses
+  that report a missing key. Used by `arizona_template:format_error/2`
+  and `arizona_stream:format_error/2`.
+- `raise_or_propagate/7` -- the catch-clause helper that lets a
+  dispatcher re-tag a failure originating at the user's exact callback
+  while propagating any other failure untouched. Used by every
+  `arizona_handler:call_*` wrapper.
 """.
 
 -export([closest/2]).
+-export([raise_or_propagate/7]).
 -ignore_xref([closest/2]).
+-ignore_xref([raise_or_propagate/7]).
 
 -doc """
 Returns the candidate closest to `Target` by Levenshtein edit distance, or
@@ -29,6 +37,36 @@ closest(Target, Candidates) ->
         [{D, Match} | _] when D =< Threshold, D > 0 -> Match;
         _ -> undefined
     end.
+
+-doc """
+Catch-clause helper for dispatchers that wrap a user callback.
+
+When the top stack frame is the user's exact callback (`Mod:Fn`), raises
+`Reason` with an `error_info` annotation pointing at `FormatErrorMod` --
+the module that exports the matching `format_error/2` clause. Otherwise
+propagates `error:OrigReason` with the original stacktrace untouched.
+
+The `FormatErrorMod` parameter exists because this helper lives in
+`arizona_error` but is called from various dispatcher modules; the
+`error_info` annotation must point at whichever module owns the format
+clauses for `Reason`.
+""".
+-spec raise_or_propagate(OrigReason, Stacktrace, Mod, Fn, Reason, ErrorArgs, FormatErrorMod) ->
+    no_return()
+when
+    OrigReason :: term(),
+    Stacktrace :: [tuple()],
+    Mod :: module(),
+    Fn :: atom(),
+    Reason :: term(),
+    ErrorArgs :: [term()],
+    FormatErrorMod :: module().
+raise_or_propagate(
+    _OrigReason, [{Mod, Fn, _, _} | _], Mod, Fn, Reason, ErrorArgs, FormatErrorMod
+) ->
+    erlang:error(Reason, ErrorArgs, [{error_info, #{module => FormatErrorMod}}]);
+raise_or_propagate(OrigReason, ST, _Mod, _Fn, _Reason, _ErrorArgs, _FormatErrorMod) ->
+    erlang:raise(error, OrigReason, ST).
 
 %% --------------------------------------------------------------------
 %% Internal functions

--- a/src/arizona_error_hint.erl
+++ b/src/arizona_error_hint.erl
@@ -1,0 +1,72 @@
+-module(arizona_error_hint).
+-moduledoc """
+Helpers for error messages: did-you-mean suggestions.
+
+Used by `arizona_template:format_error/2` and `arizona_stream:format_error/2`
+to append `Did you mean 'X'?` when a missing key looks like a typo of an
+available key.
+""".
+
+-export([closest/2]).
+-ignore_xref([closest/2]).
+
+-doc """
+Returns the candidate closest to `Target` by Levenshtein edit distance, or
+`undefined` when nothing is close enough. The threshold scales with the
+target length so very short keys must match almost exactly.
+""".
+-spec closest(Target, Candidates) -> Match | undefined when
+    Target :: term(),
+    Candidates :: [term()],
+    Match :: term().
+closest(_Target, []) ->
+    undefined;
+closest(Target, Candidates) ->
+    TargetBin = to_bin(Target),
+    Threshold = max(2, byte_size(TargetBin) div 4),
+    Scored = [{distance(TargetBin, to_bin(C)), C} || C <- Candidates],
+    case lists:sort(Scored) of
+        [{D, Match} | _] when D =< Threshold, D > 0 -> Match;
+        _ -> undefined
+    end.
+
+%% --------------------------------------------------------------------
+%% Internal functions
+%% --------------------------------------------------------------------
+
+to_bin(B) when is_binary(B) -> B;
+to_bin(A) when is_atom(A) -> atom_to_binary(A);
+to_bin(I) when is_integer(I) -> integer_to_binary(I);
+to_bin(T) -> unicode:characters_to_binary(io_lib:format("~0tp", [T])).
+
+%% Iterative two-row Levenshtein over byte sequences. O(N*M) time, O(min(N,M))
+%% space. Sufficient for short identifier keys, never called on hot paths.
+distance(A, B) ->
+    distance_rows(binary_to_list(A), binary_to_list(B)).
+
+distance_rows([], B) ->
+    length(B);
+distance_rows(A, []) ->
+    length(A);
+distance_rows([A | As], B) ->
+    Prev = lists:seq(0, length(B)),
+    Final = step_row([A | As], B, Prev),
+    lists:last(Final).
+
+step_row([], _B, Prev) ->
+    Prev;
+step_row([A | As], B, Prev) ->
+    [First | _] = Prev,
+    Curr = build_row(B, Prev, A, [First + 1]),
+    step_row(As, B, lists:reverse(Curr)).
+
+build_row([], _Prev, _A, Acc) ->
+    Acc;
+build_row([B | Bs], [P0, P1 | Rest], A, [Last | _] = Acc) ->
+    Cost =
+        case A =:= B of
+            true -> 0;
+            false -> 1
+        end,
+    Min = min(min(Last + 1, P1 + 1), P0 + Cost),
+    build_row(Bs, [P1 | Rest], A, [Min | Acc]).

--- a/src/arizona_error_page.erl
+++ b/src/arizona_error_page.erl
@@ -61,7 +61,7 @@ render(Bindings) ->
     Stacktrace = maps:get(stacktrace, ErrorInfo),
     ReloadUrl = maps:get(reload_url, ErrorInfo, undefined),
     Title = escape(format_title(Class, Reason, Stacktrace)),
-    ReasonStr = format_reason(Reason),
+    ReasonStr = format_reason(Class, Reason, Stacktrace),
     ?html(
         {html, [], [
             {head, [], [
@@ -89,13 +89,7 @@ render(Bindings) ->
                             {'div', [{class, ~"frame"}], [
                                 {span, [{class, ~"mod"}], [escape(atom_to_binary(M))]},
                                 ~":",
-                                {span, [{class, ~"fun"}], [
-                                    <<
-                                        (escape(atom_to_binary(F)))/binary,
-                                        "/",
-                                        (integer_to_binary(arity(A)))/binary
-                                    >>
-                                ]},
+                                {span, [{class, ~"fun"}], [escape(format_fun_name(F, A))]},
                                 {span, [{class, ~"loc"}], [~" ", Loc]}
                             ]}
                         end,
@@ -111,23 +105,121 @@ render(Bindings) ->
 %% Internal functions
 %% --------------------------------------------------------------------
 
+%% Title is just a short location -- the body shows the full reason.
+%%
+%% Strategy:
+%%
+%% 1. `compile_error` -- always "Compilation Error".
+%% 2. Otherwise, walk the stacktrace for the deepest user frame --
+%%    skipping `arizona_*` (framework) and any OTP/stdlib module.
+%%    That's the user's nearest call site, the line they actually want
+%%    to look at.
+%% 3. If the whole stack is framework/OTP, fall back to the top frame.
+%% 4. If the stack is empty, fall back to `arizona_loc`'s captured
+%%    location (when the reason is wrapped) or the bare class.
+%%
+%% Note: `arizona_loc` captures the *lexical* location of a template
+%% dynamic, which for layouts is the outer dynamic's call site, not
+%% the inner crash site. The stack tells the truth, so prefer it.
 format_title(_Class, {compile_error, _Errors}, _Stacktrace) ->
     ~"Compilation Error";
-format_title(Class, {arizona_loc, {Mod, Line}, Reason}, Stacktrace) ->
-    Prefix = unicode:characters_to_binary(io_lib:format("~s:~b: ", [Mod, Line])),
-    unicode:characters_to_binary([Prefix, error_summary(Class, Reason, Stacktrace)]);
 format_title(Class, Reason, Stacktrace) ->
-    unicode:characters_to_binary(
-        io_lib:format("~s: ~ts", [Class, error_summary(Class, Reason, Stacktrace)])
-    ).
+    case first_user_frame(Stacktrace) of
+        none ->
+            fallback_title(Class, Reason);
+        {Mod, _Fn, _A, Info} ->
+            case proplists:get_value(line, Info) of
+                undefined -> fallback_title(Class, Reason);
+                Line -> fmt_mod_line(Mod, Line)
+            end
+    end.
+
+fallback_title(_Class, {arizona_loc, {Mod, Line}, _}) ->
+    fmt_mod_line(Mod, Line);
+fallback_title(Class, _Reason) ->
+    unicode:characters_to_binary(io_lib:format("~s", [Class])).
+
+fmt_mod_line(Mod, Line) ->
+    unicode:characters_to_binary(io_lib:format("~s:~b", [Mod, Line])).
+
+%% Returns the first stack frame whose module is not framework or OTP,
+%% the topmost frame when the whole stack is framework/OTP, or `none`
+%% when the stack is empty.
+first_user_frame([]) ->
+    none;
+first_user_frame([Top | _] = Stack) ->
+    case lists:dropwhile(fun is_framework_frame/1, Stack) of
+        [] -> Top;
+        [User | _] -> User
+    end.
+
+is_framework_frame({Mod, _Fn, _A, _Info}) ->
+    is_arizona_module(Mod) orelse is_otp_module(Mod).
+
+is_arizona_module(Mod) ->
+    case atom_to_list(Mod) of
+        "arizona_" ++ _ -> true;
+        _ -> false
+    end.
+
+%% True for OTP/stdlib modules. Detected via `code:which/1`:
+%% built-ins are `preloaded`, stdlib lives under `code:root_dir()`.
+%% User modules and dependencies (e.g. arizona itself when checked out)
+%% live elsewhere and return false here.
+is_otp_module(Mod) ->
+    case code:which(Mod) of
+        preloaded ->
+            true;
+        Path when is_list(Path) ->
+            string:prefix(Path, code:root_dir() ++ "/") =/= nomatch;
+        _ ->
+            false
+    end.
+
+%% Rewrites OTP-mangled fun names for readability.
+%%
+%%   '-render/1-fun-1-'/N         -> "render/1 (anonymous fun)"
+%%   '-render_ssr_val/1-lc$^0/1-0-'/N -> "render_ssr_val/1 (list comprehension)"
+%%   '-render/1-mc$^0/1-0-'/N         -> "render/1 (map comprehension)"
+%%   <plain Fn>/N                  -> "Fn/N"
+format_fun_name(Fn, A) ->
+    Arity = arity(A),
+    Name = atom_to_list(Fn),
+    case prettify_mangled(Name) of
+        {Outer, Suffix} ->
+            unicode:characters_to_binary([Outer, " (", Suffix, ")"]);
+        plain ->
+            unicode:characters_to_binary([Name, "/", integer_to_list(Arity)])
+    end.
+
+prettify_mangled([$- | Rest]) ->
+    prettify_mangled_body(Rest, [
+        {"-fun-", "anonymous fun"},
+        {"-lc$", "list comprehension"},
+        {"-mc$", "map comprehension"}
+    ]);
+prettify_mangled(_) ->
+    plain.
+
+prettify_mangled_body(_Rest, []) ->
+    plain;
+prettify_mangled_body(Rest, [{Sep, Suffix} | More]) ->
+    case string:split(Rest, Sep) of
+        [Outer, _Tail] when Outer =/= Rest -> {Outer, Suffix};
+        _ -> prettify_mangled_body(Rest, More)
+    end.
 
 %% Use erl_error:format_exception to get the rich, shell-style summary.
-%% Output looks like:
-%%   "exception error: no function clause matching \n
-%%                     arizona_template:to_bin({}) (src/...erl:68)\n
-%%     in function  arizona_render:zip/2 ..."
-%% We extract everything after "exception <class>: " up to "\n  in ",
-%% collapsing continuation newlines into spaces.
+%% Output for an error_info-annotated raise looks like:
+%%   "exception error: missing_binding\n
+%%      in function  arizona_template:get/2\n
+%%         called as arizona_template:get(missing_key, #{a => 1})\n
+%%         *** binding missing_key not found. Available bindings: ...\n
+%%      in call from ..."
+%% The format_error/2 sentence lands on the `*** ` line, nested under
+%% the failing function's frame -- prefer it when present. For errors
+%% without error_info (plain badmatch, etc.) the top "exception <class>: "
+%% line already carries the useful message, so we fall back to that.
 error_summary(Class, Reason, Stacktrace) ->
     try
         Flat = lists:flatten(erl_error:format_exception(Class, Reason, Stacktrace)),
@@ -137,9 +229,34 @@ error_summary(Class, Reason, Stacktrace) ->
             io_lib:format("~w:~0tp", [Class, Reason])
     end.
 
-extract_summary("exception " ++ Rest) ->
+%% Prefer the format_error/2 annotation line when erl_error attached one.
+%% Otherwise take the top "exception <class>: ..." line up to the first
+%% stack frame.
+extract_summary(Flat) ->
+    case extract_format_error_line(Flat) of
+        nomatch -> extract_top_line(Flat);
+        Line -> Line
+    end.
+
+%% erl_error indents the format_error/2 annotation with 5 spaces under
+%% "called as ...". Find that marker, skip it, take the rest of the line.
+extract_format_error_line(Flat) ->
+    Marker = "\n     *** ",
+    case string:find(Flat, Marker) of
+        nomatch ->
+            nomatch;
+        Found ->
+            AfterMarker = string:slice(Found, length(Marker)),
+            take_until_newline(AfterMarker, [])
+    end.
+
+take_until_newline([$\n | _], Acc) -> lists:reverse(Acc);
+take_until_newline([C | Rest], Acc) -> take_until_newline(Rest, [C | Acc]);
+take_until_newline([], Acc) -> lists:reverse(Acc).
+
+extract_top_line("exception " ++ Rest) ->
     skip_class(Rest);
-extract_summary(Other) ->
+extract_top_line(Other) ->
     Other.
 
 skip_class([$:, $\s | Rest]) ->
@@ -164,16 +281,22 @@ take_summary([], Acc) ->
 skip_spaces([$\s | Rest]) -> skip_spaces(Rest);
 skip_spaces(Other) -> Other.
 
-format_reason({compile_error, Errors}) ->
+format_reason(_Class, {compile_error, Errors}, _Stacktrace) ->
     escape(
         unicode:characters_to_binary(
             lists:join("\n\n", [format_file_errors(F, Es) || {F, Es} <:- Errors])
         )
     );
-format_reason({arizona_loc, _Loc, Reason}) ->
-    format_reason(Reason);
-format_reason(Reason) ->
-    escape(unicode:characters_to_binary(io_lib:format("~0tp", [Reason]))).
+format_reason(Class, {arizona_loc, _Loc, Reason}, Stacktrace) ->
+    format_reason(Class, Reason, Stacktrace);
+format_reason(Class, Reason, Stacktrace) ->
+    %% Body shows the full summary -- title is just the location, so
+    %% there's no repetition. Falls back to `~0tp` for plain reasons
+    %% without any erl_error-format output.
+    case error_summary(Class, Reason, Stacktrace) of
+        [] -> escape(unicode:characters_to_binary(io_lib:format("~0tp", [Reason])));
+        Summary -> escape(unicode:characters_to_binary(Summary))
+    end.
 
 format_file_errors(File, Errors) ->
     [File, ":\n", lists:join("\n", [format_one_error(E) || E <- Errors])].
@@ -188,7 +311,22 @@ format_loc(Info) ->
     Line = proplists:get_value(line, Info, 0),
     case File of
         "" -> <<>>;
-        _ -> unicode:characters_to_binary([File, ":", integer_to_list(Line)])
+        _ -> unicode:characters_to_binary([relative_path(File), ":", integer_to_list(Line)])
+    end.
+
+%% Trims the cwd prefix from absolute paths so frames render as e.g.
+%% `src/arizona_template.erl:153` instead of
+%% `/home/.../arizona_template.erl:153`. Falls through unchanged when
+%% cwd lookup fails or the path is already relative / outside cwd.
+relative_path(File) ->
+    case file:get_cwd() of
+        {ok, Cwd} ->
+            case string:prefix(File, Cwd ++ "/") of
+                nomatch -> File;
+                Rel -> Rel
+            end;
+        _ ->
+            File
     end.
 
 escape(Bin) when is_binary(Bin) ->
@@ -222,19 +360,21 @@ format_title_compile_error_test() ->
     ?assertEqual(~"Compilation Error", format_title(error, {compile_error, []}, [])).
 
 format_title_arizona_loc_test() ->
+    %% Empty stack -> fallback uses arizona_loc's captured location.
     Title = format_title(error, {arizona_loc, {my_mod, 42}, badarg}, []),
-    ?assertNotEqual(nomatch, binary:match(Title, <<"my_mod:42: ">>)).
+    ?assertEqual(<<"my_mod:42">>, Title).
 
 format_reason_compile_error_test() ->
     Errors = [{"src/foo.erl", [{{10, 1}, erl_lint, {unused_var, 'X'}}]}],
-    Bin = format_reason({compile_error, Errors}),
+    Bin = format_reason(error, {compile_error, Errors}, []),
     ?assertNotEqual(nomatch, binary:match(Bin, <<"src/foo.erl">>)),
     ?assertNotEqual(nomatch, binary:match(Bin, <<"line 10">>)).
 
 format_reason_arizona_loc_test() ->
-    %% arizona_loc wraps another reason -- the wrapper is stripped for body.
-    Bin = format_reason({arizona_loc, {m, 1}, badarg}),
-    ?assertNotEqual(nomatch, binary:match(Bin, <<"badarg">>)).
+    %% arizona_loc wraps another reason -- the wrapper is stripped for body
+    %% and erl_error renders the inner reason via its standard pipeline.
+    Bin = format_reason(error, {arizona_loc, {m, 1}, badarg}, []),
+    ?assertNotEqual(nomatch, binary:match(Bin, <<"bad argument">>)).
 
 render_with_reload_url_test() ->
     ErrorInfo = #{

--- a/src/arizona_handler.erl
+++ b/src/arizona_handler.erl
@@ -333,8 +333,11 @@ format_error({render_no_clause, Mod, Bindings}, _ST) ->
         )
     }.
 
-view_id(Bindings) when is_map(Bindings) -> maps:get(id, Bindings, undefined);
-view_id(_) -> undefined.
+view_id(Bindings) ->
+    case Bindings of
+        #{id := ViewId} -> ViewId;
+        _ -> undefined
+    end.
 
 %% Used by every dispatcher catch clause. When the top stack frame is the
 %% user's exact callback, raises Reason with an error_info annotation

--- a/src/arizona_handler.erl
+++ b/src/arizona_handler.erl
@@ -120,12 +120,18 @@ call_render(H, Bindings) ->
         H:render(Bindings)
     catch
         error:undef:ST ->
-            raise_or_propagate(
-                undef, ST, H, render, {missing_callback, H, render, 1}, [H, Bindings]
+            arizona_error:raise_or_propagate(
+                undef, ST, H, render, {missing_callback, H, render, 1}, [H, Bindings], ?MODULE
             );
         error:function_clause:ST ->
-            raise_or_propagate(
-                function_clause, ST, H, render, {render_no_clause, H, Bindings}, [H, Bindings]
+            arizona_error:raise_or_propagate(
+                function_clause,
+                ST,
+                H,
+                render,
+                {render_no_clause, H, Bindings},
+                [H, Bindings],
+                ?MODULE
             )
     end.
 
@@ -150,22 +156,24 @@ call_handle_event(H, Event, Payload, Bindings) ->
         H:handle_event(Event, Payload, Bindings)
     catch
         error:undef:ST ->
-            raise_or_propagate(
+            arizona_error:raise_or_propagate(
                 undef,
                 ST,
                 H,
                 handle_event,
                 {missing_callback, H, handle_event, 3},
-                [H, Event, Payload, Bindings]
+                [H, Event, Payload, Bindings],
+                ?MODULE
             );
         error:function_clause:ST ->
-            raise_or_propagate(
+            arizona_error:raise_or_propagate(
                 function_clause,
                 ST,
                 H,
                 handle_event,
                 {unhandled_event, H, Event, Bindings},
-                [H, Event, Payload, Bindings]
+                [H, Event, Payload, Bindings],
+                ?MODULE
             )
     end.
 
@@ -191,13 +199,14 @@ call_handle_info(H, Info, Bindings) ->
                 H:handle_info(Info, Bindings)
             catch
                 error:function_clause:ST ->
-                    raise_or_propagate(
+                    arizona_error:raise_or_propagate(
                         function_clause,
                         ST,
                         H,
                         handle_info,
                         {unhandled_info, H, Info, Bindings},
-                        [H, Info, Bindings]
+                        [H, Info, Bindings],
+                        ?MODULE
                     )
             end;
         false ->
@@ -225,13 +234,14 @@ call_handle_update(H, Props, Bindings) ->
                 H:handle_update(Props, Bindings)
             catch
                 error:function_clause:ST ->
-                    raise_or_propagate(
+                    arizona_error:raise_or_propagate(
                         function_clause,
                         ST,
                         H,
                         handle_update,
                         {unhandled_update, H, Props, Bindings},
-                        [H, Props, Bindings]
+                        [H, Props, Bindings],
+                        ?MODULE
                     )
             end;
         false ->
@@ -255,13 +265,14 @@ call_unmount(H, Bindings) ->
                 H:unmount(Bindings)
             catch
                 error:function_clause:ST ->
-                    raise_or_propagate(
+                    arizona_error:raise_or_propagate(
                         function_clause,
                         ST,
                         H,
                         unmount,
                         {unhandled_unmount, H, Bindings},
-                        [H, Bindings]
+                        [H, Bindings],
+                        ?MODULE
                     )
             end;
         false ->
@@ -338,13 +349,3 @@ view_id(Bindings) ->
         #{id := ViewId} -> ViewId;
         _ -> undefined
     end.
-
-%% Used by every dispatcher catch clause. When the top stack frame is the
-%% user's exact callback, raises Reason with an error_info annotation
-%% pointing at this module. Otherwise propagates the original
-%% `error:OrigReason` untouched -- failures from inside the callback body
-%% are not the dispatcher's concern.
-raise_or_propagate(_OrigReason, [{H, Fn, _, _} | _], H, Fn, Reason, ErrorArgs) ->
-    erlang:error(Reason, ErrorArgs, [{error_info, #{module => ?MODULE}}]);
-raise_or_propagate(OrigReason, ST, _H, _Fn, _Reason, _ErrorArgs) ->
-    erlang:raise(error, OrigReason, ST).

--- a/src/arizona_handler.erl
+++ b/src/arizona_handler.erl
@@ -173,7 +173,10 @@ call_handle_event(H, Event, Payload, Bindings) ->
 Invokes the optional `handle_info/2` callback.
 
 Returns `ok` if the handler does not export `handle_info/2`, letting
-the caller skip the subsequent diff + push cycle.
+the caller skip the subsequent diff + push cycle. Re-tags a
+no-matching-clause crash at the callback's head as
+`{unhandled_info, H, Info, Bindings}`; errors raised from inside
+the callback body propagate untagged.
 """.
 -spec call_handle_info(Handler, Info, Bindings) ->
     {arizona_stateful:bindings(), arizona_stateful:resets(), arizona_stateful:effects()} | ok
@@ -205,7 +208,9 @@ call_handle_info(H, Info, Bindings) ->
 Invokes the optional `handle_update/2` callback.
 
 Falls back to merging `Props` into `Bindings` if the callback is not
-exported.
+exported. Re-tags a no-matching-clause crash at the callback's
+head as `{unhandled_update, H, Props, Bindings}`; errors raised
+from inside the callback body propagate untagged.
 """.
 -spec call_handle_update(Handler, Props, Bindings) ->
     arizona_stateful:handle_update_ret()
@@ -236,7 +241,9 @@ call_handle_update(H, Props, Bindings) ->
 -doc """
 Invokes the optional `unmount/1` callback on a handler module.
 
-No-op if the callback is not exported.
+No-op if the callback is not exported. Re-tags a no-matching-clause
+crash at the callback's head as `{unhandled_unmount, H, Bindings}`;
+errors raised from inside the callback body propagate untagged.
 """.
 -spec call_unmount(Handler, Bindings) -> ok when
     Handler :: module(),

--- a/src/arizona_handler.erl
+++ b/src/arizona_handler.erl
@@ -34,6 +34,13 @@ User modules declare both behaviours via the headers:
 -export([call_handle_info/3]).
 -export([call_handle_update/3]).
 -export([call_unmount/2]).
+-export([format_error/2]).
+
+%% --------------------------------------------------------------------
+%% Ignore xref warnings
+%% --------------------------------------------------------------------
+
+-ignore_xref([format_error/2]).
 
 %% --------------------------------------------------------------------
 %% Behaviour callbacks
@@ -98,19 +105,38 @@ Cleanup hook called when the instance is removed. Optional.
 
 -doc """
 Invokes the required `render/1` callback on a handler module.
+
+Re-tags the failure when the immediate stack frame is the user's
+`render/1` itself: a missing export becomes `{missing_callback, H,
+render, 1}` and a head-pattern mismatch becomes
+`{render_no_clause, H, Bindings}`. Errors raised from inside the
+callback body propagate untagged.
 """.
 -spec call_render(Handler, Bindings) -> arizona_template:template() when
     Handler :: module(),
     Bindings :: arizona_stateful:bindings().
 call_render(H, Bindings) ->
-    H:render(Bindings).
+    try
+        H:render(Bindings)
+    catch
+        error:undef:ST ->
+            raise_or_propagate(
+                undef, ST, H, render, {missing_callback, H, render, 1}, [H, Bindings]
+            );
+        error:function_clause:ST ->
+            raise_or_propagate(
+                function_clause, ST, H, render, {render_no_clause, H, Bindings}, [H, Bindings]
+            )
+    end.
 
 -doc """
 Invokes the optional `handle_event/3` callback.
 
-The callback is declared optional but callers that dispatch an event
-expect it to be exported -- an unhandled event is a programming error
-and will crash with `undef`.
+Re-tags the failure when the immediate stack frame is the user's
+`handle_event/3` itself: a missing export becomes
+`{missing_callback, H, handle_event, 3}` and a no-matching-clause
+crash becomes `{unhandled_event, H, Event, Bindings}`. Errors
+raised from inside the callback body propagate untagged.
 """.
 -spec call_handle_event(Handler, Event, Payload, Bindings) ->
     {arizona_stateful:bindings(), arizona_stateful:resets(), arizona_stateful:effects()}
@@ -120,7 +146,28 @@ when
     Payload :: map(),
     Bindings :: arizona_stateful:bindings().
 call_handle_event(H, Event, Payload, Bindings) ->
-    H:handle_event(Event, Payload, Bindings).
+    try
+        H:handle_event(Event, Payload, Bindings)
+    catch
+        error:undef:ST ->
+            raise_or_propagate(
+                undef,
+                ST,
+                H,
+                handle_event,
+                {missing_callback, H, handle_event, 3},
+                [H, Event, Payload, Bindings]
+            );
+        error:function_clause:ST ->
+            raise_or_propagate(
+                function_clause,
+                ST,
+                H,
+                handle_event,
+                {unhandled_event, H, Event, Bindings},
+                [H, Event, Payload, Bindings]
+            )
+    end.
 
 -doc """
 Invokes the optional `handle_info/2` callback.
@@ -136,8 +183,22 @@ when
     Bindings :: arizona_stateful:bindings().
 call_handle_info(H, Info, Bindings) ->
     case erlang:function_exported(H, handle_info, 2) of
-        true -> H:handle_info(Info, Bindings);
-        false -> ok
+        true ->
+            try
+                H:handle_info(Info, Bindings)
+            catch
+                error:function_clause:ST ->
+                    raise_or_propagate(
+                        function_clause,
+                        ST,
+                        H,
+                        handle_info,
+                        {unhandled_info, H, Info, Bindings},
+                        [H, Info, Bindings]
+                    )
+            end;
+        false ->
+            ok
     end.
 
 -doc """
@@ -154,8 +215,22 @@ when
     Bindings :: arizona_stateful:bindings().
 call_handle_update(H, Props, Bindings) ->
     case erlang:function_exported(H, handle_update, 2) of
-        true -> H:handle_update(Props, Bindings);
-        false -> {maps:merge(Bindings, Props), #{}}
+        true ->
+            try
+                H:handle_update(Props, Bindings)
+            catch
+                error:function_clause:ST ->
+                    raise_or_propagate(
+                        function_clause,
+                        ST,
+                        H,
+                        handle_update,
+                        {unhandled_update, H, Props, Bindings},
+                        [H, Props, Bindings]
+                    )
+            end;
+        false ->
+            {maps:merge(Bindings, Props), #{}}
     end.
 
 -doc """
@@ -168,6 +243,98 @@ No-op if the callback is not exported.
     Bindings :: arizona_stateful:bindings().
 call_unmount(H, Bindings) ->
     case erlang:function_exported(H, unmount, 1) of
-        true -> H:unmount(Bindings);
-        false -> ok
+        true ->
+            try
+                H:unmount(Bindings)
+            catch
+                error:function_clause:ST ->
+                    raise_or_propagate(
+                        function_clause,
+                        ST,
+                        H,
+                        unmount,
+                        {unhandled_unmount, H, Bindings},
+                        [H, Bindings]
+                    )
+            end;
+        false ->
+            ok
     end.
+
+-doc """
+Formats dispatcher-tagged errors raised by the `call_*` wrappers above.
+
+Picked up by `erl_error:format_exception/3` via the `error_info`
+annotation, so the dev error page (and crash log) reads a sentence
+that names the failing module/callback and (when known) the view id.
+""".
+-spec format_error(Reason, Stacktrace) -> ErrorInfo when
+    Reason :: term(),
+    Stacktrace :: [tuple()],
+    ErrorInfo :: #{general := iolist()}.
+format_error({missing_callback, Mod, Name, Arity}, [{_M, _F, Args, _Info} | _]) ->
+    %% Bindings is always the LAST arg to every dispatcher (see call_*/N
+    %% above). Pull it from the failing stack frame so the message can
+    %% name the view that was being served.
+    Bindings = lists:last(Args),
+    #{
+        general => io_lib:format(
+            "while serving view ~0tp: module ~s does not export ~s/~b. "
+            "Add the callback to make this code path work.",
+            [view_id(Bindings), Mod, Name, Arity]
+        )
+    };
+format_error({unhandled_event, Mod, Event, Bindings}, _ST) ->
+    #{
+        general => io_lib:format(
+            "while handling event ~0tp on view ~0tp: no clause in "
+            "~s:handle_event/3 matches that event name. Add a clause "
+            "or fix the az-click attribute that dispatched it.",
+            [Event, view_id(Bindings), Mod]
+        )
+    };
+format_error({unhandled_info, Mod, Info, Bindings}, _ST) ->
+    #{
+        general => io_lib:format(
+            "while delivering message ~0tp on view ~0tp: no clause "
+            "in ~s:handle_info/2 matches that message.",
+            [Info, view_id(Bindings), Mod]
+        )
+    };
+format_error({unhandled_update, Mod, Props, Bindings}, _ST) ->
+    #{
+        general => io_lib:format(
+            "while applying parent props ~0tp on view ~0tp: no clause "
+            "in ~s:handle_update/2 matches.",
+            [Props, view_id(Bindings), Mod]
+        )
+    };
+format_error({unhandled_unmount, Mod, Bindings}, _ST) ->
+    #{
+        general => io_lib:format(
+            "while unmounting view ~0tp: no clause in ~s:unmount/1 "
+            "matches.",
+            [view_id(Bindings), Mod]
+        )
+    };
+format_error({render_no_clause, Mod, Bindings}, _ST) ->
+    #{
+        general => io_lib:format(
+            "while rendering view ~0tp: no clause in ~s:render/1 "
+            "matches the current bindings.",
+            [view_id(Bindings), Mod]
+        )
+    }.
+
+view_id(Bindings) when is_map(Bindings) -> maps:get(id, Bindings, undefined);
+view_id(_) -> undefined.
+
+%% Used by every dispatcher catch clause. When the top stack frame is the
+%% user's exact callback, raises Reason with an error_info annotation
+%% pointing at this module. Otherwise propagates the original
+%% `error:OrigReason` untouched -- failures from inside the callback body
+%% are not the dispatcher's concern.
+raise_or_propagate(_OrigReason, [{H, Fn, _, _} | _], H, Fn, Reason, ErrorArgs) ->
+    erlang:error(Reason, ErrorArgs, [{error_info, #{module => ?MODULE}}]);
+raise_or_propagate(OrigReason, ST, _H, _Fn, _Reason, _ErrorArgs) ->
+    erlang:raise(error, OrigReason, ST).

--- a/src/arizona_live.erl
+++ b/src/arizona_live.erl
@@ -61,6 +61,7 @@ fingerprints already shipped in the initial HTML.
 -export([handle_event/4]).
 -export([seed_fps/2]).
 -export([apply_on_mount/3]).
+-export([format_error/2]).
 
 %% --------------------------------------------------------------------
 %% gen_server callback exports
@@ -80,7 +81,8 @@ fingerprints already shipped in the initial HTML.
     connected/0,
     send/2,
     send_after/3,
-    navigate/4
+    navigate/4,
+    format_error/2
 ]).
 
 %% --------------------------------------------------------------------
@@ -401,7 +403,11 @@ handle_info({arizona_view, ViewId, Msg}, #state{bindings = B0, views = V0} = Sta
                 #{ViewId := _} ->
                     handle_child_info(ViewId, Msg, State);
                 #{} ->
-                    error({unknown_view, ViewId, Msg})
+                    erlang:error(
+                        {unknown_view, ViewId, Msg},
+                        [{arizona_view, ViewId, Msg}, B0, V0],
+                        [{error_info, #{module => ?MODULE}}]
+                    )
             end
     end;
 handle_info(Info, State) ->
@@ -411,6 +417,26 @@ terminate(_Reason, #state{handler = H, bindings = B}) ->
     ok = arizona_handler:call_unmount(H, B);
 terminate(_Reason, _State) ->
     ok.
+
+-doc """
+Formats `arizona_live` runtime errors raised with an `error_info`
+annotation pointing at this module. Picked up by
+`erl_error:format_exception/3`.
+""".
+-spec format_error(Reason, Stacktrace) -> ErrorInfo when
+    Reason :: term(),
+    Stacktrace :: [tuple()],
+    ErrorInfo :: #{general := iolist()}.
+format_error({unknown_view, ViewId, Msg}, [{_M, _F, [_, _B, V0], _Info} | _]) ->
+    #{
+        general => io_lib:format(
+            "no view matches id ~0tp; the message ~0tp can't be routed. "
+            "Known child views in this live process: ~0tp. The id either "
+            "belongs to an unmounted view or was sent before the child "
+            "was embedded.",
+            [ViewId, Msg, lists:sort(maps:keys(V0))]
+        )
+    }.
 
 %% --------------------------------------------------------------------
 %% Internal functions

--- a/src/arizona_stream.erl
+++ b/src/arizona_stream.erl
@@ -424,13 +424,22 @@ to_list(#stream{items = Items, order = Order} = S) ->
     end.
 
 -doc """
-Returns the item at `Key`. Errors with `{badkey, Key}` if not present.
+Returns the item at `Key`. Errors with `missing_stream_key` (carrying an
+`error_info` annotation that routes through `format_error/2`) if not present.
+Use `get/3` for a default.
 """.
 -spec get(Stream, Key) -> item() when
     Stream :: stream(),
     Key :: key().
-get(#stream{items = Items}, Key) ->
-    maps:get(Key, Items).
+get(#stream{items = Items} = S, Key) ->
+    case Items of
+        #{Key := Val} ->
+            Val;
+        #{} ->
+            erlang:error(missing_stream_key, [S, Key], [
+                {error_info, #{module => ?MODULE}}
+            ])
+    end.
 
 -doc """
 Returns the item at `Key`, or `Default` if not present.
@@ -498,6 +507,14 @@ format_error({stream_order_stale_key, K, Order, ItemKeys}, _ST) ->
             "(order=~0tp, items keys=~0tp). Every key in order must "
             "be present in items, with no duplicates.",
             [K, Order, ItemKeys]
+        )
+    };
+format_error(missing_stream_key, [{_M, _F, [#stream{items = Items}, Key], _Info} | _]) ->
+    #{
+        general => io_lib:format(
+            "stream key ~0tp not found. Available keys: ~0tp. "
+            "Use arizona_stream:get/3 with a default to make it optional.",
+            [Key, lists:sort(maps:keys(Items))]
         )
     }.
 

--- a/src/arizona_stream.erl
+++ b/src/arizona_stream.erl
@@ -66,6 +66,7 @@ reorder                  %% from sort/2 when order changes
 -export([clear_stream_pending/2]).
 -export([stream_keys/1]).
 -export([compute_item_changed/2]).
+-export([format_error/2]).
 
 %% --------------------------------------------------------------------
 %% Ignore xref warnings
@@ -86,7 +87,8 @@ reorder                  %% from sort/2 when order changes
     to_list/1,
     get/2,
     get/3,
-    get_lazy/3
+    get_lazy/3,
+    format_error/2
 ]).
 
 %% --------------------------------------------------------------------
@@ -399,11 +401,27 @@ sort(
 
 -doc """
 Returns all items in display order as a list.
+
+Crashes with `{stream_order_stale_key, K, Order, ItemKeys}` carrying
+`error_info` when the items <-> order invariant is broken (a key in
+`order` is not in `items`). The named reason routes through
+`format_error/2`, so the dev error page renders a sentence instead
+of the raw `{badkey, _}`.
 """.
 -spec to_list(Stream) -> [item()] when
     Stream :: stream().
-to_list(#stream{items = Items, order = Order}) ->
-    [maps:get(K, Items) || K <- flat_order(Order)].
+to_list(#stream{items = Items, order = Order} = S) ->
+    Flat = flat_order(Order),
+    try
+        [maps:get(K, Items) || K <- Flat]
+    catch
+        error:{badkey, K} ->
+            error(
+                {stream_order_stale_key, K, Flat, maps:keys(Items)},
+                [S],
+                [{error_info, #{module => ?MODULE}}]
+            )
+    end.
 
 -doc """
 Returns the item at `Key`. Errors with `{badkey, Key}` if not present.
@@ -463,6 +481,25 @@ Returns the binding keys whose values are streams.
     Bindings :: map().
 stream_keys(Bindings) when is_map(Bindings) ->
     [K || K := #stream{} <- Bindings].
+
+-doc """
+Formats `arizona_stream` runtime errors into a human-readable message.
+Picked up by `erl_error:format_exception/3` via the `error_info`
+annotation attached at the raise site.
+""".
+-spec format_error(Reason, Stacktrace) -> ErrorInfo when
+    Reason :: term(),
+    Stacktrace :: [tuple()],
+    ErrorInfo :: #{general := iolist()}.
+format_error({stream_order_stale_key, K, Order, ItemKeys}, _ST) ->
+    #{
+        general => io_lib:format(
+            "stream order references key ~0tp which is not in items "
+            "(order=~0tp, items keys=~0tp). Every key in order must "
+            "be present in items, with no duplicates.",
+            [K, Order, ItemKeys]
+        )
+    }.
 
 %% --------------------------------------------------------------------
 %% Internal functions

--- a/src/arizona_stream.erl
+++ b/src/arizona_stream.erl
@@ -512,7 +512,7 @@ format_error({stream_order_stale_key, K, Order, ItemKeys}, _ST) ->
 format_error(missing_stream_key, [{_M, _F, [#stream{items = Items}, Key], _Info} | _]) ->
     Available = lists:sort(maps:keys(Items)),
     Suggestion =
-        case arizona_error_hint:closest(Key, Available) of
+        case arizona_error:closest(Key, Available) of
             undefined -> "";
             Match -> io_lib:format(" Did you mean ~0tp?", [Match])
         end,

--- a/src/arizona_stream.erl
+++ b/src/arizona_stream.erl
@@ -512,7 +512,7 @@ format_error({stream_order_stale_key, K, Order, ItemKeys}, _ST) ->
 format_error(missing_stream_key, [{_M, _F, [#stream{items = Items}, Key], _Info} | _]) ->
     Available = lists:sort(maps:keys(Items)),
     Suggestion =
-        case arizona_error:closest(Key, Available) of
+        case arizona_error:did_you_mean(Key, Available) of
             undefined -> "";
             Match -> io_lib:format(" Did you mean ~0tp?", [Match])
         end,

--- a/src/arizona_stream.erl
+++ b/src/arizona_stream.erl
@@ -510,11 +510,17 @@ format_error({stream_order_stale_key, K, Order, ItemKeys}, _ST) ->
         )
     };
 format_error(missing_stream_key, [{_M, _F, [#stream{items = Items}, Key], _Info} | _]) ->
+    Available = lists:sort(maps:keys(Items)),
+    Suggestion =
+        case arizona_error_hint:closest(Key, Available) of
+            undefined -> "";
+            Match -> io_lib:format(" Did you mean ~0tp?", [Match])
+        end,
     #{
         general => io_lib:format(
-            "stream key ~0tp not found. Available keys: ~0tp. "
+            "stream key ~0tp not found.~s Available keys: ~0tp. "
             "Use arizona_stream:get/3 with a default to make it optional.",
-            [Key, lists:sort(maps:keys(Items))]
+            [Key, Suggestion, Available]
         )
     }.
 

--- a/src/arizona_template.erl
+++ b/src/arizona_template.erl
@@ -301,7 +301,7 @@ this module. Picked up by `erl_error:format_exception/3`.
 format_error(missing_binding, [{_M, _F, [Key, Bindings], _Info} | _]) ->
     Available = lists:sort(maps:keys(Bindings)),
     Suggestion =
-        case arizona_error_hint:closest(Key, Available) of
+        case arizona_error:closest(Key, Available) of
             undefined -> "";
             Match -> io_lib:format(" Did you mean ~0tp?", [Match])
         end,

--- a/src/arizona_template.erl
+++ b/src/arizona_template.erl
@@ -48,6 +48,7 @@ render(Bindings) ->
 -export([to_bin/1]).
 -export([dyn_az/1]).
 -export([format_error/1]).
+-export([format_error/2]).
 -export([unwrap_val/1]).
 -export([render_attr/2]).
 -export([maybe_propagate/2]).
@@ -62,6 +63,7 @@ render(Bindings) ->
 %% --------------------------------------------------------------------
 
 -ignore_xref([format_error/1]).
+-ignore_xref([format_error/2]).
 
 %% --------------------------------------------------------------------
 %% Types exports
@@ -135,7 +137,8 @@ render(Bindings) ->
 -doc """
 Reads `Key` from `Bindings` and tracks the access for diff dependency analysis.
 
-Errors with `{badkey, Key}` if not present. Use `get/3` for a default.
+Errors with `missing_binding` (carrying an `error_info` annotation that
+routes through `format_error/2`) if not present. Use `get/3` for a default.
 """.
 -spec get(Key, Bindings) -> Value when
     Key :: term(),
@@ -143,7 +146,14 @@ Errors with `{badkey, Key}` if not present. Use `get/3` for a default.
     Value :: term().
 get(Key, Bindings) ->
     track(Key),
-    maps:get(Key, Bindings).
+    case Bindings of
+        #{Key := Val} ->
+            Val;
+        #{} ->
+            erlang:error(missing_binding, [Key, Bindings], [
+                {error_info, #{module => ?MODULE}}
+            ])
+    end.
 
 -doc """
 Reads `Key` from `Bindings`, returning `Default` if absent. Tracks the access.
@@ -272,6 +282,24 @@ format_error(parse_transform_not_applied) ->
     "parse transform not applied -- include arizona_stateful.hrl or arizona_stateless.hrl";
 format_error({bad_template_value, V}) ->
     lists:flatten(io_lib:format("cannot convert ~0tp to binary in template", [V])).
+
+-doc """
+Formats runtime errors raised with an `error_info` annotation pointing at
+this module. Picked up by `erl_error:format_exception/3`.
+""".
+-spec format_error(Reason, Stacktrace) -> ErrorInfo when
+    Reason :: term(),
+    Stacktrace :: [tuple()],
+    ErrorInfo :: #{general := iolist()}.
+format_error(missing_binding, [{_M, _F, [Key, Bindings], _Info} | _]) ->
+    #{
+        general => io_lib:format(
+            "binding ~0tp not found. Available bindings: ~0tp. "
+            "Use arizona_template:get/3 (or ?get/2) with a default "
+            "to make the binding optional.",
+            [Key, lists:sort(maps:keys(Bindings))]
+        )
+    }.
 
 -doc """
 Materializes an attribute dynamic into its rendered binary, leaving plain

--- a/src/arizona_template.erl
+++ b/src/arizona_template.erl
@@ -299,12 +299,18 @@ this module. Picked up by `erl_error:format_exception/3`.
     Stacktrace :: [tuple()],
     ErrorInfo :: #{general := iolist()}.
 format_error(missing_binding, [{_M, _F, [Key, Bindings], _Info} | _]) ->
+    Available = lists:sort(maps:keys(Bindings)),
+    Suggestion =
+        case arizona_error_hint:closest(Key, Available) of
+            undefined -> "";
+            Match -> io_lib:format(" Did you mean ~0tp?", [Match])
+        end,
     #{
         general => io_lib:format(
-            "binding ~0tp not found. Available bindings: ~0tp. "
+            "binding ~0tp not found.~s Available bindings: ~0tp. "
             "Use arizona_template:get/3 (or ?get/2) with a default "
             "to make the binding optional.",
-            [Key, lists:sort(maps:keys(Bindings))]
+            [Key, Suggestion, Available]
         )
     };
 format_error({bad_template_value, _V} = Reason, _ST) ->

--- a/src/arizona_template.erl
+++ b/src/arizona_template.erl
@@ -301,7 +301,7 @@ this module. Picked up by `erl_error:format_exception/3`.
 format_error(missing_binding, [{_M, _F, [Key, Bindings], _Info} | _]) ->
     Available = lists:sort(maps:keys(Bindings)),
     Suggestion =
-        case arizona_error:closest(Key, Available) of
+        case arizona_error:did_you_mean(Key, Available) of
             undefined -> "";
             Match -> io_lib:format(" Did you mean ~0tp?", [Match])
         end,

--- a/src/arizona_template.erl
+++ b/src/arizona_template.erl
@@ -207,7 +207,9 @@ this function runs, the parse transform was not applied -- include
 """.
 -spec html(term()) -> no_return().
 html(_Elems) ->
-    erlang:error(parse_transform_not_applied).
+    erlang:error(parse_transform_not_applied, [], [
+        {error_info, #{module => ?MODULE}}
+    ]).
 
 -doc """
 Builds a stateful child descriptor. The renderer mounts `Handler` with `Props`.
@@ -260,10 +262,15 @@ to_bin(V) when is_binary(V) -> V;
 to_bin(V) when is_integer(V) -> integer_to_binary(V);
 to_bin(V) when is_float(V) -> float_to_binary(V, [{decimals, 10}, compact]);
 to_bin(V) when is_atom(V) -> atom_to_binary(V);
-to_bin({arizona_js, _} = Cmd) -> arizona_js:encode(Cmd);
-to_bin([{arizona_js, _} | _] = Cmds) -> arizona_js:encode(Cmds);
+to_bin({arizona_js, _} = Cmd) ->
+    arizona_js:encode(Cmd);
+to_bin([{arizona_js, _} | _] = Cmds) ->
+    arizona_js:encode(Cmds);
 to_bin(V) when is_list(V) -> iolist_to_binary(V);
-to_bin(V) -> erlang:error({bad_template_value, V}).
+to_bin(V) ->
+    erlang:error({bad_template_value, V}, [V], [
+        {error_info, #{module => ?MODULE}}
+    ]).
 
 -doc """
 Extracts the `t:az/0` index from a 2- or 3-tuple `t:dynamic/0`.
@@ -299,7 +306,11 @@ format_error(missing_binding, [{_M, _F, [Key, Bindings], _Info} | _]) ->
             "to make the binding optional.",
             [Key, lists:sort(maps:keys(Bindings))]
         )
-    }.
+    };
+format_error({bad_template_value, _V} = Reason, _ST) ->
+    #{general => format_error(Reason)};
+format_error(parse_transform_not_applied = Reason, _ST) ->
+    #{general => format_error(Reason)}.
 
 -doc """
 Materializes an attribute dynamic into its rendered binary, leaving plain

--- a/test/arizona_error_SUITE.erl
+++ b/test/arizona_error_SUITE.erl
@@ -1,4 +1,4 @@
--module(arizona_error_hint_SUITE).
+-module(arizona_error_SUITE).
 -include_lib("stdlib/include/assert.hrl").
 
 -export([all/0, groups/0]).
@@ -30,31 +30,31 @@ groups() ->
 
 closest_atom_typo_returns_match(Config) when is_list(Config) ->
     %% One-character transposition against an atom candidate list.
-    ?assertEqual(title, arizona_error_hint:closest(tilte, [id, title, count])).
+    ?assertEqual(title, arizona_error:closest(tilte, [id, title, count])).
 
 closest_binary_typo_returns_match(Config) when is_list(Config) ->
     %% Same with binary keys.
     ?assertEqual(
         <<"alpha">>,
-        arizona_error_hint:closest(<<"alpah">>, [<<"alpha">>, <<"beta">>])
+        arizona_error:closest(<<"alpah">>, [<<"alpha">>, <<"beta">>])
     ).
 
 closest_no_match_returns_undefined(Config) when is_list(Config) ->
     %% Nothing close enough -- distance exceeds the threshold.
-    ?assertEqual(undefined, arizona_error_hint:closest(xyzzy, [id, title, count])).
+    ?assertEqual(undefined, arizona_error:closest(xyzzy, [id, title, count])).
 
 closest_empty_candidates_returns_undefined(Config) when is_list(Config) ->
-    ?assertEqual(undefined, arizona_error_hint:closest(foo, [])).
+    ?assertEqual(undefined, arizona_error:closest(foo, [])).
 
 closest_exact_match_returns_undefined(Config) when is_list(Config) ->
     %% An exact match means the target is in the list -- the caller
     %% wouldn't be asking for a suggestion in the first place. Returns
     %% undefined so the caller doesn't suggest "did you mean X" for X.
-    ?assertEqual(undefined, arizona_error_hint:closest(title, [id, title, count])).
+    ?assertEqual(undefined, arizona_error:closest(title, [id, title, count])).
 
 closest_short_target_strict_threshold(Config) when is_list(Config) ->
     %% Threshold scales with target length. A 2-char target should not
     %% match a 5-char candidate even though Levenshtein is small (5)
     %% relative to the 5-char candidate -- it's too large for the 2-char
     %% target.
-    ?assertEqual(undefined, arizona_error_hint:closest(ab, [hello])).
+    ?assertEqual(undefined, arizona_error:closest(ab, [hello])).

--- a/test/arizona_error_SUITE.erl
+++ b/test/arizona_error_SUITE.erl
@@ -3,12 +3,12 @@
 
 -export([all/0, groups/0]).
 -export([
-    closest_atom_typo_returns_match/1,
-    closest_binary_typo_returns_match/1,
-    closest_no_match_returns_undefined/1,
-    closest_empty_candidates_returns_undefined/1,
-    closest_exact_match_returns_undefined/1,
-    closest_short_target_strict_threshold/1
+    did_you_mean_atom_typo_returns_match/1,
+    did_you_mean_binary_typo_returns_match/1,
+    did_you_mean_no_match_returns_undefined/1,
+    did_you_mean_empty_candidates_returns_undefined/1,
+    did_you_mean_exact_match_returns_undefined/1,
+    did_you_mean_short_target_strict_threshold/1
 ]).
 
 all() ->
@@ -17,44 +17,44 @@ all() ->
 groups() ->
     [
         {tests, [parallel], [
-            closest_atom_typo_returns_match,
-            closest_binary_typo_returns_match,
-            closest_no_match_returns_undefined,
-            closest_empty_candidates_returns_undefined,
-            closest_exact_match_returns_undefined,
-            closest_short_target_strict_threshold
+            did_you_mean_atom_typo_returns_match,
+            did_you_mean_binary_typo_returns_match,
+            did_you_mean_no_match_returns_undefined,
+            did_you_mean_empty_candidates_returns_undefined,
+            did_you_mean_exact_match_returns_undefined,
+            did_you_mean_short_target_strict_threshold
         ]}
     ].
 
-%% --- closest/2 -----------------------------------------------------------
+%% --- did_you_mean/2 ------------------------------------------------------
 
-closest_atom_typo_returns_match(Config) when is_list(Config) ->
+did_you_mean_atom_typo_returns_match(Config) when is_list(Config) ->
     %% One-character transposition against an atom candidate list.
-    ?assertEqual(title, arizona_error:closest(tilte, [id, title, count])).
+    ?assertEqual(title, arizona_error:did_you_mean(tilte, [id, title, count])).
 
-closest_binary_typo_returns_match(Config) when is_list(Config) ->
+did_you_mean_binary_typo_returns_match(Config) when is_list(Config) ->
     %% Same with binary keys.
     ?assertEqual(
         <<"alpha">>,
-        arizona_error:closest(<<"alpah">>, [<<"alpha">>, <<"beta">>])
+        arizona_error:did_you_mean(<<"alpah">>, [<<"alpha">>, <<"beta">>])
     ).
 
-closest_no_match_returns_undefined(Config) when is_list(Config) ->
+did_you_mean_no_match_returns_undefined(Config) when is_list(Config) ->
     %% Nothing close enough -- distance exceeds the threshold.
-    ?assertEqual(undefined, arizona_error:closest(xyzzy, [id, title, count])).
+    ?assertEqual(undefined, arizona_error:did_you_mean(xyzzy, [id, title, count])).
 
-closest_empty_candidates_returns_undefined(Config) when is_list(Config) ->
-    ?assertEqual(undefined, arizona_error:closest(foo, [])).
+did_you_mean_empty_candidates_returns_undefined(Config) when is_list(Config) ->
+    ?assertEqual(undefined, arizona_error:did_you_mean(foo, [])).
 
-closest_exact_match_returns_undefined(Config) when is_list(Config) ->
+did_you_mean_exact_match_returns_undefined(Config) when is_list(Config) ->
     %% An exact match means the target is in the list -- the caller
     %% wouldn't be asking for a suggestion in the first place. Returns
     %% undefined so the caller doesn't suggest "did you mean X" for X.
-    ?assertEqual(undefined, arizona_error:closest(title, [id, title, count])).
+    ?assertEqual(undefined, arizona_error:did_you_mean(title, [id, title, count])).
 
-closest_short_target_strict_threshold(Config) when is_list(Config) ->
+did_you_mean_short_target_strict_threshold(Config) when is_list(Config) ->
     %% Threshold scales with target length. A 2-char target should not
     %% match a 5-char candidate even though Levenshtein is small (5)
     %% relative to the 5-char candidate -- it's too large for the 2-char
     %% target.
-    ?assertEqual(undefined, arizona_error:closest(ab, [hello])).
+    ?assertEqual(undefined, arizona_error:did_you_mean(ab, [hello])).

--- a/test/arizona_error_hint_SUITE.erl
+++ b/test/arizona_error_hint_SUITE.erl
@@ -1,0 +1,60 @@
+-module(arizona_error_hint_SUITE).
+-include_lib("stdlib/include/assert.hrl").
+
+-export([all/0, groups/0]).
+-export([
+    closest_atom_typo_returns_match/1,
+    closest_binary_typo_returns_match/1,
+    closest_no_match_returns_undefined/1,
+    closest_empty_candidates_returns_undefined/1,
+    closest_exact_match_returns_undefined/1,
+    closest_short_target_strict_threshold/1
+]).
+
+all() ->
+    [{group, tests}].
+
+groups() ->
+    [
+        {tests, [parallel], [
+            closest_atom_typo_returns_match,
+            closest_binary_typo_returns_match,
+            closest_no_match_returns_undefined,
+            closest_empty_candidates_returns_undefined,
+            closest_exact_match_returns_undefined,
+            closest_short_target_strict_threshold
+        ]}
+    ].
+
+%% --- closest/2 -----------------------------------------------------------
+
+closest_atom_typo_returns_match(Config) when is_list(Config) ->
+    %% One-character transposition against an atom candidate list.
+    ?assertEqual(title, arizona_error_hint:closest(tilte, [id, title, count])).
+
+closest_binary_typo_returns_match(Config) when is_list(Config) ->
+    %% Same with binary keys.
+    ?assertEqual(
+        <<"alpha">>,
+        arizona_error_hint:closest(<<"alpah">>, [<<"alpha">>, <<"beta">>])
+    ).
+
+closest_no_match_returns_undefined(Config) when is_list(Config) ->
+    %% Nothing close enough -- distance exceeds the threshold.
+    ?assertEqual(undefined, arizona_error_hint:closest(xyzzy, [id, title, count])).
+
+closest_empty_candidates_returns_undefined(Config) when is_list(Config) ->
+    ?assertEqual(undefined, arizona_error_hint:closest(foo, [])).
+
+closest_exact_match_returns_undefined(Config) when is_list(Config) ->
+    %% An exact match means the target is in the list -- the caller
+    %% wouldn't be asking for a suggestion in the first place. Returns
+    %% undefined so the caller doesn't suggest "did you mean X" for X.
+    ?assertEqual(undefined, arizona_error_hint:closest(title, [id, title, count])).
+
+closest_short_target_strict_threshold(Config) when is_list(Config) ->
+    %% Threshold scales with target length. A 2-char target should not
+    %% match a 5-char candidate even though Levenshtein is small (5)
+    %% relative to the 5-char candidate -- it's too large for the 2-char
+    %% target.
+    ?assertEqual(undefined, arizona_error_hint:closest(ab, [hello])).

--- a/test/arizona_handler_SUITE.erl
+++ b/test/arizona_handler_SUITE.erl
@@ -73,7 +73,10 @@ missing_callback_render_tagged(Config) when is_list(Config) ->
         catch
             error:{missing_callback, Mod, render, 1}:ST -> ST
         end,
-    [{arizona_handler, _, _, Info} | _] = Stack,
+    %% Top frame is the arizona_error helper that re-raised; the
+    %% error_info annotation points back at arizona_handler so
+    %% erl_error dispatches to the right format_error/2.
+    [{arizona_error, raise_or_propagate, _, Info} | _] = Stack,
     ?assertEqual(
         #{module => arizona_handler},
         proplists:get_value(error_info, Info)
@@ -98,7 +101,10 @@ unhandled_event_tagged(Config) when is_list(Config) ->
         catch
             error:{unhandled_event, Mod, <<"unknown">>, _}:ST -> ST
         end,
-    [{arizona_handler, _, _, Info} | _] = Stack,
+    %% Top frame is the arizona_error helper that re-raised; the
+    %% error_info annotation points back at arizona_handler so
+    %% erl_error dispatches to the right format_error/2.
+    [{arizona_error, raise_or_propagate, _, Info} | _] = Stack,
     ?assertEqual(
         #{module => arizona_handler},
         proplists:get_value(error_info, Info)

--- a/test/arizona_handler_SUITE.erl
+++ b/test/arizona_handler_SUITE.erl
@@ -4,11 +4,14 @@
 -export([all/0, groups/0]).
 -export([
     missing_callback_render_tagged/1,
+    missing_callback_handle_event_tagged/1,
     unhandled_event_tagged/1,
     unhandled_info_tagged/1,
+    unhandled_update_tagged/1,
     unhandled_unmount_tagged/1,
     function_clause_inside_callback_propagates_untagged/1,
-    format_error_messages_include_view_id/1
+    format_error_messages_include_view_id/1,
+    format_error_renders_all_reasons/1
 ]).
 
 all() ->
@@ -18,11 +21,14 @@ groups() ->
     [
         {dispatcher_tagging, [parallel], [
             missing_callback_render_tagged,
+            missing_callback_handle_event_tagged,
             unhandled_event_tagged,
             unhandled_info_tagged,
+            unhandled_update_tagged,
             unhandled_unmount_tagged,
             function_clause_inside_callback_propagates_untagged,
-            format_error_messages_include_view_id
+            format_error_messages_include_view_id,
+            format_error_renders_all_reasons
         ]}
     ].
 
@@ -153,3 +159,70 @@ format_error_messages_include_view_id(Config) when is_list(Config) ->
     ?assertNotEqual(nomatch, binary:match(Bin, <<"page">>)),
     ?assertNotEqual(nomatch, binary:match(Bin, <<"my_handler">>)),
     ?assertNotEqual(nomatch, binary:match(Bin, <<"foo">>)).
+
+missing_callback_handle_event_tagged(Config) when is_list(Config) ->
+    %% Module without a handle_event/3 export -- call_handle_event must
+    %% re-tag the resulting `undef` into `{missing_callback, _, handle_event, 3}`.
+    Mod = compile_module("-module(stub_no_he). -export([]).\n"),
+    try
+        arizona_handler:call_handle_event(
+            Mod, <<"foo">>, #{}, #{id => <<"v">>}
+        )
+    of
+        _ -> ct:fail(expected_missing_callback)
+    catch
+        error:{missing_callback, Mod, handle_event, 3} -> ok
+    end.
+
+unhandled_update_tagged(Config) when is_list(Config) ->
+    %% Module exports handle_update/2 but no clause matches the props --
+    %% call_handle_update must re-tag the function_clause into
+    %% `{unhandled_update, _, _, _}`.
+    Mod = compile_module(
+        "-module(stub_update). "
+        "-export([handle_update/2]). "
+        "handle_update(#{tag := keep} = P, B) -> {maps:merge(B, P), #{}}.\n"
+    ),
+    try
+        arizona_handler:call_handle_update(
+            Mod, #{other => 1}, #{id => <<"v">>}
+        )
+    of
+        _ -> ct:fail(expected_unhandled_update)
+    catch
+        error:{unhandled_update, Mod, #{other := 1}, _} -> ok
+    end.
+
+format_error_renders_all_reasons(Config) when is_list(Config) ->
+    %% Every tagged reason has a format_error/2 clause that returns an
+    %% iolist mentioning the offending module and (when relevant) the
+    %% offending key/event/info. The `missing_callback` clause pulls
+    %% Bindings from the stack frame's args (last position), so the
+    %% synthetic stack carries a realistic frame.
+    Bindings = #{id => <<"page">>},
+    %% Frame shape mirrors what call_render/2 raises: the dispatcher's
+    %% Args list has Bindings as its tail.
+    Stack = [{arizona_handler, call_render, [my_mod, Bindings], []}],
+    Cases = [
+        {{missing_callback, my_mod, render, 1}, [<<"page">>, <<"my_mod">>, <<"render">>, <<"1">>]},
+        {{unhandled_event, my_mod, <<"e">>, Bindings}, [<<"page">>, <<"my_mod">>, <<"e">>]},
+        {{unhandled_info, my_mod, hello, Bindings}, [<<"page">>, <<"my_mod">>, <<"hello">>]},
+        {{unhandled_update, my_mod, #{}, Bindings}, [<<"page">>, <<"my_mod">>]},
+        {{unhandled_unmount, my_mod, Bindings}, [<<"page">>, <<"my_mod">>]},
+        {{render_no_clause, my_mod, Bindings}, [<<"page">>, <<"my_mod">>]}
+    ],
+    [
+        begin
+            #{general := Msg} = arizona_handler:format_error(Reason, Stack),
+            Bin = unicode:characters_to_binary(Msg),
+            [
+                ?assertNotEqual(
+                    nomatch,
+                    binary:match(Bin, Token),
+                    {Reason, Token, Bin}
+                )
+             || Token <- Tokens
+            ]
+        end
+     || {Reason, Tokens} <- Cases
+    ].

--- a/test/arizona_handler_SUITE.erl
+++ b/test/arizona_handler_SUITE.erl
@@ -1,0 +1,155 @@
+-module(arizona_handler_SUITE).
+-include_lib("stdlib/include/assert.hrl").
+
+-export([all/0, groups/0]).
+-export([
+    missing_callback_render_tagged/1,
+    unhandled_event_tagged/1,
+    unhandled_info_tagged/1,
+    unhandled_unmount_tagged/1,
+    function_clause_inside_callback_propagates_untagged/1,
+    format_error_messages_include_view_id/1
+]).
+
+all() ->
+    [{group, dispatcher_tagging}].
+
+groups() ->
+    [
+        {dispatcher_tagging, [parallel], [
+            missing_callback_render_tagged,
+            unhandled_event_tagged,
+            unhandled_info_tagged,
+            unhandled_unmount_tagged,
+            function_clause_inside_callback_propagates_untagged,
+            format_error_messages_include_view_id
+        ]}
+    ].
+
+%% --- Stub modules built per-case via dynamic compile ---------------------
+
+compile_module(Source) ->
+    {ok, Tokens, _} = erl_scan:string(Source),
+    Splits = split_forms(Tokens, [], []),
+    Forms = [parse_form(S) || S <- Splits],
+    Result = compile:forms(Forms, [binary]),
+    {Mod, Bin} =
+        case Result of
+            {ok, M, B} -> {M, B};
+            {ok, M, B, _Warnings} -> {M, B}
+        end,
+    {module, Mod} = code:load_binary(Mod, atom_to_list(Mod) ++ ".erl", Bin),
+    Mod.
+
+split_forms([], [], Acc) ->
+    lists:reverse(Acc);
+split_forms([], Cur, Acc) ->
+    lists:reverse([lists:reverse(Cur) | Acc]);
+split_forms([{dot, _} = Dot | Rest], Cur, Acc) ->
+    split_forms(Rest, [], [lists:reverse([Dot | Cur]) | Acc]);
+split_forms([T | Rest], Cur, Acc) ->
+    split_forms(Rest, [T | Cur], Acc).
+
+parse_form(Tokens) ->
+    {ok, Form} = erl_parse:parse_form(Tokens),
+    Form.
+
+%% --- Tests ---------------------------------------------------------------
+
+missing_callback_render_tagged(Config) when is_list(Config) ->
+    %% Module without a render/1 export -- call_render must re-tag the
+    %% resulting `undef` into `{missing_callback, _, render, 1}` with
+    %% an error_info annotation.
+    Mod = compile_module("-module(stub_no_render). -export([]).\n"),
+    Stack =
+        try arizona_handler:call_render(Mod, #{id => <<"v">>}) of
+            _ -> ct:fail(expected_missing_callback)
+        catch
+            error:{missing_callback, Mod, render, 1}:ST -> ST
+        end,
+    [{arizona_handler, _, _, Info} | _] = Stack,
+    ?assertEqual(
+        #{module => arizona_handler},
+        proplists:get_value(error_info, Info)
+    ).
+
+unhandled_event_tagged(Config) when is_list(Config) ->
+    %% Module exports handle_event/3 but no clause matches the dispatched
+    %% event -- call_handle_event must re-tag the function_clause into
+    %% `{unhandled_event, _, _, _}`.
+    Mod = compile_module(
+        "-module(stub_event). "
+        "-export([handle_event/3]). "
+        "handle_event(<<\"known\">>, _P, B) -> {B, #{}, []}.\n"
+    ),
+    Stack =
+        try
+            arizona_handler:call_handle_event(
+                Mod, <<"unknown">>, #{}, #{id => <<"v">>}
+            )
+        of
+            _ -> ct:fail(expected_unhandled_event)
+        catch
+            error:{unhandled_event, Mod, <<"unknown">>, _}:ST -> ST
+        end,
+    [{arizona_handler, _, _, Info} | _] = Stack,
+    ?assertEqual(
+        #{module => arizona_handler},
+        proplists:get_value(error_info, Info)
+    ).
+
+unhandled_info_tagged(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(stub_info). "
+        "-export([handle_info/2]). "
+        "handle_info(known, B) -> {B, #{}, []}.\n"
+    ),
+    try arizona_handler:call_handle_info(Mod, unknown, #{id => <<"v">>}) of
+        _ -> ct:fail(expected_unhandled_info)
+    catch
+        error:{unhandled_info, Mod, unknown, _} -> ok
+    end.
+
+unhandled_unmount_tagged(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(stub_unmount). "
+        "-export([unmount/1]). "
+        "unmount(#{tag := keep}) -> ok.\n"
+    ),
+    try arizona_handler:call_unmount(Mod, #{id => <<"v">>}) of
+        _ -> ct:fail(expected_unhandled_unmount)
+    catch
+        error:{unhandled_unmount, Mod, _} -> ok
+    end.
+
+function_clause_inside_callback_propagates_untagged(Config) when is_list(Config) ->
+    %% function_clause raised from INSIDE the callback's body (a case with
+    %% no matching pattern) must propagate as raw function_clause -- only
+    %% failures at the callback's own head get re-tagged.
+    Mod = compile_module(
+        "-module(stub_inner_fc). "
+        "-export([handle_event/3]). "
+        "handle_event(_E, _P, B) -> "
+        "    case B of #{required := V} -> V end.\n"
+    ),
+    try
+        arizona_handler:call_handle_event(
+            Mod, <<"any">>, #{}, #{id => <<"v">>}
+        )
+    of
+        _ -> ct:fail(expected_function_clause)
+    catch
+        %% Raw function_clause -- not re-tagged, because the inner case
+        %% (not the handle_event head) is what failed.
+        error:{case_clause, _} -> ok;
+        error:function_clause -> ok
+    end.
+
+format_error_messages_include_view_id(Config) when is_list(Config) ->
+    %% format_error/2 must include the view id pulled from Bindings.
+    Reason = {unhandled_event, my_handler, <<"foo">>, #{id => <<"page">>}},
+    #{general := Msg} = arizona_handler:format_error(Reason, []),
+    Bin = unicode:characters_to_binary(Msg),
+    ?assertNotEqual(nomatch, binary:match(Bin, <<"page">>)),
+    ?assertNotEqual(nomatch, binary:match(Bin, <<"my_handler">>)),
+    ?assertNotEqual(nomatch, binary:match(Bin, <<"foo">>)).

--- a/test/arizona_live_SUITE.erl
+++ b/test/arizona_live_SUITE.erl
@@ -863,7 +863,20 @@ live_send_unknown_view(Config) when is_list(Config) ->
     Pid ! {arizona_view, <<"nonexistent">>, hello},
     receive
         {'DOWN', Ref, process, Pid, Reason} ->
-            ?assertMatch({{unknown_view, <<"nonexistent">>, hello}, _}, Reason)
+            ?assertMatch({{unknown_view, <<"nonexistent">>, hello}, _}, Reason),
+            %% The raise carries an error_info annotation so the dev
+            %% page can route the reason through arizona_live:format_error/2.
+            {{unknown_view, _, _}, Stack} = Reason,
+            [{arizona_live, _, _, Info} | _] = Stack,
+            ?assertEqual(
+                #{module => arizona_live},
+                proplists:get_value(error_info, Info)
+            ),
+            #{general := Msg} = arizona_live:format_error(
+                {unknown_view, <<"nonexistent">>, hello}, Stack
+            ),
+            Bin = unicode:characters_to_binary(Msg),
+            ?assertNotEqual(nomatch, binary:match(Bin, <<"no view matches id">>))
     after 1000 ->
         error(timeout)
     end.

--- a/test/arizona_live_SUITE.erl
+++ b/test/arizona_live_SUITE.erl
@@ -581,9 +581,9 @@ route_bindings_can_set_id_when_handler_accepts_it(Config) when is_list(Config) -
     %% The strip applies only to OldB, not NewIB. A route's static config
     %% can still set `id` and the new mount sees it -- the only thing the
     %% strip removes is the *previous route's* id leaking through the
-    %% carry. Here `arizona_login`'s mount does
-    %% `maps:merge(#{id => ~"login"}, Bindings)` -- Bindings (the merged
-    %% input) wins, so NewIB's id flows through to the output.
+    %% carry. Here `arizona_login`'s mount pulls `id` via
+    %% `maps:get(id, Bindings, ~"login")` -- explicit typed override --
+    %% so NewIB's id flows through to the output.
     {ok, Pid} = arizona_live:start_link(
         arizona_navigate_halt, #{}, undefined, [], arizona_req_test_adapter:new()
     ),

--- a/test/arizona_render_SUITE.erl
+++ b/test/arizona_render_SUITE.erl
@@ -12,6 +12,9 @@
     error_page_error_summaries/1,
     error_page_escapes_unsafe_chars/1,
     error_page_format_reason_unwraps_loc/1,
+    error_page_title_is_user_frame_location/1,
+    error_page_format_error_sentence_in_body/1,
+    error_page_title_falls_back_to_arizona_loc/1,
     error_page_typical_crash/1,
     error_page_undef/1,
     fingerprint_absent_when_no_f/1,
@@ -107,6 +110,9 @@ groups() ->
             render_ssr_nested_3tuple_dyn_az,
             render_ssr_nested_failure_preserves_deepest_loc,
             error_page_format_reason_unwraps_loc,
+            error_page_title_is_user_frame_location,
+            error_page_format_error_sentence_in_body,
+            error_page_title_falls_back_to_arizona_loc,
             error_page_error_summaries
         ]},
         {nodiff, [parallel], [
@@ -466,17 +472,18 @@ error_page_escapes_unsafe_chars(Config) when is_list(Config) ->
     ?assertMatch({match, _}, re:run(Result, <<"&lt;script&gt;">>)).
 
 error_page_arizona_loc(Config) when is_list(Config) ->
+    %% Empty stack -> title falls back to arizona_loc's captured location.
+    %% (When the stack has a user frame, the frame wins; that's covered
+    %% in error_page_typical_crash and the format_error tests below.)
     Bindings = #{
         class => error,
         reason => {arizona_loc, {my_handler, 42}, {bad_template_value, {}}},
-        stacktrace => [
-            {arizona_template, to_bin, 1, [{file, "src/arizona_template.erl"}, {line, 74}]}
-        ]
+        stacktrace => []
     },
     Result = iolist_to_binary(
         arizona_render:render_to_iolist(arizona_error_page:render(#{error_info => Bindings}))
     ),
-    ?assertMatch({match, _}, re:run(Result, <<"my_handler:42:">>)),
+    ?assertMatch({match, _}, re:run(Result, <<"my_handler:42">>)),
     ?assertMatch({match, _}, re:run(Result, <<"bad_template_value">>)).
 
 render_nodiff_layout_location_wrapping(Config) when is_list(Config) ->
@@ -597,6 +604,8 @@ no_diff_ssr_nested(Config) when is_list(Config) ->
     [{<<"i">>, <<"frozen">>}] = maps:get(d, NestedSnap).
 
 error_page_format_reason_unwraps_loc(Config) when is_list(Config) ->
+    %% Top frame has no line -> title falls back to arizona_loc; body
+    %% still renders the unwrapped reason via erl_error ("bad argument").
     Bindings = #{
         class => error,
         reason => {arizona_loc, {handler_mod, 10}, badarg},
@@ -605,8 +614,98 @@ error_page_format_reason_unwraps_loc(Config) when is_list(Config) ->
     Result = iolist_to_binary(
         arizona_render:render_to_iolist(arizona_error_page:render(#{error_info => Bindings}))
     ),
-    ?assertMatch({match, _}, re:run(Result, <<"badarg">>)),
-    ?assertMatch({match, _}, re:run(Result, <<"handler_mod:10:">>)).
+    ?assertMatch({match, _}, re:run(Result, <<"bad argument">>)),
+    ?assertMatch({match, _}, re:run(Result, <<"handler_mod:10">>)).
+
+%% --- format_error/2 sentence surfaces in the dev page ---
+
+error_page_title_is_user_frame_location(Config) when is_list(Config) ->
+    %% Title surfaces the user's nearest call site -- the first stack
+    %% frame outside arizona_* and OTP. Here a user view's render fun
+    %% calls arizona_template:get/2 which raises; the user wants to see
+    %% their own line, not the framework frame.
+    Bindings = #{
+        class => error,
+        reason => missing_binding,
+        stacktrace => [
+            {arizona_template, get, [missing_key, #{a => 1, b => 2}], [
+                {file, "src/arizona_template.erl"},
+                {line, 153},
+                {error_info, #{module => arizona_template}}
+            ]},
+            {asobi_user_view, render, 1, [
+                {file, "src/asobi_user_view.erl"},
+                {line, 42}
+            ]}
+        ]
+    },
+    Result = iolist_to_binary(
+        arizona_render:render_to_iolist(arizona_error_page:render(#{error_info => Bindings}))
+    ),
+    Title = slice_between(Result, <<"<h1">>, <<"</h1>">>),
+    %% User frame wins: title shows asobi_user_view:42, not arizona_template:153.
+    ?assertNotEqual(nomatch, binary:match(Title, <<"asobi_user_view:42">>)),
+    ?assertEqual(nomatch, binary:match(Title, <<"arizona_template">>)),
+    %% format_error sentence stays out of the title (it's in the body).
+    ?assertEqual(nomatch, binary:match(Title, <<"binding missing_key not found">>)).
+
+error_page_format_error_sentence_in_body(Config) when is_list(Config) ->
+    %% Same setup; the reason `<pre>` carries the FULL format_error
+    %% sentence including the detail clauses the title trims out.
+    Bindings = error_info_for_missing_binding(),
+    Result = iolist_to_binary(
+        arizona_render:render_to_iolist(arizona_error_page:render(#{error_info => Bindings}))
+    ),
+    Body = slice_between(Result, <<"<pre">>, <<"</pre>">>),
+    ?assertNotEqual(nomatch, binary:match(Body, <<"binding missing_key not found">>)),
+    ?assertNotEqual(nomatch, binary:match(Body, <<"Available bindings:">>)),
+    ?assertNotEqual(nomatch, binary:match(Body, <<"Use arizona_template">>)).
+
+error_page_title_falls_back_to_arizona_loc(Config) when is_list(Config) ->
+    %% When the whole stack is framework/OTP and frames carry no line
+    %% the user can navigate to, the title falls back to arizona_loc's
+    %% captured location. The format_error sentence stays in the body.
+    Bindings = #{
+        class => error,
+        reason => {arizona_loc, {my_view, 17}, missing_binding},
+        stacktrace => [
+            {arizona_template, get, [missing_key, #{a => 1}], [
+                {error_info, #{module => arizona_template}}
+            ]}
+        ]
+    },
+    Result = iolist_to_binary(
+        arizona_render:render_to_iolist(arizona_error_page:render(#{error_info => Bindings}))
+    ),
+    Title = slice_between(Result, <<"<h1">>, <<"</h1>">>),
+    ?assertNotEqual(nomatch, binary:match(Title, <<"my_view:17">>)),
+    ?assertEqual(nomatch, binary:match(Title, <<"binding missing_key not found">>)),
+    Body = slice_between(Result, <<"<pre">>, <<"</pre>">>),
+    ?assertNotEqual(nomatch, binary:match(Body, <<"binding missing_key not found">>)).
+
+%% Builds an `error_info` map mirroring what arizona_template:get/2 raises
+%% when a binding is absent: reason = atom, top stack frame carries the
+%% args + an `error_info` annotation pointing at arizona_template (which
+%% has the format_error/2 clause).
+error_info_for_missing_binding() ->
+    Bindings = #{a => 1, b => 2},
+    Stack = [
+        {arizona_template, get, [missing_key, Bindings], [
+            {file, "src/arizona_template.erl"},
+            {line, 153},
+            {error_info, #{module => arizona_template}}
+        ]}
+    ],
+    #{class => error, reason => missing_binding, stacktrace => Stack}.
+
+%% Returns the substring between `Open` and the next `Close` after it.
+%% The opening tag itself plus any attributes are included up to the
+%% matching close. Used to scope assertions to a particular HTML element
+%% in test rendered output.
+slice_between(Bin, Open, Close) ->
+    [_, Tail] = binary:split(Bin, Open),
+    [Inner | _] = binary:split(Tail, Close),
+    Inner.
 
 error_page_error_summaries(Config) when is_list(Config) ->
     Base = #{stacktrace => [{m, f, 0, []}]},

--- a/test/arizona_stream_SUITE.erl
+++ b/test/arizona_stream_SUITE.erl
@@ -125,7 +125,9 @@
     repro_insert_dup_then_delete_yields_stale_order/1,
     repro_to_list_crash_matches_production_stack/1,
     repro_shuffle_after_insert_dup_then_delete_crashes/1,
-    datatable_navigate_from_page_then_add_row_no_crash/1
+    datatable_navigate_from_page_then_add_row_no_crash/1,
+    format_error_missing_stream_key_suggests_close_match/1,
+    format_error_missing_stream_key_no_suggestion_for_far_match/1
 ]).
 
 all() ->
@@ -235,6 +237,8 @@ groups() ->
             stream_delete_nonexistent_key,
             stream_update_nonexistent_key,
             stream_duplicate_key_insert,
+            format_error_missing_stream_key_suggests_close_match,
+            format_error_missing_stream_key_no_suggestion_for_far_match,
             stream_limit_one,
             stream_move_to_same_position,
             stream_empty_stream_operations,
@@ -1295,6 +1299,42 @@ stream_get_missing_key_crashes(Config) when is_list(Config) ->
     Bin = unicode:characters_to_binary(Msg),
     ?assertNotEqual(nomatch, binary:match(Bin, <<"stream key 99 not found">>)),
     ?assertNotEqual(nomatch, binary:match(Bin, <<"1,2">>)).
+
+%% --- did-you-mean hints in missing_stream_key messages ---
+
+format_error_missing_stream_key_suggests_close_match(Config) when is_list(Config) ->
+    %% Binary keys that differ by one character should suggest the close match.
+    KeyFun = fun(#{id := Id}) -> Id end,
+    S = arizona_stream:new(KeyFun, [
+        #{id => <<"alpha">>, n => 1},
+        #{id => <<"beta">>, n => 2}
+    ]),
+    Stack =
+        try arizona_stream:get(S, <<"alpah">>) of
+            _ -> ct:fail(expected_missing_stream_key)
+        catch
+            error:missing_stream_key:ST -> ST
+        end,
+    #{general := Msg} = arizona_stream:format_error(missing_stream_key, Stack),
+    Bin = unicode:characters_to_binary(Msg),
+    ?assertNotEqual(nomatch, binary:match(Bin, <<"Did you mean">>)),
+    ?assertNotEqual(nomatch, binary:match(Bin, <<"alpha">>)).
+
+format_error_missing_stream_key_no_suggestion_for_far_match(Config) when is_list(Config) ->
+    KeyFun = fun(#{id := Id}) -> Id end,
+    S = arizona_stream:new(KeyFun, [
+        #{id => <<"alpha">>, n => 1},
+        #{id => <<"beta">>, n => 2}
+    ]),
+    Stack =
+        try arizona_stream:get(S, <<"qwerty">>) of
+            _ -> ct:fail(expected_missing_stream_key)
+        catch
+            error:missing_stream_key:ST -> ST
+        end,
+    #{general := Msg} = arizona_stream:format_error(missing_stream_key, Stack),
+    Bin = unicode:characters_to_binary(Msg),
+    ?assertEqual(nomatch, binary:match(Bin, <<"Did you mean">>)).
 
 stream_get3_existing_key(Config) when is_list(Config) ->
     S = arizona_stream:new(

--- a/test/arizona_stream_SUITE.erl
+++ b/test/arizona_stream_SUITE.erl
@@ -116,7 +116,16 @@
     reset_pending_op_carries_old_items/1,
     stream_to_list/1,
     stream_update_no_change/1,
-    stream_update_nonexistent_key/1
+    stream_update_nonexistent_key/1,
+    %% --- shuffle crash reproducers ----------------------------------------
+    repro_insert_dup_breaks_invariant/1,
+    repro_insert_at_dup_breaks_invariant/1,
+    repro_reset_with_dup_keys_breaks_invariant/1,
+    repro_update_missing_key_breaks_invariant/1,
+    repro_insert_dup_then_delete_yields_stale_order/1,
+    repro_to_list_crash_matches_production_stack/1,
+    repro_shuffle_after_insert_dup_then_delete_crashes/1,
+    datatable_navigate_from_page_then_add_row_no_crash/1
 ]).
 
 all() ->
@@ -134,7 +143,8 @@ all() ->
         {group, stream_move_after_key},
         {group, nested_stream},
         {group, datatable},
-        {group, list_type_switch}
+        {group, list_type_switch},
+        {group, shuffle_crash_repro}
     ].
 
 groups() ->
@@ -287,12 +297,25 @@ groups() ->
             datatable_live_reset_restores_next_id,
             datatable_live_shuffle,
             datatable_live_sort_dom_simulation,
-            datatable_live_delete_all_then_reset
+            datatable_live_delete_all_then_reset,
+            datatable_navigate_from_page_then_add_row_no_crash
         ]},
         %% List type switch tests
         {list_type_switch, [parallel], [
             list_type_switch_stream_to_list,
             list_type_switch_list_to_stream
+        ]},
+        %% Reproducers for the `arizona_datatable` shuffle crash.
+        %% Each case exercises a single public-API misuse and asserts the
+        %% items <-> order invariant that the production crash violated.
+        {shuffle_crash_repro, [parallel], [
+            repro_insert_dup_breaks_invariant,
+            repro_insert_at_dup_breaks_invariant,
+            repro_reset_with_dup_keys_breaks_invariant,
+            repro_update_missing_key_breaks_invariant,
+            repro_insert_dup_then_delete_yields_stale_order,
+            repro_to_list_crash_matches_production_stack,
+            repro_shuffle_after_insert_dup_then_delete_crashes
         ]}
     ].
 
@@ -2900,6 +2923,262 @@ datatable_live_delete_all_then_reset(Config) when is_list(Config) ->
     RemOps = [Op || [?OP_REMOVE | _] = Op <- Ops],
     ?assertEqual(5, length(InsOps)),
     ?assertEqual(0, length(RemOps)).
+
+%% --- datatable_navigate_from_page_then_add_row_no_crash -------------------
+%% End-to-end check that the example handlers' explicit-bindings mounts
+%% prevent the production shuffle crash trigger:
+%%   1. Mount /  (arizona_page) -- its own next_id=1.
+%%   2. add_todo 3x -- bumps page's next_id to 4.
+%%   3. Navigate to /datatable. Each handler's mount picks only the
+%%      keys it accepts (title), so the carried next_id=4 does not
+%%      override the datatable default of 6.
+%%   4. Click Add Row -- uses datatable's own next_id=6, no dup with
+%%      the existing rows {1..5} stream.
+%%   5. Click Shuffle -- works.
+%% This is the "test modules should not reproduce this error, keep
+%% them fixed" assertion: navigation + clicks stay clean.
+datatable_navigate_from_page_then_add_row_no_crash(Config) when is_list(Config) ->
+    {ok, Pid} = arizona_live:start_link(
+        arizona_page, #{}, undefined, [], arizona_req_test_adapter:new()
+    ),
+    {ok, _} = arizona_live:mount(Pid),
+    ok = lists:foreach(
+        fun(_) ->
+            {ok, _, _} = arizona_live:handle_event(
+                Pid, <<"page">>, <<"add_todo">>, #{<<"text">> => <<"t">>}
+            ),
+            ok
+        end,
+        lists:seq(1, 3)
+    ),
+    {ok, _, _} = arizona_live:navigate(
+        Pid, arizona_datatable, #{title => <<"DataTable">>}, arizona_req_test_adapter:new()
+    ),
+    {ok, _, _} = arizona_live:handle_event(Pid, <<"page">>, <<"add_row">>, #{}),
+    LiveState = sys:get_state(Pid),
+    [B] = [El || El <- tuple_to_list(LiveState), is_map(El), is_map_key(rows, El)],
+    Rows = maps:get(rows, B),
+    {Items, Flat, Size} = stream_invariant_components(Rows),
+    %% Initial 5 items + 1 just added = 6, no dups.
+    ?assertEqual(6, map_size(Items)),
+    ?assertEqual(6, length(Flat)),
+    ?assertEqual(6, Size),
+    ?assertEqual(lists:sort(maps:keys(Items)), lists:sort(lists:usort(Flat))),
+    %% Diana stayed at id=4 (was not overwritten by a dup-keyed New 4).
+    ?assertMatch(#{name := <<"Diana">>}, maps:get(4, Items)),
+    %% Shuffle path is clean.
+    {ok, _, _} = arizona_live:handle_event(Pid, <<"page">>, <<"shuffle">>, #{}).
+
+%% =============================================================================
+%% Shuffle crash reproducers
+%%
+%% The production crash:
+%%   {badkey,1},
+%%   [{erlang,map_get,[1, #{4=>...,5=>...,7=>...,8=>...}], ...},
+%%    {arizona_stream,'-to_list/1-lc$^0/1-0-',2,
+%%                    [{file,"src/arizona_stream.erl"},{line,406}]},
+%%    {arizona_datatable,handle_event,3,
+%%                       [{file,"test/support/arizona_datatable.erl"},{line,127}]}]
+%%
+%% State at crash:
+%%   items = #{4=>"New 4",5=>"New 5",7=>"New 7",8=>"New 8"}
+%%   order = {[7,4,5,1,2,3,4,5,8],[]}
+%%   size  = 9
+%%
+%% These cases isolate each public-API misuse that can break the
+%% items <-> order invariant. The invariant is:
+%%   set(flat_order(Order)) =:= maps:keys(Items)
+%%   length(flat_order(Order)) =:= map_size(Items)
+%%   Size =:= map_size(Items)
+%% Once any op breaks it, every later op compounds the damage; finally
+%% `to_list/1` (or any iterator that does `maps:get(K, Items)`) crashes.
+%% =============================================================================
+
+%% --- helpers ---------------------------------------------------------------
+
+%% Read the (private) #stream record fields. The record is in arizona.hrl
+%% (already included), so we can pattern-match without reaching into internals.
+stream_invariant_components(#stream{items = Items, order = Order, size = Size}) ->
+    {Front, Back} = Order,
+    Flat = Front ++ lists:reverse(Back),
+    {Items, Flat, Size}.
+
+%% --- repro_insert_dup_breaks_invariant -------------------------------------
+%% insert/2 with a key that's already in items: items dedups, order grows,
+%% size grows. Pure invariant violation, no crash yet.
+repro_insert_dup_breaks_invariant(Config) when is_list(Config) ->
+    KeyFun = fun(#{id := Id}) -> Id end,
+    S0 = arizona_stream:new(KeyFun, [#{id => 1, n => <<"a">>}, #{id => 2, n => <<"b">>}]),
+    S1 = arizona_stream:insert(S0, #{id => 1, n => <<"dup">>}),
+    %% Demonstrate the corruption: items count != order length != size
+    {Items, Flat, Size} = stream_invariant_components(S1),
+    ?assertEqual(2, map_size(Items)),
+    ?assertEqual(3, length(Flat)),
+    ?assertEqual(3, Size),
+    ?assertEqual([1, 2, 1], Flat),
+    %% Items <-> order invariant is broken (length(Flat) > map_size(Items)).
+    ?assertNotEqual(map_size(Items), length(Flat)).
+
+%% --- repro_insert_at_dup_breaks_invariant ----------------------------------
+%% insert/3 has the same problem as insert/2 — order_insert_at/3 blindly
+%% adds, regardless of whether the key already lives in the order list.
+repro_insert_at_dup_breaks_invariant(Config) when is_list(Config) ->
+    KeyFun = fun(#{id := Id}) -> Id end,
+    S0 = arizona_stream:new(KeyFun, [#{id => 1, n => <<"a">>}, #{id => 2, n => <<"b">>}]),
+    S1 = arizona_stream:insert(S0, #{id => 1, n => <<"dup">>}, 0),
+    {Items, Flat, Size} = stream_invariant_components(S1),
+    ?assertEqual(2, map_size(Items)),
+    ?assertEqual(3, length(Flat)),
+    ?assertEqual(3, Size),
+    ?assertEqual([1, 1, 2], Flat),
+    ?assertNotEqual(map_size(Items), length(Flat)).
+
+%% --- repro_reset_with_dup_keys_breaks_invariant ----------------------------
+%% reset/2's items map dedups via comprehension (last-wins) but
+%% order_from_keyed/1 keeps duplicates. So passing a list with dup keys
+%% directly produces an inconsistent state — no crash yet, but a delete
+%% afterwards turns it into the production crash shape.
+repro_reset_with_dup_keys_breaks_invariant(Config) when is_list(Config) ->
+    KeyFun = fun(#{id := Id}) -> Id end,
+    S0 = arizona_stream:new(KeyFun, []),
+    DupItems = [
+        #{id => 1, n => <<"first">>},
+        #{id => 1, n => <<"second">>},
+        #{id => 2, n => <<"two">>}
+    ],
+    S1 = arizona_stream:reset(S0, DupItems),
+    {Items, Flat, Size} = stream_invariant_components(S1),
+    ?assertEqual(2, map_size(Items)),
+    ?assertEqual(3, length(Flat)),
+    %% Note: in this branch `size = map_size(ItemsMap)` (not length(Flat)),
+    %% so size matches items but disagrees with order length.
+    ?assertEqual(2, Size),
+    ?assertEqual([1, 1, 2], Flat),
+    ?assertNotEqual(map_size(Items), length(Flat)).
+
+%% --- repro_update_missing_key_breaks_invariant -----------------------------
+%% update/3 silently inserts the key into items if it wasn't there, but
+%% never touches order. The asymmetric mismatch (items has key, order
+%% doesn't) doesn't crash to_list but does break the invariant and will
+%% trip up sort/2 when its comparator is called on a key not in the
+%% order-iterated subset (and vice versa for any caller that walks items).
+repro_update_missing_key_breaks_invariant(Config) when is_list(Config) ->
+    KeyFun = fun(#{id := Id}) -> Id end,
+    S0 = arizona_stream:new(KeyFun, [#{id => 1, n => <<"a">>}]),
+    S1 = arizona_stream:update(S0, 99, #{id => 99, n => <<"phantom">>}),
+    {Items, Flat, Size} = stream_invariant_components(S1),
+    ?assertEqual(2, map_size(Items)),
+    ?assertEqual(1, length(Flat)),
+    ?assertEqual(1, Size),
+    ?assertEqual([1], Flat),
+    %% Items <-> order invariant is broken (items has 99, order doesn't).
+    ?assertNotEqual(lists:sort(maps:keys(Items)), lists:sort(lists:usort(Flat))).
+
+%% --- repro_insert_dup_then_delete_yields_stale_order ----------------------
+%% This is the minimal sequence that produces the production crash shape:
+%% insert/2 dup → delete the dup'd key. delete/2 calls order_delete which
+%% strips only the FIRST match, but maps:take fully removes the items
+%% entry. Result: order keeps a stale key not in items.
+repro_insert_dup_then_delete_yields_stale_order(Config) when is_list(Config) ->
+    KeyFun = fun(#{id := Id}) -> Id end,
+    S0 = arizona_stream:new(KeyFun, [#{id => 1, n => <<"a">>}, #{id => 2, n => <<"b">>}]),
+    S1 = arizona_stream:insert(S0, #{id => 1, n => <<"dup">>}),
+    S2 = arizona_stream:delete(S1, 1),
+    {Items, Flat, Size} = stream_invariant_components(S2),
+    %% items lost key 1 entirely; order kept a stale 1
+    ?assertEqual(1, map_size(Items)),
+    ?assert(is_map_key(2, Items)),
+    ?assertNot(is_map_key(1, Items)),
+    ?assertEqual([2, 1], Flat),
+    ?assertEqual(2, Size),
+    %% This is the same shape as production: items is a strict subset of
+    %% the keys in flat_order(Order).
+    ?assertNotEqual(lists:sort(maps:keys(Items)), lists:sort(lists:usort(Flat))).
+
+%% --- repro_to_list_crash_matches_production_stack -------------------------
+%% Same setup as the previous case, then call to_list/1 — this fires the
+%% production crash, now wrapped as a named reason carrying the
+%% `error_info` annotation that routes through `format_error/2`.
+repro_to_list_crash_matches_production_stack(Config) when is_list(Config) ->
+    KeyFun = fun(#{id := Id}) -> Id end,
+    S0 = arizona_stream:new(KeyFun, [#{id => 1, n => <<"a">>}, #{id => 2, n => <<"b">>}]),
+    S1 = arizona_stream:insert(S0, #{id => 1, n => <<"dup">>}),
+    S2 = arizona_stream:delete(S1, 1),
+    {Reason, Stack} =
+        try arizona_stream:to_list(S2) of
+            _ -> ct:fail(expected_invariant_break)
+        catch
+            error:R:ST -> {R, ST}
+        end,
+    %% Reason is the semantic, named-tag form (not the raw {badkey,_}).
+    ?assertMatch({stream_order_stale_key, 1, [2, 1], [2]}, Reason),
+    %% The top stack frame is arizona_stream's `error/3` site, carrying
+    %% the {error_info, #{module => arizona_stream}} annotation.
+    [{arizona_stream, to_list, _Args, Info} | _] = Stack,
+    ?assertEqual(
+        #{module => arizona_stream},
+        proplists:get_value(error_info, Info)
+    ),
+    %% format_error/2 returns the human-readable sentence the dev page
+    %% will surface via erl_error:format_exception/3.
+    #{general := Msg} = arizona_stream:format_error(Reason, Stack),
+    Bin = unicode:characters_to_binary(Msg),
+    ?assertNotEqual(nomatch, binary:match(Bin, <<"stream order references key 1">>)).
+
+%% --- repro_shuffle_after_insert_dup_then_delete_crashes -------------------
+%% End-to-end demonstration: drive arizona_datatable through the live
+%% process. We can't trigger insert/2 with a dup via the public handlers
+%% (add_row uses next_id), so we splice a corrupted stream into the
+%% bindings and then send a `shuffle` event — same path the production
+%% crash took.
+repro_shuffle_after_insert_dup_then_delete_crashes(Config) when is_list(Config) ->
+    {ok, Pid} = arizona_live:start_link(
+        arizona_datatable, #{}, undefined, [], arizona_req_test_adapter:new()
+    ),
+    {ok, _} = arizona_live:mount(Pid),
+    %% Reach into the live state, corrupt the rows stream the same way
+    %% insert(dup) + delete would, and put it back. This simulates whatever
+    %% production trigger we haven't pinned down — the crash is downstream
+    %% of the corruption, so the trigger doesn't change the crash shape.
+    KeyFun = fun(#{id := Id}) -> Id end,
+    S0 = arizona_stream:new(KeyFun, [
+        #{id => 4, name => <<"New 4">>, age => 20},
+        #{id => 5, name => <<"New 5">>, age => 20},
+        #{id => 7, name => <<"New 7">>, age => 20},
+        #{id => 8, name => <<"New 8">>, age => 20}
+    ]),
+    %% Inject the same shape as the production state: stale 1,2,3 +
+    %% duplicates of 4,5 in order.
+    Corrupt = inject_bad_order(S0, [7, 4, 5, 1, 2, 3, 4, 5, 8]),
+    _NewState = sys:replace_state(Pid, fun(LiveState) ->
+        replace_rows_in_live_state(LiveState, Corrupt)
+    end),
+    %% Now click Shuffle. The gen_server crashes; arizona_live:handle_event
+    %% propagates the exception via gen_server:call. Trap exits so the
+    %% test process survives the linked live process going down.
+    process_flag(trap_exit, true),
+    ?assertExit(
+        {{{stream_order_stale_key, _, _, _}, _Stack}, _CallCtx},
+        arizona_live:handle_event(Pid, <<"page">>, <<"shuffle">>, #{})
+    ).
+
+%% Helpers for the live-state corruption injection above.
+inject_bad_order(#stream{} = S, Flat) ->
+    S#stream{order = {Flat, []}, size = length(Flat)}.
+
+replace_rows_in_live_state(LiveState, Stream) ->
+    %% arizona_live's #state{} record stores its handler bindings; the
+    %% datatable handler keeps its rows stream under `rows`. Tuple-update
+    %% rather than including the (private) #state{} record from arizona_live.
+    %% Layout: state record → bindings map at a fixed position. We find
+    %% the tuple element that's a map containing `rows` and update it.
+    list_to_tuple([
+        case El of
+            #{rows := _} = B -> B#{rows => Stream};
+            _ -> El
+        end
+     || El <- tuple_to_list(LiveState)
+    ]).
 
 %% Mirrors arizona_live:compute_changed/2 for unit tests
 arizona_live_compute_changed(OldBindings, NewBindings) ->

--- a/test/arizona_stream_SUITE.erl
+++ b/test/arizona_stream_SUITE.erl
@@ -1275,8 +1275,26 @@ stream_get_existing_key(Config) when is_list(Config) ->
     ?assertEqual(#{id => 1, text => <<"A">>}, arizona_stream:get(S, 1)).
 
 stream_get_missing_key_crashes(Config) when is_list(Config) ->
-    S = arizona_stream:new(fun(#{id := Id}) -> Id end),
-    ?assertError({badkey, 99}, arizona_stream:get(S, 99)).
+    S = arizona_stream:new(
+        fun(#{id := Id}) -> Id end,
+        [#{id => 1, text => <<"A">>}, #{id => 2, text => <<"B">>}]
+    ),
+    Stack =
+        try arizona_stream:get(S, 99) of
+            _ -> ct:fail(expected_missing_stream_key)
+        catch
+            error:missing_stream_key:ST -> ST
+        end,
+    [{arizona_stream, get, [S, 99], Info} | _] = Stack,
+    ?assertEqual(
+        #{module => arizona_stream},
+        proplists:get_value(error_info, Info)
+    ),
+    %% format_error/2 yields a sentence with the missing key + available keys.
+    #{general := Msg} = arizona_stream:format_error(missing_stream_key, Stack),
+    Bin = unicode:characters_to_binary(Msg),
+    ?assertNotEqual(nomatch, binary:match(Bin, <<"stream key 99 not found">>)),
+    ?assertNotEqual(nomatch, binary:match(Bin, <<"1,2">>)).
 
 stream_get3_existing_key(Config) when is_list(Config) ->
     S = arizona_stream:new(

--- a/test/arizona_template_SUITE.erl
+++ b/test/arizona_template_SUITE.erl
@@ -1,6 +1,12 @@
 -module(arizona_template_SUITE).
 -include_lib("stdlib/include/assert.hrl").
 
+%% Dialyzer flags `arizona_template:to_bin(make_ref())` as "will never
+%% return" -- which is correct: the catch-all clause raises. Suppress
+%% per-function rather than fixing the spec, matching the precedent in
+%% arizona_parse_transform_SUITE.
+-dialyzer({nowarn_function, to_bin_bad_value_routes_through_format_error_2/1}).
+
 -export([all/0, groups/0]).
 -export([
     html_stub/1,
@@ -11,7 +17,9 @@
     to_bin_binary/1,
     to_bin_integer/1,
     get_missing_binding_raises_named_reason/1,
-    format_error_missing_binding_renders_message/1
+    format_error_missing_binding_renders_message/1,
+    to_bin_bad_value_routes_through_format_error_2/1,
+    parse_transform_not_applied_routes_through_format_error_2/1
 ]).
 
 all() ->
@@ -28,7 +36,9 @@ groups() ->
             to_bin_binary,
             to_bin_integer,
             get_missing_binding_raises_named_reason,
-            format_error_missing_binding_renders_message
+            format_error_missing_binding_renders_message,
+            to_bin_bad_value_routes_through_format_error_2,
+            parse_transform_not_applied_routes_through_format_error_2
         ]}
     ].
 
@@ -111,3 +121,43 @@ format_error_missing_binding_renders_message(Config) when is_list(Config) ->
     ?assertNotEqual(nomatch, binary:match(Bin, <<"binding tilte not found">>)),
     %% Available keys are sorted and listed.
     ?assertNotEqual(nomatch, binary:match(Bin, <<"id,title">>)).
+
+%% --- to_bin/1 routes bad-value errors through format_error/2 ---
+
+to_bin_bad_value_routes_through_format_error_2(Config) when is_list(Config) ->
+    %% to_bin/1 raises {bad_template_value, V} with an error_info annotation
+    %% so erl_error:format_exception/3 dispatches to format_error/2, which
+    %% delegates to the existing format_error/1 message.
+    Stack =
+        try arizona_template:to_bin(make_ref()) of
+            _ -> ct:fail(expected_bad_template_value)
+        catch
+            error:{bad_template_value, _}:ST -> ST
+        end,
+    [{arizona_template, to_bin, [_], Info} | _] = Stack,
+    ?assertEqual(
+        #{module => arizona_template},
+        proplists:get_value(error_info, Info)
+    ),
+    Reason = {bad_template_value, make_ref()},
+    #{general := Msg} = arizona_template:format_error(Reason, Stack),
+    Bin = unicode:characters_to_binary(Msg),
+    ?assertNotEqual(nomatch, binary:match(Bin, <<"cannot convert">>)).
+
+%% --- html/1 routes parse_transform_not_applied through format_error/2 ---
+
+parse_transform_not_applied_routes_through_format_error_2(Config) when is_list(Config) ->
+    Stack =
+        try arizona_template:html(foo) of
+            _ -> ct:fail(expected_parse_transform_not_applied)
+        catch
+            error:parse_transform_not_applied:ST -> ST
+        end,
+    [{arizona_template, html, _, Info} | _] = Stack,
+    ?assertEqual(
+        #{module => arizona_template},
+        proplists:get_value(error_info, Info)
+    ),
+    #{general := Msg} = arizona_template:format_error(parse_transform_not_applied, Stack),
+    Bin = unicode:characters_to_binary(Msg),
+    ?assertNotEqual(nomatch, binary:match(Bin, <<"parse transform not applied">>)).

--- a/test/arizona_template_SUITE.erl
+++ b/test/arizona_template_SUITE.erl
@@ -19,7 +19,9 @@
     get_missing_binding_raises_named_reason/1,
     format_error_missing_binding_renders_message/1,
     to_bin_bad_value_routes_through_format_error_2/1,
-    parse_transform_not_applied_routes_through_format_error_2/1
+    parse_transform_not_applied_routes_through_format_error_2/1,
+    format_error_missing_binding_suggests_close_match/1,
+    format_error_missing_binding_no_suggestion_for_far_match/1
 ]).
 
 all() ->
@@ -38,7 +40,9 @@ groups() ->
             get_missing_binding_raises_named_reason,
             format_error_missing_binding_renders_message,
             to_bin_bad_value_routes_through_format_error_2,
-            parse_transform_not_applied_routes_through_format_error_2
+            parse_transform_not_applied_routes_through_format_error_2,
+            format_error_missing_binding_suggests_close_match,
+            format_error_missing_binding_no_suggestion_for_far_match
         ]}
     ].
 
@@ -161,3 +165,29 @@ parse_transform_not_applied_routes_through_format_error_2(Config) when is_list(C
     #{general := Msg} = arizona_template:format_error(parse_transform_not_applied, Stack),
     Bin = unicode:characters_to_binary(Msg),
     ?assertNotEqual(nomatch, binary:match(Bin, <<"parse transform not applied">>)).
+
+%% --- did-you-mean hints in missing_binding messages ---
+
+format_error_missing_binding_suggests_close_match(Config) when is_list(Config) ->
+    %% A one-character typo against a binding name should produce a suggestion.
+    Stack =
+        try arizona_template:get(tilte, #{id => <<"p">>, title => <<"hi">>}) of
+            _ -> ct:fail(expected_missing_binding)
+        catch
+            error:missing_binding:ST -> ST
+        end,
+    #{general := Msg} = arizona_template:format_error(missing_binding, Stack),
+    Bin = unicode:characters_to_binary(Msg),
+    ?assertNotEqual(nomatch, binary:match(Bin, <<"Did you mean title">>)).
+
+format_error_missing_binding_no_suggestion_for_far_match(Config) when is_list(Config) ->
+    %% A key with no near match in the binding list should not produce a suggestion.
+    Stack =
+        try arizona_template:get(xyzzy, #{id => <<"p">>, title => <<"hi">>}) of
+            _ -> ct:fail(expected_missing_binding)
+        catch
+            error:missing_binding:ST -> ST
+        end,
+    #{general := Msg} = arizona_template:format_error(missing_binding, Stack),
+    Bin = unicode:characters_to_binary(Msg),
+    ?assertEqual(nomatch, binary:match(Bin, <<"Did you mean">>)).

--- a/test/arizona_template_SUITE.erl
+++ b/test/arizona_template_SUITE.erl
@@ -9,7 +9,9 @@
     stateless_descriptor/1,
     to_bin_atom/1,
     to_bin_binary/1,
-    to_bin_integer/1
+    to_bin_integer/1,
+    get_missing_binding_raises_named_reason/1,
+    format_error_missing_binding_renders_message/1
 ]).
 
 all() ->
@@ -24,7 +26,9 @@ groups() ->
             stateless_descriptor,
             to_bin_atom,
             to_bin_binary,
-            to_bin_integer
+            to_bin_integer,
+            get_missing_binding_raises_named_reason,
+            format_error_missing_binding_renders_message
         ]}
     ].
 
@@ -70,3 +74,40 @@ to_bin_atom(Config) when is_list(Config) ->
 
 html_stub(Config) when is_list(Config) ->
     ?assertError(parse_transform_not_applied, arizona_template:html(foo)).
+
+%% --- get/2 missing-binding error ---
+
+get_missing_binding_raises_named_reason(Config) when is_list(Config) ->
+    %% A typo'd ?get/1 (e.g. `?get(tilte)` instead of `?get(title)`) hits
+    %% arizona_template:get/2 with a key that's not in Bindings. The
+    %% public contract: raise `error:missing_binding` carrying an
+    %% `error_info` annotation that points at arizona_template, so
+    %% `erl_error:format_exception/3` dispatches to format_error/2.
+    {Reason, Stack} =
+        try arizona_template:get(tilte, #{id => <<"p">>, title => <<"hi">>}) of
+            _ -> ct:fail(expected_missing_binding)
+        catch
+            error:R:ST -> {R, ST}
+        end,
+    ?assertEqual(missing_binding, Reason),
+    [{arizona_template, get, [tilte, _Bindings], Info} | _] = Stack,
+    ?assertEqual(
+        #{module => arizona_template},
+        proplists:get_value(error_info, Info)
+    ).
+
+format_error_missing_binding_renders_message(Config) when is_list(Config) ->
+    %% format_error/2 returns the human sentence the dev page surfaces
+    %% via erl_error:format_exception/3.
+    Bindings = #{id => <<"p">>, title => <<"hi">>},
+    Stack =
+        try arizona_template:get(tilte, Bindings) of
+            _ -> ct:fail(expected_missing_binding)
+        catch
+            error:missing_binding:ST -> ST
+        end,
+    #{general := Msg} = arizona_template:format_error(missing_binding, Stack),
+    Bin = unicode:characters_to_binary(Msg),
+    ?assertNotEqual(nomatch, binary:match(Bin, <<"binding tilte not found">>)),
+    %% Available keys are sorted and listed.
+    ?assertNotEqual(nomatch, binary:match(Bin, <<"id,title">>)).

--- a/test/support/arizona_about.erl
+++ b/test/support/arizona_about.erl
@@ -3,16 +3,13 @@
 -export([mount/2, render/1, handle_event/3, handle_info/2]).
 
 -spec mount(az:bindings(), az:request()) -> az:mount_ret().
-mount(Bindings0, _Req) ->
-    Bindings = maps:merge(
-        #{
-            id => ~"page",
-            title => ~"About",
-            tick => 0,
-            tags => [~"erlang", ~"otp", ~"arizona"]
-        },
-        Bindings0
-    ),
+mount(Init, _Req) ->
+    Bindings = #{
+        id => ~"page",
+        title => maps:get(title, Init, ~"About"),
+        tick => 0,
+        tags => [~"erlang", ~"otp", ~"arizona"]
+    },
     ?connected andalso ?send(arizona_connected),
     {Bindings, #{}}.
 

--- a/test/support/arizona_bench_chain_a.erl
+++ b/test/support/arizona_bench_chain_a.erl
@@ -12,8 +12,8 @@ nested stateful descriptors.
 -export([render/1]).
 
 -spec mount(az:bindings(), az:request()) -> az:mount_ret().
-mount(Bindings0, _Req) ->
-    {maps:merge(#{id => ~"chain_a"}, Bindings0), #{}}.
+mount(_Bindings, _Req) ->
+    {#{id => ~"chain_a"}, #{}}.
 
 -spec render(az:bindings()) -> az:template().
 render(Bindings) ->

--- a/test/support/arizona_bench_chain_b.erl
+++ b/test/support/arizona_bench_chain_b.erl
@@ -13,7 +13,7 @@ snapshot allocation at this level.
 
 -spec mount(az:bindings()) -> az:mount_ret().
 mount(Bindings) ->
-    {maps:merge(#{id => ~"chain_b"}, Bindings), #{}}.
+    {#{id => maps:get(id, Bindings, ~"chain_b")}, #{}}.
 
 -spec handle_update(az:bindings(), az:bindings()) -> az:handle_update_ret().
 handle_update(Props, Bindings) ->

--- a/test/support/arizona_bench_chain_c.erl
+++ b/test/support/arizona_bench_chain_c.erl
@@ -15,15 +15,20 @@ section/row components in real apps.
 -spec mount(az:bindings()) -> az:mount_ret().
 mount(Bindings) ->
     %% Lazy default: only generate the 10 leaf items if no override was
-    %% passed. Eager maps:merge would re-run default_items()/0 on every
-    %% mount even when items were provided.
-    Bindings1 = maps:merge(#{id => ~"chain_c"}, Bindings),
-    Bindings2 =
-        case Bindings1 of
-            #{items := _} -> Bindings1;
-            _ -> Bindings1#{items => default_items()}
+    %% passed -- the stateful chain re-mounts on every SSR render and
+    %% any computation in the default would dominate the profile.
+    Items =
+        case Bindings of
+            #{items := V} -> V;
+            #{} -> default_items()
         end,
-    {Bindings2, #{}}.
+    {
+        #{
+            id => maps:get(id, Bindings, ~"chain_c"),
+            items => Items
+        },
+        #{}
+    }.
 
 -spec handle_update(az:bindings(), az:bindings()) -> az:handle_update_ret().
 handle_update(Props, Bindings) ->

--- a/test/support/arizona_bench_each_track.erl
+++ b/test/support/arizona_bench_each_track.erl
@@ -11,7 +11,7 @@
 mount(Bindings, _Req) ->
     Items = maps:get(items, Bindings, []),
     Stream = arizona_stream:new(fun(#{id := Id}) -> Id end, Items),
-    {Bindings#{id => ~"bench_each", items => Stream}, #{}}.
+    {#{id => ~"bench_each", items => Stream}, #{}}.
 
 -spec render(az:bindings()) -> az:template().
 render(Bindings) ->

--- a/test/support/arizona_bench_many_dyn.erl
+++ b/test/support/arizona_bench_many_dyn.erl
@@ -10,7 +10,8 @@
 -spec mount(az:bindings(), az:request()) -> az:mount_ret().
 mount(Bindings, _Req) ->
     Defaults = maps:from_list([{key_for(I), I} || I <- lists:seq(0, 49)]),
-    {maps:merge(Defaults, Bindings#{id => ~"many_dyn"}), #{}}.
+    Vals = #{K => maps:get(K, Bindings, V) || K := V <- Defaults},
+    {Vals#{id => ~"many_dyn"}, #{}}.
 
 -spec render(az:bindings()) -> az:template().
 render(Bindings) ->

--- a/test/support/arizona_bench_multi_key.erl
+++ b/test/support/arizona_bench_multi_key.erl
@@ -10,7 +10,8 @@
 -spec mount(az:bindings(), az:request()) -> az:mount_ret().
 mount(Bindings, _Req) ->
     Defaults = maps:from_list([{key_for(I), 0} || I <- lists:seq(0, 9)]),
-    {maps:merge(Defaults, Bindings#{id => ~"multi_key"}), #{}}.
+    Vals = #{K => maps:get(K, Bindings, V) || K := V <- Defaults},
+    {Vals#{id => ~"multi_key"}, #{}}.
 
 -spec render(az:bindings()) -> az:template().
 render(Bindings) ->

--- a/test/support/arizona_bench_nested_each.erl
+++ b/test/support/arizona_bench_nested_each.erl
@@ -12,18 +12,16 @@ through a tree shape rather than a flat 100-item list.
 -export([render/1]).
 
 -spec mount(az:bindings(), az:request()) -> az:mount_ret().
-mount(Bindings0, _Req) ->
-    %% Lazy default for `sections` -- the bench workload pre-generates
-    %% the 10x10 data once and passes it via bindings, so we never want
-    %% to recompute `default_sections()` on hot-path renders. Eager
-    %% maps:merge would evaluate it regardless.
-    Bindings1 = maps:merge(#{id => ~"page"}, Bindings0),
-    Bindings =
-        case Bindings1 of
-            #{sections := _} -> Bindings1;
-            _ -> Bindings1#{sections => default_sections()}
+mount(Bindings, _Req) ->
+    %% Lazy default for `sections` -- the bench workload pre-generates the
+    %% 10x10 data once and passes it via bindings, so we never want to
+    %% recompute `default_sections()` on hot-path renders.
+    Sections =
+        case Bindings of
+            #{sections := V} -> V;
+            #{} -> default_sections()
         end,
-    {Bindings, #{}}.
+    {#{id => ~"page", sections => Sections}, #{}}.
 
 -spec render(az:bindings()) -> az:template().
 render(Bindings) ->

--- a/test/support/arizona_chat.erl
+++ b/test/support/arizona_chat.erl
@@ -6,7 +6,14 @@
 mount(Bindings, _Req) ->
     ?connected andalso ?subscribe(chat),
     Stream = arizona_stream:new(fun(#{id := Id}) -> Id end),
-    {maps:merge(#{id => ~"page", messages => Stream}, Bindings), #{}}.
+    {
+        #{
+            id => ~"page",
+            title => maps:get(title, Bindings, ~"Chat"),
+            messages => Stream
+        },
+        #{}
+    }.
 
 -spec unmount(az:bindings()) -> ok.
 unmount(_Bindings) ->

--- a/test/support/arizona_counter.erl
+++ b/test/support/arizona_counter.erl
@@ -4,7 +4,13 @@
 
 -spec mount(az:bindings()) -> az:mount_ret().
 mount(Bindings) ->
-    {maps:merge(#{id => ~"counter", count => 0}, Bindings), #{}}.
+    {
+        #{
+            id => maps:get(id, Bindings, ~"counter"),
+            count => maps:get(count, Bindings, 0)
+        },
+        #{}
+    }.
 
 %% Only counter2 doubles the parent count; others merge normally.
 -spec handle_update(az:bindings(), az:bindings()) -> az:handle_update_ret().

--- a/test/support/arizona_crashable.erl
+++ b/test/support/arizona_crashable.erl
@@ -10,11 +10,15 @@ mount(Bindings, Req) ->
         false ->
             {Params, _Req1} = arizona_req:params(Req),
             Locale = proplists:get_value(~"locale", Params, ~"none"),
-            Merged = maps:merge(
-                #{id => ~"crashable", status => ~"ok", <<"locale">> => Locale},
-                Bindings
-            ),
-            {Merged, #{}}
+            {
+                #{
+                    id => ~"crashable",
+                    status => maps:get(status, Bindings, ~"ok"),
+                    <<"locale">> => maps:get(<<"locale">>, Bindings, Locale),
+                    item_id => maps:get(item_id, Bindings, ~"none")
+                },
+                #{}
+            }
     end.
 
 -spec render(az:bindings()) -> az:template().

--- a/test/support/arizona_datatable.erl
+++ b/test/support/arizona_datatable.erl
@@ -3,7 +3,7 @@
 -export([mount/2, render/1, handle_event/3, handle_info/2]).
 
 -spec mount(az:bindings(), az:request()) -> az:mount_ret().
-mount(Bindings0, _Req) ->
+mount(Init, _Req) ->
     Items = [
         #{id => 1, name => ~"Alice", age => 30},
         #{id => 2, name => ~"Bob", age => 25},
@@ -12,18 +12,15 @@ mount(Bindings0, _Req) ->
         #{id => 5, name => ~"Eve", age => 32}
     ],
     Rows = arizona_stream:new(fun(#{id := Id}) -> Id end, Items),
-    Bindings = maps:merge(
-        #{
-            id => ~"page",
-            title => ~"DataTable",
-            rows => Rows,
-            next_id => 6,
-            sort_col => id,
-            sort_dir => asc,
-            connected => false
-        },
-        Bindings0
-    ),
+    Bindings = #{
+        id => ~"page",
+        title => maps:get(title, Init, ~"DataTable"),
+        rows => Rows,
+        next_id => 6,
+        sort_col => id,
+        sort_dir => asc,
+        connected => false
+    },
     ?connected andalso ?send(arizona_connected),
     {Bindings, #{}}.
 

--- a/test/support/arizona_each_map.erl
+++ b/test/support/arizona_each_map.erl
@@ -3,11 +3,11 @@
 -export([mount/1, render/1]).
 
 -spec mount(az:bindings()) -> az:mount_ret().
-mount(Bindings0) ->
-    Bindings = maps:merge(
-        #{id => ~"page", entries => #{~"a" => ~"1", ~"b" => ~"2"}},
-        Bindings0
-    ),
+mount(Props) ->
+    Bindings = #{
+        id => maps:get(id, Props, ~"page"),
+        entries => maps:get(entries, Props, #{~"a" => ~"1", ~"b" => ~"2"})
+    },
     {Bindings, #{}}.
 
 -spec render(az:bindings()) -> az:template().

--- a/test/support/arizona_effectful.erl
+++ b/test/support/arizona_effectful.erl
@@ -3,8 +3,8 @@
 -export([mount/2, render/1, handle_event/3]).
 
 -spec mount(az:bindings(), az:request()) -> az:mount_ret().
-mount(Bindings, _Req) ->
-    {maps:merge(#{id => ~"effectful", value => ~"initial"}, Bindings), #{}}.
+mount(_Bindings, _Req) ->
+    {#{id => ~"effectful", value => ~"initial"}, #{}}.
 
 -spec render(az:bindings()) -> az:template().
 render(Bindings) ->

--- a/test/support/arizona_leaky_mount.erl
+++ b/test/support/arizona_leaky_mount.erl
@@ -8,7 +8,13 @@
 -spec mount(az:bindings()) -> az:mount_ret().
 mount(Bindings) ->
     eager_value = arizona_template:get(eager_mount_key, #{eager_mount_key => eager_value}),
-    {maps:merge(#{id => ~"leaky", count => 0}, Bindings), #{}}.
+    {
+        #{
+            id => maps:get(id, Bindings, ~"leaky"),
+            count => maps:get(count, Bindings, 0)
+        },
+        #{}
+    }.
 
 -spec render(az:bindings()) -> az:template().
 render(Bindings) ->

--- a/test/support/arizona_login.erl
+++ b/test/support/arizona_login.erl
@@ -3,8 +3,8 @@
 -export([mount/2, render/1]).
 
 -spec mount(az:bindings(), az:request()) -> az:mount_ret().
-mount(_Bindings, _Req) ->
-    {#{id => ~"login"}, #{}}.
+mount(Bindings, _Req) ->
+    {#{id => maps:get(id, Bindings, ~"login")}, #{}}.
 
 -spec render(az:bindings()) -> az:template().
 render(Bindings) ->

--- a/test/support/arizona_login.erl
+++ b/test/support/arizona_login.erl
@@ -3,8 +3,8 @@
 -export([mount/2, render/1]).
 
 -spec mount(az:bindings(), az:request()) -> az:mount_ret().
-mount(Bindings, _Req) ->
-    {maps:merge(#{id => ~"login"}, Bindings), #{}}.
+mount(_Bindings, _Req) ->
+    {#{id => ~"login"}, #{}}.
 
 -spec render(az:bindings()) -> az:template().
 render(Bindings) ->

--- a/test/support/arizona_mixed_children.erl
+++ b/test/support/arizona_mixed_children.erl
@@ -27,8 +27,8 @@
 %%   </div>
 
 -spec mount(az:bindings(), az:request()) -> az:mount_ret().
-mount(Bindings, _Req) ->
-    B = maps:merge(
+mount(_Bindings, _Req) ->
+    {
         #{
             id => ~"mixed",
             visible => false,
@@ -37,9 +37,8 @@ mount(Bindings, _Req) ->
             card_label => ~"Initial",
             message => ~"Hello"
         },
-        Bindings
-    ),
-    {B, #{}}.
+        #{}
+    }.
 
 -spec render(az:bindings()) -> az:template().
 render(Bindings) ->

--- a/test/support/arizona_navigate_halt.erl
+++ b/test/support/arizona_navigate_halt.erl
@@ -3,8 +3,8 @@
 -export([mount/2, render/1]).
 
 -spec mount(az:bindings(), az:request()) -> az:mount_ret().
-mount(Bindings, _Req) ->
-    {maps:merge(#{id => ~"navigate-halt"}, Bindings), #{}}.
+mount(_Bindings, _Req) ->
+    {#{id => ~"navigate-halt"}, #{}}.
 
 -spec render(az:bindings()) -> az:template().
 render(Bindings) ->

--- a/test/support/arizona_no_diff_counter.erl
+++ b/test/support/arizona_no_diff_counter.erl
@@ -4,7 +4,13 @@
 
 -spec mount(az:bindings()) -> az:mount_ret().
 mount(Bindings) ->
-    {maps:merge(#{id => ~"nd_counter", count => 0}, Bindings), #{}}.
+    {
+        #{
+            id => maps:get(id, Bindings, ~"nd_counter"),
+            count => maps:get(count, Bindings, 0)
+        },
+        #{}
+    }.
 
 -spec render(az:bindings()) -> az:template().
 render(Bindings) ->

--- a/test/support/arizona_no_info_root.erl
+++ b/test/support/arizona_no_info_root.erl
@@ -6,8 +6,8 @@
 %% drops inbox messages when the handler doesn't export the callback.
 
 -spec mount(az:bindings(), az:request()) -> az:mount_ret().
-mount(Bindings0, _Req) ->
-    {Bindings0#{id => ~"noinfo"}, #{}}.
+mount(_Bindings, _Req) ->
+    {#{id => ~"noinfo"}, #{}}.
 
 -spec render(az:bindings()) -> az:template().
 render(Bindings) ->

--- a/test/support/arizona_page.erl
+++ b/test/support/arizona_page.erl
@@ -3,20 +3,17 @@
 -export([mount/2, render/1, handle_event/3, handle_info/2]).
 
 -spec mount(az:bindings(), az:request()) -> az:mount_ret().
-mount(Bindings0, _Req) ->
+mount(Init, _Req) ->
     Todos = arizona_stream:new(fun(#{id := Id}) -> Id end),
-    Bindings = maps:merge(
-        #{
-            id => ~"page",
-            title => ~"Welcome",
-            theme => ~"light",
-            count => 0,
-            connected => false,
-            todos => Todos,
-            next_id => 1
-        },
-        Bindings0
-    ),
+    Bindings = #{
+        id => ~"page",
+        title => maps:get(title, Init, ~"Welcome"),
+        theme => ~"light",
+        count => 0,
+        connected => false,
+        todos => Todos,
+        next_id => 1
+    },
     ?connected andalso ?send(arizona_connected),
     {Bindings, #{}}.
 

--- a/test/support/arizona_root_counter.erl
+++ b/test/support/arizona_root_counter.erl
@@ -7,12 +7,14 @@
 %% arizona_live only spawns views.
 
 -spec mount(az:bindings(), az:request()) -> az:mount_ret().
-mount(Bindings0, _Req) ->
-    Bindings = maps:merge(
-        #{id => ~"counter", count => 0},
-        Bindings0
-    ),
-    {Bindings, #{}}.
+mount(Bindings, _Req) ->
+    {
+        #{
+            id => ~"counter",
+            count => maps:get(count, Bindings, 0)
+        },
+        #{}
+    }.
 
 -spec render(az:bindings()) -> az:template().
 render(Bindings) ->

--- a/test/support/arizona_scroll_about.erl
+++ b/test/support/arizona_scroll_about.erl
@@ -3,11 +3,8 @@
 -export([mount/2, render/1, handle_info/2]).
 
 -spec mount(az:bindings(), az:request()) -> az:mount_ret().
-mount(Bindings0, _Req) ->
-    %% Handler-identity keys (id, title) and per-page boot state
-    %% (connected) are written by the handler; previous-page values
-    %% carried via navigate must not pollute them.
-    Bindings = Bindings0#{
+mount(_Bindings, _Req) ->
+    Bindings = #{
         id => ~"page",
         title => ~"Scroll About",
         connected => false

--- a/test/support/arizona_scroll_home.erl
+++ b/test/support/arizona_scroll_home.erl
@@ -3,11 +3,8 @@
 -export([mount/2, render/1, handle_info/2]).
 
 -spec mount(az:bindings(), az:request()) -> az:mount_ret().
-mount(Bindings0, _Req) ->
-    %% Handler-identity keys (id, title) and per-page boot state
-    %% (connected) are written by the handler; previous-page values
-    %% carried via navigate must not pollute them.
-    Bindings = Bindings0#{
+mount(_Bindings, _Req) ->
+    Bindings = #{
         id => ~"page",
         title => ~"Scroll Home",
         connected => false

--- a/test/support/arizona_stream_with_child.erl
+++ b/test/support/arizona_stream_with_child.erl
@@ -6,14 +6,17 @@
 %% Used to test that child views survive dep-skipping of the stream.
 
 -spec mount(az:bindings(), az:request()) -> az:mount_ret().
-mount(Bindings0, _Req) ->
+mount(Bindings, _Req) ->
     Items = [#{id => 1, label => ~"Item 1"}],
     Stream = arizona_stream:new(fun(#{id := Id}) -> Id end, Items),
-    Bindings = maps:merge(
-        #{id => ~"swc", items => Stream, title => ~"Hello"},
-        Bindings0
-    ),
-    {Bindings, #{}}.
+    {
+        #{
+            id => ~"swc",
+            items => Stream,
+            title => maps:get(title, Bindings, ~"Hello")
+        },
+        #{}
+    }.
 
 -spec render(az:bindings()) -> az:template().
 render(Bindings) ->

--- a/test/support/arizona_timer.erl
+++ b/test/support/arizona_timer.erl
@@ -3,8 +3,8 @@
 -export([mount/2, render/1, handle_info/2]).
 
 -spec mount(az:bindings(), az:request()) -> az:mount_ret().
-mount(Bindings, _Req) ->
-    {maps:merge(#{id => ~"timer", message => ~"none"}, Bindings), #{}}.
+mount(_Bindings, _Req) ->
+    {#{id => ~"timer", message => ~"none"}, #{}}.
 
 -spec render(az:bindings()) -> az:template().
 render(Bindings) ->

--- a/test/support/arizona_todo.erl
+++ b/test/support/arizona_todo.erl
@@ -6,8 +6,7 @@
 mount(Bindings, _Req) ->
     Items = maps:get(items, Bindings, []),
     Stream = arizona_stream:new(fun(#{id := Id}) -> Id end, Items),
-    B = maps:merge(#{id => ~"todo"}, Bindings),
-    {B#{items => Stream}, #{}}.
+    {#{id => ~"todo", items => Stream}, #{}}.
 
 -spec render(az:bindings()) -> az:template().
 render(Bindings) ->


### PR DESCRIPTION
# Description

Routes framework runtime errors through OTP's `format_error/2` so every surface that prints an exception (dev error page, server logs, shell) reads sentences instead of raw `{badkey, _}` / `function_clause` / `undef` terms. Adds did-you-mean hints for missing keys, and tags dispatcher-level mistakes (missing callback, no matching `handle_event` clause) at the boundary.

The dev error page now reads as a one-line headline plus the full sentence:

- title is the user's nearest call site (e.g. `my_view:42`), walking past `arizona_*` and OTP frames
- body shows the full `format_error/2` sentence (no more title/body duplication)
- stack frames render mangled fun names readably (`render/1 (anonymous fun)`, `(list comprehension)`) and trim absolute paths to project-relative

What the dev sees:

- `?get(tilte)` → title `my_view:42`, body `binding tilte not found. Did you mean title? Available bindings: [id, title, ...]`
- `az_click="foo"` with no matching clause → `while handling event 'foo' on view 'page': no clause in arizona_datatable:handle_event/3 matches that event name`

---

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
