### PR TITLE
Add arizona_static for offline static HTML generation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,20 @@ Client JS: `arizona.set(viewId, key, value)` (always 3-arg -- the 2-arg `arizona
 
 **Caveat:** a `?local` value survives normal per-slot diffs, but resets to its SSR initial if an enclosing region is re-rendered wholesale (`OP_UPDATE`/`OP_REPLACE`/`?each` swap) or on a forced reconnect. Inside `?each`, every item shares the slot **key** -- keys are compile-time literals (no `?local(<<"open_", Id/binary>>, ...)`), so `set`/`set_all` updates **all** items at once; `?local` can't hold per-item independent client state in a list/stream (use server state for that). The server never reads it back -- to use it server-side, send it in a `push_event` payload. See [docs/architecture.md](docs/architecture.md).
 
+## Static generation
+
+`arizona_static:generate/2,3` renders route handlers to HTML files offline (no server/WS), building
+on the request-free SSR path, and returns `{Written, Failed}` (paths plus per-spec failures). A spec is `{Handler, Outfile}` or
+`{Handler, Outfile, Opts}` (`Outfile` relative to `OutDir`; `Opts` = `bindings`/`on_mount`/`layouts`).
+`generate/3` takes a `DefaultOpts` map each spec's `Opts` override (e.g. a shared layout).
+
+```erlang
+arizona_static:generate(~"_site", [
+    {home_page, ~"index.html"},
+    {about_page, ~"about/index.html", #{bindings => #{title => ~"About"}}}
+], #{layouts => [{site_layout, render}]}).
+```
+
 ## What's missing
 
 ### Engine

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -30,6 +30,7 @@
 | `src/arizona_middleware.erl`              | Request-to-bindings middleware pipeline -- `apply_middlewares/3` runner (run by the HTTP/WS transports) + built-in `extract/1`/`put_request/2` steps                                      |
 | `src/arizona_user_agent.erl`              | User-Agent classification for dual-serve views -- `browser/1`, `os/1`, `mobile/1` (best-effort); pairs with `arizona_req:user_agent/1`                                                    |
 | `src/arizona_http.erl`                    | Transport-agnostic HTTP render pipeline -- `render/3` runs middlewares, renders the view, returns `{halt\|redirect\|ok\|error, ...}` tuples                                               |
+| `src/arizona_static.erl`                  | Offline static-site generation -- `generate/2,3` renders route handlers to HTML files under an out-dir; returns `{Written, Failed}`                                                       |
 | `src/arizona_ws.erl`                      | Transport-agnostic WS upgrade bootstrap -- `prepare/3` parses framework keys, resolves the route, runs middlewares, returns state for `arizona_socket`                                    |
 | `src/arizona_live.erl`                    | Gen_server -- mount (stateful or view), handle_event, handle_info, views map, transport push                                                                                              |
 | `src/arizona_parse_transform.erl`         | Compile-time transform -- `?html`/`?native`, `?each` DSL to `#{s, d, f}` maps, `az-view` auto-injection, `az-nodiff`, attribute compilation, cross-target nesting guard                   |
@@ -597,6 +598,19 @@ Transport-agnostic upgrade bootstrap for WebSocket handlers.
 
 `arizona_roadrunner_ws` collapses to a few lines that call `parse_qs`, invoke
 `arizona_ws:prepare/3`, and wire the result into roadrunner's callback contract.
+
+## API -- `arizona_static.erl`
+
+Offline static-site generation -- renders route handlers to HTML files with no server, live
+process, or WebSocket (built on `arizona_render:render_view_to_iolist/2`).
+
+- `generate/2,3(OutDir, Specs[, DefaultOpts])` -- renders each spec under `OutDir`, writes the
+  HTML files, and returns `{Written, Failed}` (the paths plus `{Spec, Reason}` for any spec that
+  failed -- a `mount`/`render` crash or a write error; one failure does not stop the batch). A
+  spec is `{Handler, Outfile}` or `{Handler, Outfile, Opts}`; `Outfile` is joined onto `OutDir`.
+  `Opts` (and the optional `DefaultOpts`, which each spec's `Opts` override) is the offline subset
+  of `t:arizona_live:route_opts/0` (`bindings`/`on_mount`/`layouts`; no `middlewares`). The client
+  `<script>` / `connect('/ws')` lives in the layout, so a pure-static page omits the WS connect.
 
 ## Roadrunner handlers
 

--- a/src/arizona_static.erl
+++ b/src/arizona_static.erl
@@ -1,0 +1,160 @@
+-module(arizona_static).
+-moduledoc """
+Offline static-site generation: render route-level handlers to HTML files.
+
+After the request/transport decoupling, `arizona_render:render_view_to_iolist/2`
+renders a handler to HTML with no server, live process, or WebSocket. This
+module is the thin batch/file layer over it: mount a handler, render it, and
+write the result to disk.
+
+`generate/2,3` renders a list of specs under a base output directory and returns
+`{Written, Failed}`: the paths written and `{Spec, Reason}` for any spec that
+raised (one failing page does not stop the rest). `generate/3` also takes a
+`DefaultOpts` map that each spec's own options override (key-wise), so a shared
+layout need not be repeated per page:
+
+```erlang
+{Written, Failed} = arizona_static:generate(~"_site", [
+    {home_page, ~"index.html"},
+    {about_page, ~"about/index.html", #{bindings => #{title => ~"About"}}}
+], #{layouts => [{site_layout, render}]}).
+```
+
+## Options
+
+`opts()` (per spec, and the `DefaultOpts`) is the offline-relevant subset of
+`t:arizona_live:route_opts/0`: `bindings`, `on_mount`, and `layouts`.
+`middlewares` does not apply offline (there is no request); any extra keys are
+ignored, so a route's opts map can be pasted in. A spec's own options override
+`DefaultOpts` key-wise (a map value like `bindings` is replaced, not deep-merged).
+
+## Failures
+
+A spec that fails -- a `mount`/`render` crash, or a write error (a
+`filelib:ensure_dir`/`file:write_file` `{error, _}`) -- is collected in `Failed`
+rather than stopping the batch; the caller decides what is fatal. A
+structurally-malformed spec (not a 2- or 3-tuple) still crashes -- that's a
+caller bug, not a per-page failure.
+
+## Caveats
+
+Generated pages are SSR HTML. The client `<script>` / `connect('/ws')` lives in
+your layout, not here: a purely static page uses a layout without the WS connect.
+The output carries the usual `az-view` / `id` markers (inert as static HTML;
+meaningful only if later hydrated by an Arizona server). `generate/2,3` writes
+files but does not clean `OutDir`, so a page removed from `Specs` leaves its
+previously generated file behind.
+""".
+
+%% --------------------------------------------------------------------
+%% API function exports
+%% --------------------------------------------------------------------
+
+-export([generate/2]).
+-export([generate/3]).
+
+%% --------------------------------------------------------------------
+%% Ignore xref warnings
+%% --------------------------------------------------------------------
+
+-ignore_xref([generate/2]).
+-ignore_xref([generate/3]).
+
+%% --------------------------------------------------------------------
+%% Types exports
+%% --------------------------------------------------------------------
+
+-export_type([spec/0]).
+-export_type([opts/0]).
+
+%% --------------------------------------------------------------------
+%% Types definitions
+%% --------------------------------------------------------------------
+
+-nominal opts() :: #{
+    bindings => arizona_template:bindings(),
+    on_mount => arizona_live:on_mount(),
+    layouts => [arizona_render:layout()]
+}.
+
+%% `Outfile` is relative to the `generate/2,3` `OutDir`.
+-nominal spec() ::
+    {module(), file:filename_all()}
+    | {module(), file:filename_all(), opts()}.
+
+%% --------------------------------------------------------------------
+%% API Functions
+%% --------------------------------------------------------------------
+
+-doc """
+Equivalent to `generate(OutDir, Specs, #{})`.
+""".
+-spec generate(OutDir, Specs) -> {Written, Failed} when
+    OutDir :: file:filename_all(),
+    Specs :: [spec()],
+    Written :: [file:filename_all()],
+    Failed :: [{spec(), term()}].
+generate(OutDir, Specs) ->
+    generate(OutDir, Specs, #{}).
+
+-doc """
+Renders each spec under `OutDir`, writes the HTML files, and returns
+`{Written, Failed}` -- the paths written (in `Specs` order) and `{Spec, Reason}`
+for any spec that raised. A failing spec is collected rather than stopping the
+batch; the caller decides what is fatal.
+
+A spec is `{Handler, Outfile}` or `{Handler, Outfile, Opts}`, where `Outfile`
+is joined onto `OutDir` (an absolute `Outfile` bypasses `OutDir`, per standard
+`filename:join` behavior) and parent directories are created as needed. A spec's
+own `Opts` override `DefaultOpts` key-wise.
+""".
+-spec generate(OutDir, Specs, DefaultOpts) -> {Written, Failed} when
+    OutDir :: file:filename_all(),
+    Specs :: [spec()],
+    DefaultOpts :: opts(),
+    Written :: [file:filename_all()],
+    Failed :: [{spec(), term()}].
+generate(OutDir, Specs, DefaultOpts) when is_list(Specs), is_map(DefaultOpts) ->
+    generate_loop(Specs, OutDir, DefaultOpts, [], []).
+
+%% --------------------------------------------------------------------
+%% Internal functions
+%% --------------------------------------------------------------------
+
+generate_loop([], _OutDir, _DefaultOpts, Written, Failed) ->
+    {lists:reverse(Written), lists:reverse(Failed)};
+generate_loop([Spec | T], OutDir, DefaultOpts, Written, Failed) ->
+    case generate_spec(OutDir, DefaultOpts, Spec) of
+        {ok, Filename} ->
+            generate_loop(T, OutDir, DefaultOpts, [Filename | Written], Failed);
+        {error, Reason} ->
+            generate_loop(T, OutDir, DefaultOpts, Written, [{Spec, Reason} | Failed])
+    end.
+
+generate_spec(OutDir, DefaultOpts, {Handler, Outfile}) ->
+    safe_generate(Handler, OutDir, Outfile, DefaultOpts);
+generate_spec(OutDir, DefaultOpts, {Handler, Outfile, Opts}) ->
+    safe_generate(Handler, OutDir, Outfile, maps:merge(DefaultOpts, Opts)).
+
+safe_generate(Handler, OutDir, Outfile, Opts) ->
+    try
+        Filename = filename:join(OutDir, Outfile),
+        case generate_one(Handler, Filename, Opts) of
+            ok ->
+                {ok, Filename};
+            {error, _} = Error ->
+                Error
+        end
+    catch
+        _Class:Reason ->
+            {error, Reason}
+    end.
+
+generate_one(Handler, Filename, Opts) when is_atom(Handler), is_map(Opts) ->
+    maybe
+        RenderOpts = maps:with([bindings, on_mount, layouts], Opts),
+        Content = arizona_render:render_view_to_iolist(Handler, RenderOpts),
+        ok ?= filelib:ensure_dir(Filename),
+        ok ?= file:write_file(Filename, Content),
+        ok
+    end.

--- a/test/arizona_static_SUITE.erl
+++ b/test/arizona_static_SUITE.erl
@@ -1,0 +1,144 @@
+-module(arizona_static_SUITE).
+-include_lib("stdlib/include/assert.hrl").
+
+-export([all/0]).
+-export([groups/0]).
+
+-export([writes_file_and_returns_path/1]).
+-export([applies_bindings/1]).
+-export([applies_layout/1]).
+-export([creates_nested_dirs/1]).
+-export([applies_on_mount/1]).
+-export([multiple_specs_return_all_paths/1]).
+-export([default_opts_apply_to_every_spec/1]).
+-export([spec_opts_override_defaults/1]).
+-export([collects_failures/1]).
+-export([collects_write_errors/1]).
+
+all() ->
+    [{group, generate}].
+
+groups() ->
+    [
+        {generate, [parallel], [
+            writes_file_and_returns_path,
+            applies_bindings,
+            applies_layout,
+            creates_nested_dirs,
+            applies_on_mount,
+            multiple_specs_return_all_paths,
+            default_opts_apply_to_every_spec,
+            spec_opts_override_defaults,
+            collects_failures,
+            collects_write_errors
+        ]}
+    ].
+
+writes_file_and_returns_path(Config) when is_list(Config) ->
+    Dir = subdir(Config, "writes"),
+    {[Out], []} = arizona_static:generate(Dir, [{arizona_static_page, ~"index.html"}]),
+    ?assert(filelib:is_regular(Out)),
+    Content = read(Out),
+    ?assertMatch({_, _}, binary:match(Content, ~"static_page")),
+    ?assertMatch({_, _}, binary:match(Content, ~"Static")).
+
+applies_bindings(Config) when is_list(Config) ->
+    Dir = subdir(Config, "bindings"),
+    {[Out], []} = arizona_static:generate(
+        Dir, [{arizona_static_page, ~"index.html", #{bindings => #{title => ~"Hello"}}}]
+    ),
+    ?assertMatch({_, _}, binary:match(read(Out), ~"Hello")).
+
+applies_layout(Config) when is_list(Config) ->
+    Dir = subdir(Config, "layout"),
+    {[Out], []} = arizona_static:generate(
+        Dir, [{arizona_static_page, ~"index.html", #{layouts => [{arizona_layout, render}]}}]
+    ),
+    Content = read(Out),
+    ?assertMatch({_, _}, binary:match(Content, ~"<!DOCTYPE html>")),
+    ?assertMatch({_, _}, binary:match(Content, ~"static_page")).
+
+creates_nested_dirs(Config) when is_list(Config) ->
+    Dir = subdir(Config, "nested"),
+    {[Out], []} = arizona_static:generate(Dir, [{arizona_static_page, ~"deep/page.html"}]),
+    ?assert(filelib:is_regular(Out)).
+
+applies_on_mount(Config) when is_list(Config) ->
+    Dir = subdir(Config, "on_mount"),
+    Hook = fun(B) -> B#{title => ~"FromHook"} end,
+    {[Out], []} = arizona_static:generate(
+        Dir, [{arizona_static_page, ~"index.html", #{on_mount => [Hook]}}]
+    ),
+    ?assertMatch({_, _}, binary:match(read(Out), ~"FromHook")).
+
+multiple_specs_return_all_paths(Config) when is_list(Config) ->
+    Dir = subdir(Config, "batch"),
+    {[A, B], []} = arizona_static:generate(Dir, [
+        {arizona_static_page, ~"a.html"},
+        {arizona_static_page, ~"sub/b.html", #{bindings => #{title => ~"Bee"}}}
+    ]),
+    ?assert(filelib:is_regular(A)),
+    ?assertMatch({_, _}, binary:match(read(B), ~"Bee")).
+
+default_opts_apply_to_every_spec(Config) when is_list(Config) ->
+    Dir = subdir(Config, "defaults"),
+    {[P1, P2], []} = arizona_static:generate(
+        Dir,
+        [{arizona_static_page, ~"a.html"}, {arizona_static_page, ~"b.html"}],
+        #{layouts => [{arizona_layout, render}]}
+    ),
+    %% the shared layout wraps both pages
+    ?assertMatch({_, _}, binary:match(read(P1), ~"<!DOCTYPE html>")),
+    ?assertMatch({_, _}, binary:match(read(P2), ~"<!DOCTYPE html>")).
+
+spec_opts_override_defaults(Config) when is_list(Config) ->
+    Dir = subdir(Config, "override"),
+    {[Out], []} = arizona_static:generate(
+        Dir,
+        [{arizona_static_page, ~"index.html", #{bindings => #{title => ~"Override"}}}],
+        #{bindings => #{title => ~"Default"}}
+    ),
+    Content = read(Out),
+    ?assertMatch({_, _}, binary:match(Content, ~"Override")),
+    ?assertEqual(nomatch, binary:match(Content, ~"Default")).
+
+collects_failures(Config) when is_list(Config) ->
+    Dir = subdir(Config, "failures"),
+    %% A good spec is written; a spec whose handler does not exist is collected
+    %% in Failed (its `mount/1` raises `undef`) without stopping the batch.
+    {[Good], [{BadSpec, Reason}]} = arizona_static:generate(Dir, [
+        {arizona_static_page, ~"ok.html"},
+        {nonexistent_handler, ~"bad.html"}
+    ]),
+    ?assert(filelib:is_regular(Good)),
+    ?assertEqual({nonexistent_handler, ~"bad.html"}, BadSpec),
+    ?assertEqual(undef, Reason),
+    ?assertNot(filelib:is_regular(filename:join(Dir, "bad.html"))).
+
+collects_write_errors(Config) when is_list(Config) ->
+    Dir = subdir(Config, "write_errors"),
+    %% Put a regular file where a spec needs a parent directory: filelib:ensure_dir
+    %% *returns* {error, _} (it does not raise), so this exercises generate's
+    %% error-return path -- distinct from a handler crash, which is caught. The
+    %% batch still continues and the other spec is written.
+    Collide = filename:join(Dir, "collide"),
+    ok = filelib:ensure_dir(Collide),
+    ok = file:write_file(Collide, <<>>),
+    {[Good], [{BadSpec, _Reason}]} = arizona_static:generate(Dir, [
+        {arizona_static_page, ~"ok.html"},
+        {arizona_static_page, ~"collide/page.html"}
+    ]),
+    ?assert(filelib:is_regular(Good)),
+    ?assertEqual({arizona_static_page, ~"collide/page.html"}, BadSpec),
+    ?assertNot(filelib:is_regular(filename:join(Dir, "collide/page.html"))).
+
+%% --------------------------------------------------------------------
+%% Helpers
+%% --------------------------------------------------------------------
+
+subdir(Config, Name) ->
+    filename:join(proplists:get_value(priv_dir, Config), Name).
+
+read(Path) ->
+    {ok, Bin} = file:read_file(Path),
+    Bin.

--- a/test/support/arizona_static_page.erl
+++ b/test/support/arizona_static_page.erl
@@ -1,0 +1,17 @@
+-module(arizona_static_page).
+-include("arizona_stateful.hrl").
+-export([mount/1, render/1]).
+
+-spec mount(az:bindings()) -> az:mount_ret().
+mount(Bindings) ->
+    {
+        #{
+            id => ~"static_page",
+            title => maps:get(title, Bindings, ~"Static")
+        },
+        #{}
+    }.
+
+-spec render(az:bindings()) -> az:template().
+render(Bindings) ->
+    ?html({'div', [{id, ?get(id)}], [?get(title)]}).


### PR DESCRIPTION
# Description

Adds `arizona_static`: offline static HTML generation. `generate/2,3` renders route handlers to HTML files under an out-dir and returns `{Written, Failed}`, collecting per-spec failures instead of aborting the batch.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
