### PR TITLE
Fix arizona_app_SUITE port-reuse flake with an OS-assigned port

### DIFF
--- a/test/arizona_app_SUITE.erl
+++ b/test/arizona_app_SUITE.erl
@@ -93,8 +93,15 @@ server_opts() ->
         routes => [{asset, <<"/priv">>, {priv_dir, arizona, "static/assets/js"}}]
     }.
 
+%% A free OS-assigned port: bind an ephemeral port (0), read it back, release
+%% it. The old `4040 + counter` scheme was deterministic across VM restarts --
+%% the first call of each fresh VM landed on 4041 -- so it intermittently hit
+%% eaddrinuse against a prior CT run's listener still in TIME_WAIT.
 pick_port() ->
-    4040 + erlang:unique_integer([positive, monotonic]) rem 1000.
+    {ok, Sock} = gen_tcp:listen(0, []),
+    {ok, Port} = inet:port(Sock),
+    ok = gen_tcp:close(Sock),
+    Port.
 
 unset_env(Key) ->
     application:unset_env(arizona, Key).


### PR DESCRIPTION
# Description

`arizona_app_SUITE`'s `pick_port/0` derived the port from `4040 + a per-VM counter`, so the first call of each fresh VM deterministically landed on 4041 and intermittently hit `eaddrinuse` against a prior CT run's listener still in `TIME_WAIT`. It now binds an OS-assigned ephemeral port (the suite only asserts the listener is up, never connects).

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
