### PR TITLE
Fix native ticker e2e flake by widening the server-push wait budget

### DIFF
--- a/e2e/native/menu.spec.js
+++ b/e2e/native/menu.spec.js
@@ -71,8 +71,9 @@ test.describe('native (JSON) wire -- menu navigation', () => {
             // (this is what crashed TickerE2ETest after the per-view change).
             client.tap(client.tree().children[3]); // "Ticker"
             await client.waitFor((t) => t.id === 'native_ticker');
-            // No client event -- the server timer drives these.
-            await client.waitFor((t) => count(t) >= 2, 5000);
+            // No client event -- the server's 1s timer drives these. Generous budget:
+            // parallel CI load slips the BEAM timers (see ticker.spec.js).
+            await client.waitFor((t) => count(t) >= 2, 10000);
         } finally {
             client.close();
         }

--- a/e2e/native/ticker.spec.js
+++ b/e2e/native/ticker.spec.js
@@ -14,8 +14,10 @@ test.describe('native (JSON) wire -- ticker (server push)', () => {
         try {
             expect(client.tree().type).toBe('Column');
             expect(count(client.tree())).toBe(0);
-            // No pushEvent -- the server's timer drives the updates.
-            await client.waitFor((t) => count(t) >= 2, 5000);
+            // No pushEvent -- the server's 1s timer drives the updates. Budget is
+            // generous (>= 2 is ~2s nominal): under parallel CI load the BEAM timers
+            // slip, and a tight bound flaked. Stays under the 15s per-test timeout.
+            await client.waitFor((t) => count(t) >= 2, 10000);
             expect(count(client.tree())).toBeGreaterThanOrEqual(2);
         } finally {
             client.close();


### PR DESCRIPTION
# Description

The native ticker e2e (`ticker.spec.js`, and the same pattern in `menu.spec.js`) waited up to 5s for the server's 1s `send_after` timer to push `count >= 2` (~2s nominal). Under full parallel CI load the BEAM timers slip -- observed at 4.6-4.8s, right at the 5s edge -- so it intermittently timed out. The wait budget is now 10s (still under the 15s per-test timeout); tests resolve as soon as the pushes arrive, so the happy path is unchanged.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
