### PR TITLE
Inline binding reads hoisted out of ?html so they track on diff

### DIFF
--- a/.claude/rules/erlang.md
+++ b/.claude/rules/erlang.md
@@ -158,3 +158,21 @@ consequences:
 - Prefer named fun references (`?stateless(fun bar/1, Props)`,
   `?stateless(Mod, Fn, Props)`). They cannot close over outer `Bindings`,
   removing the footgun entirely.
+
+Reads **hoisted into the render function body** do track: the parse transform
+inlines each interpolated variable back into its slot closure, so the `?get`
+re-runs inside the dependency bracket.
+
+```erlang
+%% all of these track per-slot (compile-time inlining):
+Name = ?get(name),                 ?html({p, [], [Name]}).
+User = ?get(user), N = maps:get(name, User), ?html({p, [], [N]}).  %% tracks `user`
+Label = case ?get(mode) of dark -> ?get(a); _ -> ?get(b) end, ?html({p, [], [Label]}).
+case ?get(mode) of dark -> X = ?get(a); _ -> X = ?get(b) end, ?html({p, [], [X]}).
+```
+
+Exceptions that stay un-tracked (slot frozen after SSR): a binding
+destructured in the function head (`render(#{foo := Foo})` -- use `?get(foo)`),
+a variable bound inside an `if` or only on some `case` branches, and a rebound
+variable. `?get` is for top-level bindings; read sub-structures with plain
+`maps:get/2`.

--- a/.claude/rules/erlang.md
+++ b/.claude/rules/erlang.md
@@ -171,8 +171,9 @@ Label = case ?get(mode) of dark -> ?get(a); _ -> ?get(b) end, ?html({p, [], [Lab
 case ?get(mode) of dark -> X = ?get(a); _ -> X = ?get(b) end, ?html({p, [], [X]}).
 ```
 
-Exceptions that stay un-tracked (slot frozen after SSR): a binding
-destructured in the function head (`render(#{foo := Foo})` -- use `?get(foo)`),
-a variable bound inside an `if` or only on some `case` branches, and a rebound
-variable. `?get` is for top-level bindings; read sub-structures with plain
-`maps:get/2`.
+Exceptions that stay un-tracked (slot frozen after SSR): a binding destructured
+in the head (`render(#{foo := Foo})`) or through any non-bare-var pattern
+(`{ok, V} = ?get(...)` -- use `?get(foo)` then plain destructuring), a read
+reachable only through a guard, a variable bound inside an `if` or a `case`
+branch whose clause head binds a variable, and a rebound variable. `?get` is for
+top-level bindings; read sub-structures with plain `maps:get/2`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -242,11 +242,15 @@ and idiomatic templates (reads written inside `?html`) are unaffected.
   (unused variable) stays satisfied.
 
 **Reads that do not inline** (left captured, slot stays static): a binding
-destructured in the function head (`render(#{foo := Foo})` -- a pattern match
-is an untracked read; read it with `?get(foo)` instead), a variable bound
-inside an `if` or only on some `case` branches, and a rebound variable. Use
-`?get` for the top-level binding and plain `maps:get/2` for sub-structures
-(only the `?get` records a dep, which is the correct grain).
+destructured in the function head (`render(#{foo := Foo})`) or through any
+non-bare-var pattern (`{ok, V} = ?get(...)`) -- a pattern match is an untracked
+read; read the whole value with `?get(foo)` and destructure with plain Erlang.
+Also: a read reachable only through a guard (`when N > 5` -- a guard cannot hold
+a `get`), a variable bound inside an `if` or a `case` branch whose clause head
+itself binds a variable, and a rebound variable. Use `?get` for the top-level
+binding and plain `maps:get/2` for sub-structures (only the `?get` records a dep,
+which is the correct grain). In all these cases the read is left captured and the
+slot keeps its SSR value; the transform never makes valid code uncompilable.
 
 ## API -- effect commands (`arizona_js` / `arizona_android` / `arizona_effect`)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -205,6 +205,49 @@ intentional -- those reads belong to the inner scope. Idiomatic callbacks
 use a named fun reference (`?stateless(fun bar/1, Props)`), which cannot
 close over outer `Bindings` and therefore avoids the footgun entirely.
 
+## Binding-read inlining
+
+Dep tracking requires a `?get` to run *inside* its slot's `'$arizona_deps'`
+bracket. A read hoisted into the render function body --
+
+```erlang
+render(Bindings) ->
+    Name = arizona_template:get(name, Bindings),
+    ?html({p, [], [Name]}).
+```
+
+-- would otherwise compile the slot to `fun() -> Name end`: a captured value
+with no `?get`, so it records empty deps and the slot freezes after the first
+render. The parse transform (`arizona_parse_transform`) closes the gap by
+rewriting each interpolated variable back into its defining expression, so the
+`?get` re-executes inside the per-slot bracket -- exactly as if it had been
+written inline. This is purely compile-time; the runtime/diff path is unchanged
+and idiomatic templates (reads written inside `?html`) are unaffected.
+
+- **`collect_inline/1`** builds a per-clause map of top-level `Var = RHS`
+  matches whose RHS transitively reaches a `get`/`get_lazy`/`track` call.
+  Rebound vars are dropped; a derivation with no read (e.g. `Id = make_uuid()`)
+  is left captured, so a pure side effect is never re-run per slot.
+- **`inline_vars/2`** substitutes those variables wherever they appear in a
+  `?html`/`?each` argument -- including inside a `case` scrutinee or an opaque
+  call -- recursively and scope-aware (fun parameters and comprehension
+  generators shadow; patterns and guards are never substituted, so a
+  substitution can never form an illegal pattern or a guard `?get`).
+- **`normalize_tail_binds/1`** lifts a statement-form `case` that binds one
+  variable as the whole body of every branch
+  (`case ?get(m) of a -> X = ?get(p); _ -> X = ?get(q) end`) into value form
+  (`X = case ?get(m) of a -> ?get(p); _ -> ?get(q) end`) so the same machinery
+  inlines it.
+- A now-template-only match is underscore-prefixed so `warnings_as_errors`
+  (unused variable) stays satisfied.
+
+**Reads that do not inline** (left captured, slot stays static): a binding
+destructured in the function head (`render(#{foo := Foo})` -- a pattern match
+is an untracked read; read it with `?get(foo)` instead), a variable bound
+inside an `if` or only on some `case` branches, and a rebound variable. Use
+`?get` for the top-level binding and plain `maps:get/2` for sub-structures
+(only the `?get` records a dep, which is the correct grain).
+
 ## API -- effect commands (`arizona_js` / `arizona_android` / `arizona_effect`)
 
 Client effect commands, built per platform -- `arizona_js` (web), `arizona_android` (native) --

--- a/e2e/parallel/arizona_inline.spec.js
+++ b/e2e/parallel/arizona_inline.spec.js
@@ -1,0 +1,41 @@
+import { expect, test } from '@playwright/test';
+import { expectStaysConnected } from '../utils/helpers.js';
+
+// The /inline view (test/support/arizona_inline.erl) reads every binding into a
+// body variable BEFORE the ?html call (the "hoisted read" pattern) across several
+// shapes: a plain hoisted read (count), a derived chain (doubled = count * 2), and
+// a statement-form case bind (parity). The binding-read inlining feature rewrites
+// each interpolated variable back into its slot so it tracks `count` and diffs.
+// If any slot regressed to "frozen" (empty deps), its <span> would not update on
+// click -- this spec asserts every slot patches over the real WebSocket.
+
+const wsReady = (page) =>
+    page.waitForFunction(() => document.documentElement.classList.contains('az-connected'));
+
+const incBtn = (page) => page.locator(`#inline button[az-click*='"inc"']`);
+const countText = (page) => page.locator('#inline .count');
+const doubledText = (page) => page.locator('#inline .doubled');
+const parityText = (page) => page.locator('#inline .parity');
+
+const expectState = async (page, { count, doubled, parity }) => {
+    await expect(countText(page)).toHaveText(count);
+    await expect(doubledText(page)).toHaveText(doubled);
+    await expect(parityText(page)).toHaveText(parity);
+};
+
+test.describe('binding-read inlining', () => {
+    test('hoisted reads track and diff over the wire', async ({ page }) => {
+        await page.goto('/inline');
+        await wsReady(page);
+
+        // Baseline (count = 0).
+        await expectState(page, { count: '0', doubled: '0', parity: 'even' });
+
+        // Each click mutates `count` server-side; every hoisted slot must re-render.
+        await expectStaysConnected(page, () => incBtn(page).click());
+        await expectState(page, { count: '1', doubled: '2', parity: 'odd' });
+
+        await expectStaysConnected(page, () => incBtn(page).click());
+        await expectState(page, { count: '2', doubled: '4', parity: 'even' });
+    });
+});

--- a/rebar.config
+++ b/rebar.config
@@ -123,6 +123,7 @@
         {"test/support/arizona_counter.erl", [unnecessary_function_arguments]},
         {"test/support/arizona_chat.erl", [unnecessary_function_arguments]},
         {"test/support/arizona_mixed_children.erl", [unnecessary_function_arguments]},
+        {"test/support/arizona_inline.erl", [unnecessary_function_arguments]},
         {"test/support/arizona_scroll_home.erl", [unnecessary_function_arguments]},
         {"test/support/arizona_scroll_about.erl", [unnecessary_function_arguments]},
         {"test/support/arizona_timer.erl", [unnecessary_function_arguments]},

--- a/src/arizona_parse_transform.erl
+++ b/src/arizona_parse_transform.erl
@@ -305,22 +305,24 @@ transform_form(Form, _Module, _IsLive) ->
     Form.
 
 transform_clause({clause, L, Patterns, Guards, Body}, Module) ->
-    {clause, L, Patterns, Guards, [transform_expr(Expr, Module) || Expr <- Body]}.
+    Inline = collect_inline(Body),
+    Body1 = [transform_expr(Expr, Module, Inline) || Expr <- Body],
+    {clause, L, Patterns, Guards, suppress_unused_inline_matches(Body1, Inline)}.
 
-transform_expr(Expr, Module) ->
-    erl_syntax_lib:map(fun(Node) -> transform_node(Node, Module) end, Expr).
+transform_expr(Expr, Module, Inline) ->
+    erl_syntax_lib:map(fun(Node) -> transform_node(Node, Module, Inline) end, Expr).
 
-transform_node(Node, Module) ->
+transform_node(Node, Module, Inline) ->
     N = erl_syntax:revert(Node),
     case N of
         {call, L, {remote, _, {atom, _, Mod}, {atom, _, html}}, [Arg]} when
             Mod =:= arizona_template; Mod =:= az
         ->
-            compile_template(Arg, L, Module);
+            compile_template(inline_vars(Arg, Inline), L, Module);
         {call, L, {remote, _, {atom, _, Mod}, {atom, _, native}}, [Arg]} when
             Mod =:= arizona_template; Mod =:= az
         ->
-            compile_template(Arg, L, Module, false, arizona_native);
+            compile_template(inline_vars(Arg, Inline), L, Module, false, arizona_native);
         {call, L, {remote, _, {atom, _, Mod}, {atom, _, terminal}}, [Arg]} when
             Mod =:= arizona_template; Mod =:= az
         ->
@@ -329,19 +331,31 @@ transform_node(Node, Module) ->
             %% the terminal transport repaints whole frames rather than addressing
             %% the root node. So the live-render last-expr path falls through to
             %% here for `?terminal(...)`.
-            compile_template(Arg, L, Module, false, arizona_terminal);
+            compile_template(inline_vars(Arg, Inline), L, Module, false, arizona_terminal);
         {call, L, {remote, _, {atom, _, Mod}, {atom, _, each}}, [FunArg, SourceArg]} when
             Mod =:= arizona_template; Mod =:= az
         ->
-            compile_each(FunArg, SourceArg, L, Module);
+            compile_each(inline_vars(FunArg, Inline), inline_vars(SourceArg, Inline), L, Module);
         {call, L, {remote, _, {atom, _, Mod}, {atom, _, native_each}}, [FunArg, SourceArg]} when
             Mod =:= arizona_template; Mod =:= az
         ->
-            compile_each(FunArg, SourceArg, L, Module, arizona_native);
+            compile_each(
+                inline_vars(FunArg, Inline),
+                inline_vars(SourceArg, Inline),
+                L,
+                Module,
+                arizona_native
+            );
         {call, L, {remote, _, {atom, _, Mod}, {atom, _, terminal_each}}, [FunArg, SourceArg]} when
             Mod =:= arizona_template; Mod =:= az
         ->
-            compile_each(FunArg, SourceArg, L, Module, arizona_terminal);
+            compile_each(
+                inline_vars(FunArg, Inline),
+                inline_vars(SourceArg, Inline),
+                L,
+                Module,
+                arizona_terminal
+            );
         %% Sugar: `arizona_template:stateless(atom, Props)` with a literal atom
         %% callback is rewritten to `arizona_template:stateless(fun atom/1, Props)`.
         %% Fun references and other shapes pass through unchanged.
@@ -357,89 +371,104 @@ transform_node(Node, Module) ->
     end.
 
 transform_live_render_clause({clause, L, Patterns, Guards, Body}, Module) ->
+    Inline = collect_inline(Body),
     {Init, [Last]} = lists:split(length(Body) - 1, Body),
-    TransformedInit = [transform_expr(Expr, Module) || Expr <- Init],
-    TransformedLast = transform_live_render_last(Last, Module),
-    {clause, L, Patterns, Guards, TransformedInit ++ [TransformedLast]}.
+    TransformedInit = [transform_expr(Expr, Module, Inline) || Expr <- Init],
+    TransformedLast = transform_live_render_last(Last, Module, Inline),
+    Body1 = TransformedInit ++ [TransformedLast],
+    {clause, L, Patterns, Guards, suppress_unused_inline_matches(Body1, Inline)}.
 
-transform_live_render_last(Expr, Module) ->
+transform_live_render_last(Expr, Module, Inline) ->
     N = erl_syntax:revert(Expr),
     case N of
         {call, L, {remote, _, {atom, _, Mod}, {atom, _, html}}, [Arg]} when
             Mod =:= arizona_template; Mod =:= az
         ->
-            validate_live_root(Arg, L),
-            Arg1 = transform_expr(Arg, Module),
-            compile_template(Arg1, L, Module, true);
+            validate_live_root(Arg, L, Inline),
+            Arg1 = transform_expr(Arg, Module, Inline),
+            compile_template(inline_vars(Arg1, Inline), L, Module, true);
         {call, L, {remote, _, {atom, _, Mod}, {atom, _, native}}, [Arg]} when
             Mod =:= arizona_template; Mod =:= az
         ->
-            validate_live_root(Arg, L),
-            Arg1 = transform_expr(Arg, Module),
-            compile_template(Arg1, L, Module, true, arizona_native);
+            validate_live_root(Arg, L, Inline),
+            Arg1 = transform_expr(Arg, Module, Inline),
+            compile_template(inline_vars(Arg1, Inline), L, Module, true, arizona_native);
         {'case', L, CaseExpr, Clauses} ->
-            {'case', L, transform_expr(CaseExpr, Module), [
-                transform_live_render_branch(C, Module)
+            {'case', L, transform_expr(CaseExpr, Module, Inline), [
+                transform_live_render_branch(C, Module, Inline)
              || C <- Clauses
             ]};
         {'if', L, Clauses} ->
-            {'if', L, [transform_live_render_branch(C, Module) || C <- Clauses]};
+            {'if', L, [transform_live_render_branch(C, Module, Inline) || C <- Clauses]};
         {block, L, Body} ->
-            transform_live_render_block(L, Body, Module);
+            transform_live_render_block(L, Body, Module, Inline);
         {'receive', L, Clauses} ->
-            {'receive', L, [transform_live_render_branch(C, Module) || C <- Clauses]};
+            {'receive', L, [transform_live_render_branch(C, Module, Inline) || C <- Clauses]};
         {'receive', L, Clauses, AfterExpr, AfterBody} ->
-            {'receive', L, [transform_live_render_branch(C, Module) || C <- Clauses],
-                transform_expr(AfterExpr, Module),
-                transform_live_render_block_body(AfterBody, Module)};
+            {'receive', L, [transform_live_render_branch(C, Module, Inline) || C <- Clauses],
+                transform_expr(AfterExpr, Module, Inline),
+                transform_live_render_block_body(AfterBody, Module, Inline)};
         {'try', L, Body, OfClauses, CatchClauses, AfterBody} ->
-            {'try', L, transform_live_render_block_body(Body, Module),
-                [transform_live_render_branch(C, Module) || C <- OfClauses],
-                [transform_live_render_branch(C, Module) || C <- CatchClauses], [
-                    transform_expr(E, Module)
+            {'try', L, transform_live_render_block_body(Body, Module, Inline),
+                [transform_live_render_branch(C, Module, Inline) || C <- OfClauses],
+                [transform_live_render_branch(C, Module, Inline) || C <- CatchClauses], [
+                    transform_expr(E, Module, Inline)
                  || E <- AfterBody
                 ]};
         {'maybe', L, Body} ->
-            {'maybe', L, transform_live_render_block_body(Body, Module)};
+            {'maybe', L, transform_live_render_block_body(Body, Module, Inline)};
         {'maybe', L, Body, {'else', L2, ElseClauses}} ->
-            {'maybe', L, transform_live_render_block_body(Body, Module),
-                {'else', L2, [transform_live_render_branch(C, Module) || C <- ElseClauses]}};
+            {'maybe', L, transform_live_render_block_body(Body, Module, Inline),
+                {'else', L2, [
+                    transform_live_render_branch(C, Module, Inline)
+                 || C <- ElseClauses
+                ]}};
         _ ->
-            transform_expr(Expr, Module)
+            transform_expr(Expr, Module, Inline)
     end.
 
-transform_live_render_block(L, Body, Module) ->
-    {block, L, transform_live_render_block_body(Body, Module)}.
+transform_live_render_block(L, Body, Module, Inline) ->
+    {block, L, transform_live_render_block_body(Body, Module, Inline)}.
 
-transform_live_render_block_body(Body, Module) ->
+transform_live_render_block_body(Body, Module, Inline) ->
     {Init, [Last]} = lists:split(length(Body) - 1, Body),
-    [transform_expr(E, Module) || E <- Init] ++ [transform_live_render_last(Last, Module)].
+    [transform_expr(E, Module, Inline) || E <- Init] ++
+        [transform_live_render_last(Last, Module, Inline)].
 
-transform_live_render_branch({clause, L, Patterns, Guards, Body}, Module) ->
+transform_live_render_branch({clause, L, Patterns, Guards, Body}, Module, Inline) ->
     {Init, [Last]} = lists:split(length(Body) - 1, Body),
-    TransInit = [transform_expr(E, Module) || E <- Init],
-    {clause, L, Patterns, Guards, TransInit ++ [transform_live_render_last(Last, Module)]}.
+    TransInit = [transform_expr(E, Module, Inline) || E <- Init],
+    {clause, L, Patterns, Guards, TransInit ++ [transform_live_render_last(Last, Module, Inline)]}.
 
-validate_live_root({tuple, _, [_Tag, Attrs | _]}, L) ->
-    validate_id_expr(Attrs, L);
-validate_live_root(_, L) ->
+validate_live_root({tuple, _, [_Tag, Attrs | _]}, L, Inline) ->
+    validate_id_expr(Attrs, L, Inline);
+validate_live_root(_, L, _Inline) ->
     parse_error(live_render_not_single_element, L).
 
-validate_id_expr({cons, _, {tuple, _, [{atom, _, id}, ValueAST]}, _}, L) ->
-    case is_get_id_call(ValueAST) of
+validate_id_expr({cons, _, {tuple, _, [{atom, _, id}, ValueAST]}, _}, L, Inline) ->
+    case is_get_id_call(ValueAST, Inline) of
         true -> ok;
         false -> parse_error(live_render_id_must_be_get_id, L)
     end;
-validate_id_expr({cons, _, _, Rest}, L) ->
-    validate_id_expr(Rest, L);
-validate_id_expr(_, L) ->
+validate_id_expr({cons, _, _, Rest}, L, Inline) ->
+    validate_id_expr(Rest, L, Inline);
+validate_id_expr(_, L, _Inline) ->
     parse_error(live_render_missing_id, L).
 
-is_get_id_call({call, _, {remote, _, {atom, _, Mod}, {atom, _, get}}, [{atom, _, id}, _]}) when
+%% A bare `?get(id)` at the root, or a variable hoisted into the body whose
+%% definition resolves (through the inline map) to `get(id, _)`.
+is_get_id_call(
+    {call, _, {remote, _, {atom, _, Mod}, {atom, _, get}}, [{atom, _, id}, _]}, _Inline
+) when
     Mod =:= arizona_template; Mod =:= az
 ->
     true;
-is_get_id_call(_) ->
+is_get_id_call({var, _, V}, Inline) ->
+    case Inline of
+        #{V := RHS} -> is_get_id_call(RHS, Inline);
+        #{} -> false
+    end;
+is_get_id_call(_, _Inline) ->
     false.
 
 maybe_inject_or_raise_az_view(Attrs, Line, #state{live_render = true, root = true}) ->
@@ -461,6 +490,233 @@ is_az_view_attr({bin, _, [{bin_element, _, {string, _, "az-view"}, _, _}]}) ->
     true;
 is_az_view_attr(_) ->
     false.
+
+%% --------------------------------------------------------------------
+%% Binding-read inlining
+%% --------------------------------------------------------------------
+%%
+%% A read hoisted into the function body --
+%%
+%%     Name = arizona_template:get(name, Bindings),
+%%     ?html({p, [], [Name]}).
+%%
+%% -- would otherwise compile the slot to `fun() -> Name end`: a closure that
+%% captures a plain value and runs no `get`, so it records no dependency and the
+%% slot freezes after the first render. We rewrite each interpolated variable back
+%% into its defining expression, so the `get` re-executes inside the per-slot
+%% dependency bracket -- exactly as if it had been written inline in the template.
+
+%% Build the inline map for a clause body: top-level `Var = RHS` matches whose RHS
+%% transitively reaches an `arizona_template`/`az` `get`/`get_lazy`/`track` call.
+%% Variables bound more than once are dropped (ambiguous to inline); a binding-derived
+%% expression with no read (e.g. `Id = make_uuid()`) is left captured so a pure
+%% side effect is never re-run per slot.
+collect_inline(Body) ->
+    {Raw, Poisoned} = scan_top_matches(Body, #{}, #{}),
+    keep_reaching(maps:without(maps:keys(Poisoned), Raw)).
+
+scan_top_matches([], Raw, Poisoned) ->
+    {Raw, Poisoned};
+scan_top_matches([{match, _, {var, _, V}, RHS} | Rest], Raw, Poisoned) ->
+    case Raw of
+        #{V := _} -> scan_top_matches(Rest, Raw, Poisoned#{V => true});
+        #{} -> scan_top_matches(Rest, Raw#{V => RHS}, Poisoned)
+    end;
+scan_top_matches([_ | Rest], Raw, Poisoned) ->
+    scan_top_matches(Rest, Raw, Poisoned).
+
+keep_reaching(Candidates) ->
+    maps:with(maps:keys(reaching_fixpoint(Candidates, #{})), Candidates).
+
+reaching_fixpoint(Candidates, Acc) ->
+    Acc1 = maps:fold(
+        fun
+            (V, _RHS, A) when is_map_key(V, A) -> A;
+            (V, RHS, A) ->
+                case rhs_reaches(RHS, A) of
+                    true -> A#{V => true};
+                    false -> A
+                end
+        end,
+        Acc,
+        Candidates
+    ),
+    case map_size(Acc1) =:= map_size(Acc) of
+        true -> Acc1;
+        false -> reaching_fixpoint(Candidates, Acc1)
+    end.
+
+%% True when an AST subtree contains a get/get_lazy/track call, or references a
+%% variable already known to reach one.
+rhs_reaches({call, _, {remote, _, {atom, _, Mod}, {atom, _, F}}, _Args}, _Reaching) when
+    (Mod =:= arizona_template orelse Mod =:= az) andalso
+        (F =:= get orelse F =:= get_lazy orelse F =:= track)
+->
+    true;
+rhs_reaches({var, _, V}, Reaching) ->
+    is_map_key(V, Reaching);
+rhs_reaches(T, Reaching) when is_tuple(T) ->
+    rhs_reaches_any(tuple_to_list(T), Reaching);
+rhs_reaches(L, Reaching) when is_list(L) ->
+    rhs_reaches_any(L, Reaching);
+rhs_reaches(_, _Reaching) ->
+    false.
+
+rhs_reaches_any([], _Reaching) ->
+    false;
+rhs_reaches_any([H | T], Reaching) ->
+    rhs_reaches(H, Reaching) orelse rhs_reaches_any(T, Reaching).
+
+%% Recursively substitute interpolated variables with their inlined defining
+%% expression. Scope-aware: variables shadowed by fun parameters or comprehension
+%% generators are not substituted, and patterns/guards are left untouched so a
+%% substitution can never produce an illegal pattern.
+inline_vars(Expr, Inline) when map_size(Inline) =:= 0 ->
+    Expr;
+inline_vars(Expr, Inline) ->
+    iv(Expr, Inline).
+
+iv({var, _, V} = Var, Inline) ->
+    case Inline of
+        #{V := RHS} -> iv(RHS, Inline);
+        #{} -> Var
+    end;
+iv({'fun', L, {clauses, Cs}}, Inline) ->
+    {'fun', L, {clauses, [iv_fun_clause(C, Inline) || C <- Cs]}};
+iv({named_fun, L, Name, Cs}, Inline) ->
+    Inline1 = maps:remove(Name, Inline),
+    {named_fun, L, Name, [iv_fun_clause(C, Inline1) || C <- Cs]};
+iv({'case', L, E, Cs}, Inline) ->
+    {'case', L, iv(E, Inline), [iv_clause(C, Inline) || C <- Cs]};
+iv({'if', L, Cs}, Inline) ->
+    {'if', L, [iv_clause(C, Inline) || C <- Cs]};
+iv({'receive', L, Cs}, Inline) ->
+    {'receive', L, [iv_clause(C, Inline) || C <- Cs]};
+iv({'receive', L, Cs, AE, AB}, Inline) ->
+    {'receive', L, [iv_clause(C, Inline) || C <- Cs], iv(AE, Inline), iv_body(AB, Inline)};
+iv({'try', L, B, OfCs, CatchCs, Aft}, Inline) ->
+    {'try', L, iv_body(B, Inline), [iv_clause(C, Inline) || C <- OfCs],
+        [
+            iv_clause(C, Inline)
+         || C <- CatchCs
+        ],
+        iv_body(Aft, Inline)};
+iv({'catch', L, E}, Inline) ->
+    {'catch', L, iv(E, Inline)};
+iv({lc, L, T, Qs}, Inline) ->
+    {Qs1, Inline1} = iv_quals(Qs, Inline),
+    {lc, L, iv(T, Inline1), Qs1};
+iv({bc, L, T, Qs}, Inline) ->
+    {Qs1, Inline1} = iv_quals(Qs, Inline),
+    {bc, L, iv(T, Inline1), Qs1};
+iv({mc, L, T, Qs}, Inline) ->
+    {Qs1, Inline1} = iv_quals(Qs, Inline),
+    {mc, L, iv(T, Inline1), Qs1};
+iv({block, L, B}, Inline) ->
+    {block, L, iv_body(B, Inline)};
+iv({match, L, P, E}, Inline) ->
+    {match, L, P, iv(E, Inline)};
+iv({'maybe', L, B}, Inline) ->
+    {'maybe', L, iv_body(B, Inline)};
+iv({'maybe', L, B, {'else', L2, Cs}}, Inline) ->
+    {'maybe', L, iv_body(B, Inline), {'else', L2, [iv_clause(C, Inline) || C <- Cs]}};
+iv({maybe_match, L, P, E}, Inline) ->
+    {maybe_match, L, P, iv(E, Inline)};
+iv(T, Inline) when is_tuple(T) ->
+    list_to_tuple([iv(E, Inline) || E <- tuple_to_list(T)]);
+iv(L, Inline) when is_list(L) ->
+    [iv(E, Inline) || E <- L];
+iv(Other, _Inline) ->
+    Other.
+
+%% Fun clause: parameters bind and shadow; drop them from the map for the body.
+iv_fun_clause({clause, L, Params, Guards, Body}, Inline) ->
+    Inline1 = maps:without(pattern_vars(Params), Inline),
+    {clause, L, Params, Guards, iv_body(Body, Inline1)}.
+
+%% case/receive/try-of/catch clause: patterns match the (already inlined) scrutinee,
+%% so patterns and guards are left untouched. Any name a pattern binds is dropped from
+%% the map for the body as a conservative shadow guard.
+iv_clause({clause, L, Patterns, Guards, Body}, Inline) ->
+    Inline1 = maps:without(pattern_vars(Patterns), Inline),
+    {clause, L, Patterns, Guards, iv_body(Body, Inline1)}.
+
+%% A body is a sequence; a `Var = RHS` match binds Var (shadowing) for later exprs.
+iv_body(Exprs, Inline) ->
+    {Rev, _} = lists:foldl(
+        fun(E, {Acc, Inl}) ->
+            Inl1 =
+                case E of
+                    {match, _, P, _} -> maps:without(pattern_vars(P), Inl);
+                    _ -> Inl
+                end,
+            {[iv(E, Inl) | Acc], Inl1}
+        end,
+        {[], Inline},
+        Exprs
+    ),
+    lists:reverse(Rev).
+
+%% Comprehension qualifiers, left to right: generator patterns bind for subsequent
+%% qualifiers and the template; filters are plain expressions.
+iv_quals(Qs, Inline) ->
+    lists:mapfoldl(fun iv_qual/2, Inline, Qs).
+
+iv_qual({generate, L, P, E}, Inline) ->
+    {{generate, L, P, iv(E, Inline)}, maps:without(pattern_vars(P), Inline)};
+iv_qual({b_generate, L, P, E}, Inline) ->
+    {{b_generate, L, P, iv(E, Inline)}, maps:without(pattern_vars(P), Inline)};
+iv_qual({m_generate, L, P, E}, Inline) ->
+    {{m_generate, L, P, iv(E, Inline)}, maps:without(pattern_vars(P), Inline)};
+iv_qual(Filter, Inline) ->
+    {iv(Filter, Inline), Inline}.
+
+pattern_vars(Pattern) ->
+    maps:keys(collect_pattern_vars(Pattern, #{})).
+
+collect_pattern_vars({var, _, '_'}, Acc) ->
+    Acc;
+collect_pattern_vars({var, _, V}, Acc) ->
+    Acc#{V => true};
+collect_pattern_vars(T, Acc) when is_tuple(T) ->
+    collect_pattern_vars(tuple_to_list(T), Acc);
+collect_pattern_vars([H | T], Acc) ->
+    collect_pattern_vars(T, collect_pattern_vars(H, Acc));
+collect_pattern_vars(_, Acc) ->
+    Acc.
+
+%% After inlining, a variable used only inside the template no longer appears outside
+%% its own binding. Underscore-prefix such matches so `warnings_as_errors` (unused
+%% variable) doesn't reject the module; matches still referenced elsewhere are kept.
+suppress_unused_inline_matches(Body, Inline) when map_size(Inline) =:= 0 ->
+    Body;
+suppress_unused_inline_matches(Body, Inline) ->
+    [maybe_underscore_match(E, Inline, Body) || E <- Body].
+
+maybe_underscore_match({match, L, {var, VL, V}, RHS} = M, Inline, Body) ->
+    case is_map_key(V, Inline) andalso count_var(V, Body) =:= 1 of
+        true -> {match, L, {var, VL, underscore_var(V)}, RHS};
+        false -> M
+    end;
+maybe_underscore_match(E, _Inline, _Body) ->
+    E.
+
+underscore_var(V) ->
+    binary_to_atom(<<"_", (atom_to_binary(V))/binary>>).
+
+count_var(V, AST) ->
+    count_var(V, AST, 0).
+
+count_var(V, {var, _, V}, N) ->
+    N + 1;
+count_var(_V, {var, _, _}, N) ->
+    N;
+count_var(V, T, N) when is_tuple(T) ->
+    count_var(V, tuple_to_list(T), N);
+count_var(V, [H | T], N) ->
+    count_var(V, T, count_var(V, H, N));
+count_var(_V, _Other, N) ->
+    N.
 
 compile_template(Arg, Line, Module) ->
     compile_template(Arg, Line, Module, false).

--- a/src/arizona_parse_transform.erl
+++ b/src/arizona_parse_transform.erl
@@ -690,15 +690,9 @@ iv({'try', L, B, OfCs, CatchCs, Aft}, Inline) ->
         iv_body(Aft, Inline)};
 iv({'catch', L, E}, Inline) ->
     {'catch', L, iv(E, Inline)};
-iv({lc, L, T, Qs}, Inline) ->
+iv({Comp, L, T, Qs}, Inline) when Comp =:= lc; Comp =:= bc; Comp =:= mc ->
     {Qs1, Inline1} = iv_quals(Qs, Inline),
-    {lc, L, iv(T, Inline1), Qs1};
-iv({bc, L, T, Qs}, Inline) ->
-    {Qs1, Inline1} = iv_quals(Qs, Inline),
-    {bc, L, iv(T, Inline1), Qs1};
-iv({mc, L, T, Qs}, Inline) ->
-    {Qs1, Inline1} = iv_quals(Qs, Inline),
-    {mc, L, iv(T, Inline1), Qs1};
+    {Comp, L, iv(T, Inline1), Qs1};
 iv({block, L, B}, Inline) ->
     {block, L, iv_body(B, Inline)};
 iv({match, L, P, E}, Inline) ->
@@ -780,23 +774,16 @@ suppress_unused_inline_matches(Body, Inline) when map_size(Inline) =:= 0 ->
 suppress_unused_inline_matches(Body, Inline) ->
     [maybe_underscore_match(E, Inline, Body) || E <- Body].
 
+%% Rename the now-unused match LHS to the anonymous `_`: it never collides with a
+%% pre-existing `_Foo` binding (which would otherwise trip erl_lint's
+%% match_underscore_var) and never warns.
 maybe_underscore_match({match, L, {var, VL, V}, RHS} = M, Inline, Body) ->
     case is_map_key(V, Inline) andalso count_var(V, Body) =:= 1 of
-        true -> {match, L, {var, VL, underscore_var(V, Body)}, RHS};
+        true -> {match, L, {var, VL, '_'}, RHS};
         false -> M
     end;
 maybe_underscore_match(E, _Inline, _Body) ->
     E.
-
-%% `_Foo` is readable, but if the clause already binds `_Foo` (e.g. a discarded
-%% side-effect match), a second `_Foo` would trip erl_lint's match_underscore_var.
-%% Fall back to the anonymous `_`, which never collides or warns.
-underscore_var(V, Body) ->
-    U = binary_to_atom(<<"_", (atom_to_binary(V))/binary>>),
-    case count_var(U, Body) of
-        0 -> U;
-        _ -> '_'
-    end.
 
 count_var(V, AST) ->
     count_var(V, AST, 0).

--- a/src/arizona_parse_transform.erl
+++ b/src/arizona_parse_transform.erl
@@ -304,7 +304,8 @@ transform_form({function, L, Name, Arity, Clauses}, Module, _IsLive) ->
 transform_form(Form, _Module, _IsLive) ->
     Form.
 
-transform_clause({clause, L, Patterns, Guards, Body}, Module) ->
+transform_clause({clause, L, Patterns, Guards, Body0}, Module) ->
+    Body = normalize_tail_binds(Body0),
     Inline = collect_inline(Body),
     Body1 = [transform_expr(Expr, Module, Inline) || Expr <- Body],
     {clause, L, Patterns, Guards, suppress_unused_inline_matches(Body1, Inline)}.
@@ -371,8 +372,11 @@ transform_node(Node, Module, Inline) ->
     end.
 
 transform_live_render_clause({clause, L, Patterns, Guards, Body}, Module) ->
-    Inline = collect_inline(Body),
-    {Init, [Last]} = lists:split(length(Body) - 1, Body),
+    {Init0, [Last]} = lists:split(length(Body) - 1, Body),
+    %% Only the init statements are normalized: the last expr carries the live root
+    %% template and is handled by transform_live_render_last/3.
+    Init = normalize_tail_binds(Init0),
+    Inline = collect_inline(Init ++ [Last]),
     TransformedInit = [transform_expr(Expr, Module, Inline) || Expr <- Init],
     TransformedLast = transform_live_render_last(Last, Module, Inline),
     Body1 = TransformedInit ++ [TransformedLast],
@@ -566,6 +570,71 @@ rhs_reaches_any([], _Reaching) ->
     false;
 rhs_reaches_any([H | T], Reaching) ->
     rhs_reaches(H, Reaching) orelse rhs_reaches_any(T, Reaching).
+
+%% Lift a statement-form `case` that binds one variable as the whole body of every
+%% branch --
+%%
+%%     case ?get(mode) of dark -> X = ?get(a); _ -> X = ?get(b) end,
+%%
+%% -- into value form --
+%%
+%%     X = case ?get(mode) of dark -> ?get(a); _ -> ?get(b) end,
+%%
+%% so the existing top-level-match machinery can inline it. Restricted to clauses
+%% whose body is exactly a single `Var = E` match (no other bindings to strip out of
+%% scope), and only when the lifted expression actually reaches a read.
+%%
+%% `if`/`receive` are deliberately excluded: their conditions are guards, which
+%% cannot hold a read, so a binding-derived condition would stay captured and the
+%% slot would track only the branch bodies -- partial tracking that looks correct.
+%% A `case` scrutinee is an expression and inlines fully, so it is always sound.
+normalize_tail_binds(Body) ->
+    [normalize_tail_bind(Stmt) || Stmt <- Body].
+
+normalize_tail_bind({'case', L, Scrutinee, Clauses} = Stmt) ->
+    lift_tail_bind(Stmt, L, Clauses, fun(Stripped) -> {'case', L, Scrutinee, Stripped} end);
+normalize_tail_bind(Stmt) ->
+    Stmt.
+
+%% `strip_tail_binds/1` is only safe once `tail_bind_var/1` has confirmed every
+%% clause body is a single `Var = E` match, so it is computed lazily here.
+lift_tail_bind(Stmt, L, Clauses, Rebuild) ->
+    case tail_bind_var(Clauses) of
+        {ok, V} ->
+            Lifted = Rebuild(strip_tail_binds(Clauses)),
+            case rhs_reaches(Lifted, #{}) of
+                true -> {match, L, {var, L, V}, Lifted};
+                false -> Stmt
+            end;
+        error ->
+            Stmt
+    end.
+
+%% `{ok, V}` when every clause's body is exactly `[{match, {var, V}, _}]` for the
+%% same `V`; `error` otherwise.
+tail_bind_var([First | _] = Clauses) ->
+    case clause_bind_var(First) of
+        {ok, V} ->
+            case lists:all(fun(C) -> clause_bind_var(C) =:= {ok, V} end, Clauses) of
+                true -> {ok, V};
+                false -> error
+            end;
+        error ->
+            error
+    end;
+tail_bind_var([]) ->
+    error.
+
+clause_bind_var({clause, _, _Patterns, _Guards, [{match, _, {var, _, V}, _E}]}) ->
+    {ok, V};
+clause_bind_var(_) ->
+    error.
+
+strip_tail_binds(Clauses) ->
+    [strip_tail_bind(C) || C <- Clauses].
+
+strip_tail_bind({clause, L, Patterns, Guards, [{match, _, {var, _, _V}, E}]}) ->
+    {clause, L, Patterns, Guards, [E]}.
 
 %% Recursively substitute interpolated variables with their inlined defining
 %% expression. Scope-aware: variables shadowed by fun parameters or comprehension

--- a/src/arizona_parse_transform.erl
+++ b/src/arizona_parse_transform.erl
@@ -625,10 +625,28 @@ tail_bind_var([First | _] = Clauses) ->
 tail_bind_var([]) ->
     error.
 
-clause_bind_var({clause, _, _Patterns, _Guards, [{match, _, {var, _, V}, _E}]}) ->
-    {ok, V};
+%% A clause qualifies only when lifting cannot move a binding out of scope. The
+%% lifted value-form case is ALSO substituted into the slot closure, so any variable
+%% a clause introduces would be bound twice. Refuse if the clause pattern binds a
+%% variable (e.g. `{admin, Name} ->` -- would become an unsafe_var) or the branch
+%% RHS contains a nested match (e.g. `X = (Z = E)` -- would export `Z` from both
+%% copies). Such cases are left in statement form (captured, not fine-grained).
+clause_bind_var({clause, _, Patterns, _Guards, [{match, _, {var, _, V}, E}]}) ->
+    case pattern_vars(Patterns) =:= [] andalso not contains_match(E) of
+        true -> {ok, V};
+        false -> error
+    end;
 clause_bind_var(_) ->
     error.
+
+contains_match({match, _, _, _}) ->
+    true;
+contains_match(T) when is_tuple(T) ->
+    contains_match(tuple_to_list(T));
+contains_match([H | T]) ->
+    contains_match(H) orelse contains_match(T);
+contains_match(_) ->
+    false.
 
 strip_tail_binds(Clauses) ->
     [strip_tail_bind(C) || C <- Clauses].
@@ -764,14 +782,21 @@ suppress_unused_inline_matches(Body, Inline) ->
 
 maybe_underscore_match({match, L, {var, VL, V}, RHS} = M, Inline, Body) ->
     case is_map_key(V, Inline) andalso count_var(V, Body) =:= 1 of
-        true -> {match, L, {var, VL, underscore_var(V)}, RHS};
+        true -> {match, L, {var, VL, underscore_var(V, Body)}, RHS};
         false -> M
     end;
 maybe_underscore_match(E, _Inline, _Body) ->
     E.
 
-underscore_var(V) ->
-    binary_to_atom(<<"_", (atom_to_binary(V))/binary>>).
+%% `_Foo` is readable, but if the clause already binds `_Foo` (e.g. a discarded
+%% side-effect match), a second `_Foo` would trip erl_lint's match_underscore_var.
+%% Fall back to the anonymous `_`, which never collides or warns.
+underscore_var(V, Body) ->
+    U = binary_to_atom(<<"_", (atom_to_binary(V))/binary>>),
+    case count_var(U, Body) of
+        0 -> U;
+        _ -> '_'
+    end.
 
 count_var(V, AST) ->
     count_var(V, AST, 0).

--- a/test/arizona_parse_transform_SUITE.erl
+++ b/test/arizona_parse_transform_SUITE.erl
@@ -163,6 +163,7 @@
     inline_non_bindings_var_name/1,
     inline_destructuring_not_inlined/1,
     inline_guard_get_stays_captured/1,
+    inline_comprehension_source/1,
     void_element/1,
     void_in_each_with_children/1,
     void_nested_child_with_children/1,
@@ -363,7 +364,8 @@ groups() ->
             inline_same_var_two_slots,
             inline_non_bindings_var_name,
             inline_destructuring_not_inlined,
-            inline_guard_get_stays_captured
+            inline_guard_get_stays_captured,
+            inline_comprehension_source
         ]},
         %% Tests 68-77c: layout tests
         {layout, [parallel], [
@@ -4677,6 +4679,23 @@ inline_guard_get_stays_captured(Config) when is_list(Config) ->
     [{_Az, Fun, _Loc}] = maps:get(d, T),
     ?assertEqual(big, Fun()),
     ?assertEqual(#{}, slot_deps(Fun)).
+
+%% A hoisted read used as a comprehension generator SOURCE is inlined (the
+%% collapsed lc/bc/mc clause of iv/2 must preserve the comprehension tag -- this
+%% uses a *binary* comprehension so a tag-hardcoding bug would be caught). The
+%% slot tracks the source key; the generator variable stays local (untracked).
+inline_comprehension_source(Config) when is_list(Config) ->
+    Mod = compile_module_strict(
+        "-module(pt_inline_comp). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    Names = arizona_template:get(names, Bindings), "
+        "    arizona_template:html({'p', [], [<< <<N/binary>> || N <- Names >>]}). "
+    ),
+    T = Mod:render(#{names => [~"a", ~"b"]}),
+    [{_Az, Fun, _Loc}] = maps:get(d, T),
+    ?assertEqual(~"ab", Fun()),
+    ?assertEqual(#{names => true}, slot_deps(Fun)).
 
 %% Like compile_module/1 but compiles with warnings_as_errors, matching the
 %% project's real erl_opts. Needed because unused-variable / match_underscore_var

--- a/test/arizona_parse_transform_SUITE.erl
+++ b/test/arizona_parse_transform_SUITE.erl
@@ -149,6 +149,7 @@
     inline_diff_updates/1,
     inline_unrelated_key_skipped/1,
     inline_hoisted_root_id/1,
+    inline_branch_bound_var/1,
     void_element/1,
     void_in_each_with_children/1,
     void_nested_child_with_children/1,
@@ -335,7 +336,8 @@ groups() ->
             inline_side_effect_not_inlined,
             inline_diff_updates,
             inline_unrelated_key_skipped,
-            inline_hoisted_root_id
+            inline_hoisted_root_id,
+            inline_branch_bound_var
         ]},
         %% Tests 68-77c: layout tests
         {layout, [parallel], [
@@ -4404,6 +4406,24 @@ inline_hoisted_root_id(Config) when is_list(Config) ->
     [IdFun] = [F || {_Az, {attr, ~"id", F}, _Loc} <- maps:get(d, T)],
     ?assertEqual(~"v1", IdFun()),
     ?assertEqual(#{id => true}, slot_deps(IdFun)).
+
+%% A variable bound as the whole body of every branch of a statement-form case is
+%% lifted to value form and inlined, so it tracks the scrutinee and branch reads.
+inline_branch_bound_var(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_inline_branchbound). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    case arizona_template:get(mode, Bindings) of "
+        "        dark -> X = arizona_template:get(a, Bindings); "
+        "        _ -> X = arizona_template:get(b, Bindings) "
+        "    end, "
+        "    arizona_template:html({'p', [], [X]}). "
+    ),
+    T = Mod:render(#{mode => dark, a => ~"A"}),
+    [{_Az, Fun, _Loc}] = maps:get(d, T),
+    ?assertEqual(~"A", Fun()),
+    ?assertEqual(#{mode => true, a => true}, slot_deps(Fun)).
 
 %% Evaluate a slot closure under a dependency bracket (mirrors arizona_eval) and
 %% return the captured deps.

--- a/test/arizona_parse_transform_SUITE.erl
+++ b/test/arizona_parse_transform_SUITE.erl
@@ -150,6 +150,19 @@
     inline_unrelated_key_skipped/1,
     inline_hoisted_root_id/1,
     inline_branch_bound_var/1,
+    inline_underscore_collision/1,
+    inline_lifted_pattern_var/1,
+    inline_lifted_nested_match/1,
+    inline_hoisted_attr_list_read/1,
+    inline_each_hoisted_source/1,
+    inline_distinct_slots_key_isolation/1,
+    inline_multi_clause_render/1,
+    inline_get_lazy_hoisted/1,
+    inline_nested_html_shared_var/1,
+    inline_same_var_two_slots/1,
+    inline_non_bindings_var_name/1,
+    inline_destructuring_not_inlined/1,
+    inline_guard_get_stays_captured/1,
     void_element/1,
     void_in_each_with_children/1,
     void_nested_child_with_children/1,
@@ -337,7 +350,20 @@ groups() ->
             inline_diff_updates,
             inline_unrelated_key_skipped,
             inline_hoisted_root_id,
-            inline_branch_bound_var
+            inline_branch_bound_var,
+            inline_underscore_collision,
+            inline_lifted_pattern_var,
+            inline_lifted_nested_match,
+            inline_hoisted_attr_list_read,
+            inline_each_hoisted_source,
+            inline_distinct_slots_key_isolation,
+            inline_multi_clause_render,
+            inline_get_lazy_hoisted,
+            inline_nested_html_shared_var,
+            inline_same_var_two_slots,
+            inline_non_bindings_var_name,
+            inline_destructuring_not_inlined,
+            inline_guard_get_stays_captured
         ]},
         %% Tests 68-77c: layout tests
         {layout, [parallel], [
@@ -4424,6 +4450,251 @@ inline_branch_bound_var(Config) when is_list(Config) ->
     [{_Az, Fun, _Loc}] = maps:get(d, T),
     ?assertEqual(~"A", Fun()),
     ?assertEqual(#{mode => true, a => true}, slot_deps(Fun)).
+
+%% Regression: an inlined match underscored to `_Foo` must not collide with an
+%% existing `_Foo` (a discarded side-effect bind) -- that would trip erl_lint's
+%% match_underscore_var and fail the warnings_as_errors build. The read still tracks.
+inline_underscore_collision(Config) when is_list(Config) ->
+    Mod = compile_module_strict(
+        "-module(pt_inline_ucoll). "
+        "-export([render/1]). "
+        "side() -> ok. "
+        "render(Bindings) -> "
+        "    _Foo = side(), "
+        "    Foo = arizona_template:get(foo, Bindings), "
+        "    arizona_template:html({'p', [], [Foo]}). "
+    ),
+    T = Mod:render(#{foo => ~"Ada"}),
+    [{_Az, Fun, _Loc}] = maps:get(d, T),
+    ?assertEqual(~"Ada", Fun()),
+    ?assertEqual(#{foo => true}, slot_deps(Fun)).
+
+%% Regression: a tail-bind case whose clause head binds a variable
+%% (`{admin, Name} ->`) must NOT be lifted (the lifted+inlined copies would
+%% double-bind Name -> unsafe_var). It stays statement-form: compiles, frozen slot.
+inline_lifted_pattern_var(Config) when is_list(Config) ->
+    Mod = compile_module_strict(
+        "-module(pt_inline_patvar). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    case arizona_template:get(user, Bindings) of "
+        "        {admin, Name} -> Label = Name; "
+        "        _ -> Label = arizona_template:get(guest, Bindings) "
+        "    end, "
+        "    arizona_template:html({'p', [], [Label]}). "
+    ),
+    T = Mod:render(#{user => {admin, ~"Ada"}}),
+    [{_Az, Fun, _Loc}] = maps:get(d, T),
+    ?assertEqual(~"Ada", Fun()),
+    %% Not lifted -> captured -> frozen (residue).
+    ?assertEqual(#{}, slot_deps(Fun)).
+
+%% Regression: a tail-bind case whose branch RHS contains a nested match
+%% (`X = (Z = E)`) must NOT be lifted (the inlined copy would re-export Z ->
+%% exported_var). It stays statement-form and compiles.
+inline_lifted_nested_match(Config) when is_list(Config) ->
+    Mod = compile_module_strict(
+        "-module(pt_inline_nestmatch). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    case arizona_template:get(mode, Bindings) of "
+        "        dark -> X = (Z = arizona_template:get(a, Bindings)); "
+        "        _ -> X = (Z = arizona_template:get(b, Bindings)) "
+        "    end, "
+        "    arizona_template:html({'p', [], [X, <<\" \">>, Z]}). "
+    ),
+    T = Mod:render(#{mode => dark, a => ~"A"}),
+    [{_Az, FunX, _Loc} | _] = maps:get(d, T),
+    ?assertEqual(~"A", FunX()).
+
+%% A hoisted read interpolated into an attribute *list* ({class, [<<"a ">>, Cls]}):
+%% inline_vars descends into the attr-value cons; the fused dynamic composes the
+%% static prefix with the read value, and tracks the key.
+inline_hoisted_attr_list_read(Config) when is_list(Config) ->
+    Mod = compile_module_strict(
+        "-module(pt_inline_attrlist). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    Cls = arizona_template:get(cls, Bindings), "
+        "    arizona_template:html({'div', [{class, [<<\"a \">>, Cls]}], [<<\"x\">>]}). "
+    ),
+    T = Mod:render(#{cls => ~"box"}),
+    [{_Az, {attr, ~"class", Fun}, _Loc}] = maps:get(d, T),
+    ?assertEqual([~"a ", ~"box"], Fun()),
+    ?assertEqual(#{cls => true}, slot_deps(Fun)).
+
+%% End-to-end: a hoisted ?each *source* re-tracks on diff. The each container is a
+%% per-slot closure; the source get must inline back so it re-runs in the bracket.
+inline_each_hoisted_source(Config) when is_list(Config) ->
+    Mod = compile_module_strict(
+        "-module(pt_inline_eachsrc). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    Items = arizona_template:get(items, Bindings), "
+        "    arizona_template:html({'ul', [], [arizona_template:each(fun(I) -> "
+        "        arizona_template:html({'li', [], [I]}) end, Items)]}). "
+    ),
+    B0 = #{items => [~"a"]},
+    {_HTML, Snap0, V0} = arizona_render:render(Mod:render(B0), #{}),
+    B1 = #{items => [~"a", ~"b"]},
+    Changed = compute_changed(B0, B1),
+    {Ops, _Snap1, _V1} = arizona_diff:diff(Mod:render(B1), Snap0, V0, Changed),
+    ?assertNotEqual([], Ops).
+
+%% Two distinct hoisted reads in sibling slots each track ONLY their own key --
+%% per-slot inlining must not spill one slot's binding into the other's closure.
+inline_distinct_slots_key_isolation(Config) when is_list(Config) ->
+    Mod = compile_module_strict(
+        "-module(pt_inline_isolation). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    A = arizona_template:get(a, Bindings), "
+        "    B = arizona_template:get(b, Bindings), "
+        "    arizona_template:html({'div', [], [{'span', [], [A]}, {'span', [], [B]}]}). "
+    ),
+    T = Mod:render(#{a => ~"AA", b => ~"BB"}),
+    [{_Az0, FunA, _L0}, {_Az1, FunB, _L1}] = maps:get(d, T),
+    ?assertEqual(~"AA", FunA()),
+    ?assertEqual(~"BB", FunB()),
+    ?assertEqual(#{a => true}, slot_deps(FunA)),
+    ?assertEqual(#{b => true}, slot_deps(FunB)).
+
+%% A multi-clause render hoists per clause; each clause's inline map is independent.
+inline_multi_clause_render(Config) when is_list(Config) ->
+    Mod = compile_module_strict(
+        "-module(pt_inline_multiclause). "
+        "-export([render/1]). "
+        "render(#{mode := a} = Bindings) -> "
+        "    X = arizona_template:get(x, Bindings), "
+        "    arizona_template:html({'p', [], [X]}); "
+        "render(#{mode := b} = Bindings) -> "
+        "    Y = arizona_template:get(y, Bindings), "
+        "    arizona_template:html({'span', [], [Y]}). "
+    ),
+    TA = Mod:render(#{mode => a, x => ~"X"}),
+    [{_AzA, FunA, _LocA}] = maps:get(d, TA),
+    ?assertEqual(~"X", FunA()),
+    ?assertEqual(#{x => true}, slot_deps(FunA)),
+    TB = Mod:render(#{mode => b, y => ~"Y"}),
+    [{_AzB, FunB, _LocB}] = maps:get(d, TB),
+    ?assertEqual(~"Y", FunB()),
+    ?assertEqual(#{y => true}, slot_deps(FunB)).
+
+%% A hoisted get_lazy/3 read inlines whole (default fun included); the dep is
+%% tracked even when the key is absent and the default branch fires.
+inline_get_lazy_hoisted(Config) when is_list(Config) ->
+    Mod = compile_module_strict(
+        "-module(pt_inline_getlazy). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    Name = arizona_template:get_lazy(name, Bindings, fun() -> <<\"def\">> end), "
+        "    arizona_template:html({'p', [], [Name]}). "
+    ),
+    T = Mod:render(#{}),
+    [{_Az, Fun, _Loc}] = maps:get(d, T),
+    ?assertEqual(~"def", Fun()),
+    ?assertEqual(#{name => true}, slot_deps(Fun)).
+
+%% A hoisted read inlined into BOTH an outer slot and a nested ?html template --
+%% the post-order transform must rewrite the var at both compile sites.
+inline_nested_html_shared_var(Config) when is_list(Config) ->
+    Mod = compile_module_strict(
+        "-module(pt_inline_nested). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    Outer = arizona_template:get(outer, Bindings), "
+        "    arizona_template:html({'div', [], [Outer, "
+        "        arizona_template:html({'span', [], [Outer]})]}). "
+    ),
+    T = Mod:render(#{outer => ~"O"}),
+    [{_Az0, Fun1, _Loc1}, {_Az1, Fun2, _Loc2}] = maps:get(d, T),
+    ?assertEqual(~"O", Fun1()),
+    ?assertEqual(#{outer => true}, slot_deps(Fun1)),
+    Inner = Fun2(),
+    [{_IAz, InnerFun, _ILoc}] = maps:get(d, Inner),
+    ?assertEqual(~"O", InnerFun()),
+    ?assertEqual(#{outer => true}, slot_deps(InnerFun)).
+
+%% One hoisted var in two slots: every occurrence is rewritten, each slot tracks.
+inline_same_var_two_slots(Config) when is_list(Config) ->
+    Mod = compile_module_strict(
+        "-module(pt_inline_samevar). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    Name = arizona_template:get(name, Bindings), "
+        "    arizona_template:html({'div', [], [Name, <<\" / \">>, Name]}). "
+    ),
+    T = Mod:render(#{name => ~"Ada"}),
+    [{_Az0, Fun0, _Loc0}, {_Az1, Fun1, _Loc1}] = maps:get(d, T),
+    ?assertEqual(~"Ada", Fun0()),
+    ?assertEqual(~"Ada", Fun1()),
+    ?assertEqual(#{name => true}, slot_deps(Fun0)),
+    ?assertEqual(#{name => true}, slot_deps(Fun1)).
+
+%% Inlining keys off the get CALL, not the bindings-arg name, so a render param
+%% named anything other than `Bindings` still inlines and tracks.
+inline_non_bindings_var_name(Config) when is_list(Config) ->
+    Mod = compile_module_strict(
+        "-module(pt_inline_ctx). "
+        "-export([render/1]). "
+        "render(Ctx) -> "
+        "    Name = arizona_template:get(name, Ctx), "
+        "    arizona_template:html({'p', [], [Name]}). "
+    ),
+    T = Mod:render(#{name => ~"Ada"}),
+    [{_Az, Fun, _Loc}] = maps:get(d, T),
+    ?assertEqual(~"Ada", Fun()),
+    ?assertEqual(#{name => true}, slot_deps(Fun)).
+
+%% Residue: a read bound through a non-bare-var (destructuring) pattern is NOT
+%% inlined (scan_top_matches only picks bare-var matches). It compiles and renders
+%% the first value, but the slot stays static (frozen). Documents the boundary.
+inline_destructuring_not_inlined(Config) when is_list(Config) ->
+    Mod = compile_module_strict(
+        "-module(pt_inline_destr). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    {ok, Name} = {ok, arizona_template:get(name, Bindings)}, "
+        "    arizona_template:html({'p', [], [Name]}). "
+    ),
+    T = Mod:render(#{name => ~"Ada"}),
+    [{_Az, Fun, _Loc}] = maps:get(d, T),
+    ?assertEqual(~"Ada", Fun()),
+    ?assertEqual(#{}, slot_deps(Fun)).
+
+%% Residue: a read reachable only through a clause GUARD stays captured (a guard
+%% cannot hold a get), so the slot records no dep and freezes. Documents the limit.
+inline_guard_get_stays_captured(Config) when is_list(Config) ->
+    Mod = compile_module_strict(
+        "-module(pt_inline_guardget). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    N = arizona_template:get(n, Bindings), "
+        "    Label = case x of _ when N > 5 -> big; _ -> small end, "
+        "    arizona_template:html({'p', [], [Label]}). "
+    ),
+    T = Mod:render(#{n => 10}),
+    [{_Az, Fun, _Loc}] = maps:get(d, T),
+    ?assertEqual(big, Fun()),
+    ?assertEqual(#{}, slot_deps(Fun)).
+
+%% Like compile_module/1 but compiles with warnings_as_errors, matching the
+%% project's real erl_opts. Needed because unused-variable / match_underscore_var
+%% regressions surface only as warnings, which the plain [return_errors] path drops.
+compile_module_strict(Source) ->
+    {ok, Tokens, _} = erl_scan:string(Source),
+    Forms = split_forms(Tokens),
+    ParsedForms = [
+        begin
+            {ok, F} = erl_parse:parse_form(Toks),
+            F
+        end
+     || Toks <- Forms
+    ],
+    TransformedForms = arizona_parse_transform:parse_transform(ParsedForms, []),
+    {ok, Mod, Bin} = compile:forms(TransformedForms, [return_errors, warnings_as_errors]),
+    {module, Mod} = code:load_binary(Mod, "", Bin),
+    Mod.
 
 %% Evaluate a slot closure under a dependency bracket (mirrors arizona_eval) and
 %% return the captured deps.

--- a/test/arizona_parse_transform_SUITE.erl
+++ b/test/arizona_parse_transform_SUITE.erl
@@ -139,6 +139,16 @@
     utf8_static_attr/1,
     utf8_static_child_emoji/1,
     variable_dynamic/1,
+    inline_hoisted_text_read/1,
+    inline_hoisted_attr_read/1,
+    inline_maps_get_chain/1,
+    inline_case_value/1,
+    inline_case_of_case/1,
+    inline_opaque_call/1,
+    inline_side_effect_not_inlined/1,
+    inline_diff_updates/1,
+    inline_unrelated_key_skipped/1,
+    inline_hoisted_root_id/1,
     void_element/1,
     void_in_each_with_children/1,
     void_nested_child_with_children/1,
@@ -193,6 +203,7 @@ all() ->
         {group, local},
         {group, each},
         {group, integration},
+        {group, inline},
         {group, layout},
         {group, utf8},
         {group, errors},
@@ -312,6 +323,19 @@ groups() ->
             nodiff_with_other_attrs,
             nodiff_each,
             mixed_attr_forms
+        ]},
+        %% Binding-read inlining: reads hoisted out of ?html still track per-slot
+        {inline, [parallel], [
+            inline_hoisted_text_read,
+            inline_hoisted_attr_read,
+            inline_maps_get_chain,
+            inline_case_value,
+            inline_case_of_case,
+            inline_opaque_call,
+            inline_side_effect_not_inlined,
+            inline_diff_updates,
+            inline_unrelated_key_skipped,
+            inline_hoisted_root_id
         ]},
         %% Tests 68-77c: layout tests
         {layout, [parallel], [
@@ -4215,3 +4239,187 @@ terminal_each_renders(Config) when is_list(Config) ->
     Bin = iolist_to_binary(Output),
     ?assertNotEqual(nomatch, binary:match(Bin, ~"a\e[0m\n")),
     ?assertNotEqual(nomatch, binary:match(Bin, ~"b\e[0m\n")).
+
+%% ============================================================================
+%% Binding-read inlining
+%% ============================================================================
+
+%% A read hoisted into the function body still tracks per-slot: the slot closure
+%% re-runs the `get` inside the dependency bracket instead of capturing a value.
+inline_hoisted_text_read(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_inline_text). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    Name = arizona_template:get(name, Bindings), "
+        "    arizona_template:html({'p', [], [Name]}). "
+    ),
+    T = Mod:render(#{name => ~"Ada"}),
+    [{_Az, Fun, _Loc}] = maps:get(d, T),
+    ?assertEqual(~"Ada", Fun()),
+    ?assertEqual(#{name => true}, slot_deps(Fun)).
+
+inline_hoisted_attr_read(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_inline_attr). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    Cls = arizona_template:get(cls, Bindings), "
+        "    arizona_template:html({'div', [{class, Cls}], [<<\"x\">>]}). "
+    ),
+    T = Mod:render(#{cls => ~"box"}),
+    [{_Az, {attr, ~"class", Fun}, _Loc}] = maps:get(d, T),
+    ?assertEqual(~"box", Fun()),
+    ?assertEqual(#{cls => true}, slot_deps(Fun)).
+
+%% A pure derivation over a single read (maps:get on a sub-map) tracks only the
+%% top-level binding key, not the sub-key.
+inline_maps_get_chain(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_inline_chain). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    User = arizona_template:get(user, Bindings), "
+        "    Name = maps:get(name, User), "
+        "    arizona_template:html({'p', [], [Name]}). "
+    ),
+    T = Mod:render(#{user => #{name => ~"Ada"}}),
+    [{_Az, Fun, _Loc}] = maps:get(d, T),
+    ?assertEqual(~"Ada", Fun()),
+    ?assertEqual(#{user => true}, slot_deps(Fun)).
+
+%% A case assigned to a variable inlines whole; runtime tracking records whichever
+%% branch's reads fire.
+inline_case_value(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_inline_case). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    Mode = arizona_template:get(mode, Bindings), "
+        "    Label = case Mode of "
+        "                dark -> arizona_template:get(dark, Bindings); "
+        "                _ -> <<\"L\">> "
+        "            end, "
+        "    arizona_template:html({'p', [], [Label]}). "
+    ),
+    T = Mod:render(#{mode => dark, dark => ~"D"}),
+    [{_Az, Fun, _Loc}] = maps:get(d, T),
+    ?assertEqual(~"D", Fun()),
+    ?assertEqual(#{mode => true, dark => true}, slot_deps(Fun)).
+
+%% The interpolated expression *uses* a hoisted var (case-of-case): inlining walks
+%% the whole slot expression, substituting the var in the scrutinee.
+inline_case_of_case(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_inline_caseofcase). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    Label = case arizona_template:get(mode, Bindings) of "
+        "                dark -> arizona_template:get(dark, Bindings); "
+        "                _ -> <<\"L\">> "
+        "            end, "
+        "    arizona_template:html("
+        "        {'p', [], [case Label of foo -> foo; _ -> bar end]}). "
+    ),
+    T = Mod:render(#{mode => light}),
+    [{_Az, Fun, _Loc}] = maps:get(d, T),
+    ?assertEqual(bar, Fun()),
+    ?assertEqual(#{mode => true}, slot_deps(Fun)).
+
+%% An opaque call that reads bindings inlines whole; the inner get fires in-bracket.
+inline_opaque_call(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_inline_opaque). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    Name = string:uppercase(arizona_template:get(raw, Bindings)), "
+        "    arizona_template:html({'p', [], [Name]}). "
+    ),
+    T = Mod:render(#{raw => ~"ada"}),
+    [{_Az, Fun, _Loc}] = maps:get(d, T),
+    ?assertEqual(~"ADA", Fun()),
+    ?assertEqual(#{raw => true}, slot_deps(Fun)).
+
+%% A derivation that does NOT reach a get is left captured (not inlined), so a
+%% side effect is evaluated once -- repeated calls return the same value.
+inline_side_effect_not_inlined(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_inline_noinline). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    Ref = erlang:unique_integer([monotonic]), "
+        "    arizona_template:html({'p', [], [Ref]}). "
+    ),
+    T = Mod:render(#{}),
+    [{_Az, Fun, _Loc}] = maps:get(d, T),
+    ?assertEqual(Fun(), Fun()),
+    ?assertEqual(#{}, slot_deps(Fun)).
+
+%% End-to-end regression: a hoisted read now produces an op on diff (before the
+%% fix the slot was frozen and diff returned []).
+inline_diff_updates(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_inline_diff). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    Name = arizona_template:get(name, Bindings), "
+        "    arizona_template:html({'p', [], [Name]}). "
+    ),
+    B0 = #{name => ~"Ada"},
+    {_HTML, Snap0, V0} = arizona_render:render(Mod:render(B0), #{}),
+    B1 = #{name => ~"Grace"},
+    Changed = compute_changed(B0, B1),
+    {Ops, _Snap1, _V1} = arizona_diff:diff(Mod:render(B1), Snap0, V0, Changed),
+    ?assertNotEqual([], Ops).
+
+%% The inlined dep is scoped: a change to an unrelated key skips the slot.
+inline_unrelated_key_skipped(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_inline_scoped). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    Name = arizona_template:get(name, Bindings), "
+        "    arizona_template:html({'p', [], [Name]}). "
+    ),
+    B0 = #{name => ~"Ada", other => 1},
+    {_HTML, Snap0, V0} = arizona_render:render(Mod:render(B0), #{}),
+    B1 = #{name => ~"Ada", other => 2},
+    Changed = compute_changed(B0, B1),
+    {Ops, _Snap1, _V1} = arizona_diff:diff(Mod:render(B1), Snap0, V0, Changed),
+    ?assertEqual([], Ops).
+
+%% A live view may hoist the root id; validate_live_root resolves it through the
+%% inline map, and the id slot tracks `id`.
+inline_hoisted_root_id(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_inline_rootid). "
+        "-behaviour(arizona_stateful). "
+        "-export([mount/1, render/1]). "
+        "mount(B) -> {B, #{}}. "
+        "render(Bindings) -> "
+        "    Id = arizona_template:get(id, Bindings), "
+        "    arizona_template:html({'div', [{id, Id}], [<<\"x\">>]}). "
+    ),
+    T = Mod:render(#{id => ~"v1"}),
+    [IdFun] = [F || {_Az, {attr, ~"id", F}, _Loc} <- maps:get(d, T)],
+    ?assertEqual(~"v1", IdFun()),
+    ?assertEqual(#{id => true}, slot_deps(IdFun)).
+
+%% Evaluate a slot closure under a dependency bracket (mirrors arizona_eval) and
+%% return the captured deps.
+slot_deps(Fun) ->
+    erlang:put('$arizona_deps', #{}),
+    Fun(),
+    erlang:erase('$arizona_deps').
+
+%% Mirrors arizona_live:compute_changed/2 for unit tests.
+compute_changed(OldBindings, NewBindings) ->
+    maps:filter(
+        fun(K, V) ->
+            case OldBindings of
+                #{K := V} -> false;
+                #{} -> true
+            end
+        end,
+        NewBindings
+    ).

--- a/test/support/arizona_inline.erl
+++ b/test/support/arizona_inline.erl
@@ -1,0 +1,41 @@
+-module(arizona_inline).
+-include("arizona_stateful.hrl").
+-export([mount/1, render/1, handle_event/3]).
+
+-spec mount(az:bindings()) -> az:mount_ret().
+mount(Init) ->
+    Bindings = #{
+        id => ~"inline",
+        count => maps:get(count, Init, 0)
+    },
+    {Bindings, #{}}.
+
+%% Every read is HOISTED into a body variable rather than written inline in
+%% `?html` -- the binding-read inlining feature rewrites each interpolated
+%% variable back into its slot so it still tracks `count` and diffs over the
+%% wire. Exercises several inlining shapes at once: a hoisted root id, a plain
+%% hoisted read, a derived chain (`Doubled`), and a statement-form `case` bind
+%% (`Parity`, lifted by normalize_tail_binds). If any regressed to a frozen
+%% slot, the corresponding `<span>` would not update on click.
+-spec render(az:bindings()) -> az:template().
+render(Bindings) ->
+    Id = ?get(id),
+    Count = ?get(count),
+    Doubled = Count * 2,
+    case ?get(count) rem 2 of
+        0 -> Parity = ~"even";
+        _ -> Parity = ~"odd"
+    end,
+    ?html(
+        {'div', [{id, Id}], [
+            {button, [{az_click, arizona_js:push_event(~"inc")}], [~"+"]},
+            {span, [{class, ~"count"}], [integer_to_binary(Count)]},
+            {span, [{class, ~"doubled"}], [integer_to_binary(Doubled)]},
+            {span, [{class, ~"parity"}], [Parity]}
+        ]}
+    ).
+
+-spec handle_event(az:event_name(), az:event_payload(), az:bindings()) ->
+    az:handle_event_ret().
+handle_event(~"inc", _Payload, Bindings) ->
+    {Bindings#{count => maps:get(count, Bindings) + 1}, #{}, []}.

--- a/test/support/arizona_test_server.erl
+++ b/test/support/arizona_test_server.erl
@@ -20,6 +20,10 @@ start() ->
             bindings => #{title => <<"Mixed">>},
             layouts => Layouts
         }},
+        {live, <<"/inline">>, arizona_inline, #{
+            bindings => #{title => <<"Inline">>},
+            layouts => Layouts
+        }},
         {live, <<"/chat">>, arizona_chat, #{
             bindings => #{title => <<"Chat">>},
             layouts => Layouts


### PR DESCRIPTION
# Description

A read pulled into a body variable before `?html` (`Name = arizona_template:get(name, Bindings), ?html({p, [], [Name]})`) compiled the slot to `fun() -> Name end`, a captured value with no `?get` inside, so it recorded no dependency and froze after the first render. The parse transform now rewrites each interpolated variable back into its slot closure, so the read re-runs inside the per-slot dependency bracket and diffs normally. It covers plain hoists, derived chains (`maps:get`, opaque calls), `case`-as-value, and statement-form `case` binds. Compile-time only, so idiomatic templates are untouched.

Some reads are left captured (documented), since a `get` is illegal in a pattern or guard: head and non-bare-var destructuring, guard-only reads, and rebound vars. These stay static rather than mis-track.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
