### PR TITLE
Reject tracked get/get_lazy reading a non-bindings sub-map

### DIFF
--- a/src/arizona_parse_transform.erl
+++ b/src/arizona_parse_transform.erl
@@ -270,7 +270,12 @@ format_error(local_attr_mixed) ->
 format_error(cross_target_nesting) ->
     "cannot nest ?html, ?native and ?terminal in one template -- they produce "
     "incompatible statics. Render cross-target content via a separate "
-    "stateful/stateless child of the matching target".
+    "stateful/stateless child of the matching target";
+format_error(tracked_get_on_non_bindings_map) ->
+    "arizona_template:get/get_lazy (and the az: aliases) are the dependency-tracking "
+    "accessors for the view bindings, not for nested maps. Read sub-structures with "
+    "maps:get/2, e.g. `User = arizona_template:get(user, Bindings), "
+    "Name = maps:get(name, User)`".
 
 %% --------------------------------------------------------------------
 %% Internal functions
@@ -278,6 +283,90 @@ format_error(cross_target_nesting) ->
 
 parse_error(Reason, Line) ->
     throw({arizona_parse_error, Line, Reason}).
+
+%% `arizona_template:get`/`get_lazy` (and the `az:` aliases) call `track/1`
+%% regardless of which map they read, so reading a sub-map records the inner key
+%% as a top-level slot dependency. Reject a tracked read whose map argument is a
+%% variable that is not in scope as a bindings-like value: a clause/fun parameter
+%% (so `?each` item/key vars pass) or an alias of one. A non-variable map argument
+%% (a literal map, a `maps:get` call, any expression) is never flagged.
+check_tracked_get_targets(Patterns, Body) ->
+    Params = collect_fun_param_vars(Body, collect_pattern_vars(Patterns, #{})),
+    walk_tracked_gets(Body, alias_closure(Body, Params)).
+
+%% Every fun/named_fun parameter anywhere in Body. Flat across nesting depth:
+%% over-inclusion only drops a flag (false negative), never adds one.
+collect_fun_param_vars({'fun', _, {clauses, Cs}}, Acc) ->
+    collect_clause_param_vars(Cs, Acc);
+collect_fun_param_vars({named_fun, _, _Name, Cs}, Acc) ->
+    collect_clause_param_vars(Cs, Acc);
+collect_fun_param_vars(T, Acc) when is_tuple(T) ->
+    collect_fun_param_vars(tuple_to_list(T), Acc);
+collect_fun_param_vars([H | T], Acc) ->
+    collect_fun_param_vars(T, collect_fun_param_vars(H, Acc));
+collect_fun_param_vars(_, Acc) ->
+    Acc.
+
+collect_clause_param_vars(Clauses, Acc) ->
+    lists:foldl(
+        fun({clause, _, Params, _Guards, ClauseBody}, A) ->
+            collect_fun_param_vars(ClauseBody, collect_pattern_vars(Params, A))
+        end,
+        Acc,
+        Clauses
+    ).
+
+%% Grow the scope with every `V = W` (var = var) where W is already in scope, to a
+%% fixpoint (handles `B = Bindings, C = B`).
+alias_closure(Body, Scope) ->
+    Aliases = [{V, W} || {match, _, {var, _, V}, {var, _, W}} <- collect_matches(Body, [])],
+    alias_fixpoint(Aliases, Scope).
+
+alias_fixpoint(Aliases, Scope) ->
+    Scope1 = lists:foldl(
+        fun
+            ({V, W}, A) when is_map_key(W, A) -> A#{V => true};
+            (_Pair, A) -> A
+        end,
+        Scope,
+        Aliases
+    ),
+    case map_size(Scope1) =:= map_size(Scope) of
+        true -> Scope1;
+        false -> alias_fixpoint(Aliases, Scope1)
+    end.
+
+collect_matches(T, Acc) when is_tuple(T) ->
+    Acc1 =
+        case T of
+            {match, _, _, _} -> [T | Acc];
+            _ -> Acc
+        end,
+    collect_matches(tuple_to_list(T), Acc1);
+collect_matches([H | T], Acc) ->
+    collect_matches(T, collect_matches(H, Acc));
+collect_matches(_, Acc) ->
+    Acc.
+
+walk_tracked_gets(AST, Scope) when is_tuple(AST) ->
+    flag_tracked_get(AST, Scope),
+    walk_tracked_gets(tuple_to_list(AST), Scope);
+walk_tracked_gets([H | T], Scope) ->
+    walk_tracked_gets(H, Scope),
+    walk_tracked_gets(T, Scope);
+walk_tracked_gets(_, _Scope) ->
+    ok.
+
+flag_tracked_get(
+    {call, L, {remote, _, {atom, _, Mod}, {atom, _, F}}, [_Key, {var, _, V} | _]}, Scope
+) when
+    (Mod =:= arizona_template orelse Mod =:= az) andalso
+        (F =:= get orelse F =:= get_lazy) andalso
+        not is_map_key(V, Scope)
+->
+    parse_error(tracked_get_on_non_bindings_map, L);
+flag_tracked_get(_Node, _Scope) ->
+    ok.
 
 line(Node) when is_tuple(Node), tuple_size(Node) >= 2 ->
     erl_anno:line(element(2, Node));
@@ -305,6 +394,7 @@ transform_form(Form, _Module, _IsLive) ->
     Form.
 
 transform_clause({clause, L, Patterns, Guards, Body0}, Module) ->
+    check_tracked_get_targets(Patterns, Body0),
     Body = normalize_tail_binds(Body0),
     Inline = collect_inline(Body),
     Body1 = [transform_expr(Expr, Module, Inline) || Expr <- Body],
@@ -372,6 +462,7 @@ transform_node(Node, Module, Inline) ->
     end.
 
 transform_live_render_clause({clause, L, Patterns, Guards, Body}, Module) ->
+    check_tracked_get_targets(Patterns, Body),
     {Init0, [Last]} = lists:split(length(Body) - 1, Body),
     %% Only the init statements are normalized: the last expr carries the live root
     %% template and is handled by transform_live_render_last/3.

--- a/test/arizona_parse_transform_SUITE.erl
+++ b/test/arizona_parse_transform_SUITE.erl
@@ -164,6 +164,14 @@
     inline_destructuring_not_inlined/1,
     inline_guard_get_stays_captured/1,
     inline_comprehension_source/1,
+    tracked_get_submap_errors/1,
+    tracked_get_submap_az_errors/1,
+    tracked_get_lazy_submap_errors/1,
+    tracked_get_maps_get_ok/1,
+    tracked_get_each_item_ok/1,
+    tracked_get_alias_ok/1,
+    tracked_get_literal_map_ok/1,
+    tracked_get_renamed_param_ok/1,
     void_element/1,
     void_in_each_with_children/1,
     void_nested_child_with_children/1,
@@ -219,6 +227,7 @@ all() ->
         {group, each},
         {group, integration},
         {group, inline},
+        {group, tracked_get},
         {group, layout},
         {group, utf8},
         {group, errors},
@@ -366,6 +375,17 @@ groups() ->
             inline_destructuring_not_inlined,
             inline_guard_get_stays_captured,
             inline_comprehension_source
+        ]},
+        %% Reject the tracked accessor reading a non-bindings (sub-)map
+        {tracked_get, [parallel], [
+            tracked_get_submap_errors,
+            tracked_get_submap_az_errors,
+            tracked_get_lazy_submap_errors,
+            tracked_get_maps_get_ok,
+            tracked_get_each_item_ok,
+            tracked_get_alias_ok,
+            tracked_get_literal_map_ok,
+            tracked_get_renamed_param_ok
         ]},
         %% Tests 68-77c: layout tests
         {layout, [parallel], [
@@ -3271,7 +3291,10 @@ format_error(Config) when is_list(Config) ->
     Msg3 = arizona_parse_transform:format_error(invalid_element),
     ?assert(lists:prefix("invalid element form", Msg3)),
     Msg4 = arizona_parse_transform:format_error(invalid_each_fun),
-    ?assert(lists:prefix("each/2 expects", Msg4)).
+    ?assert(lists:prefix("each/2 expects", Msg4)),
+    Msg5 = arizona_parse_transform:format_error(tracked_get_on_non_bindings_map),
+    ?assert(lists:prefix("arizona_template:get/get_lazy", Msg5)),
+    ?assertNotEqual(nomatch, string:find(Msg5, "maps:get/2")).
 
 %% Test 92: Void element with single-expression child form.
 void_with_single_expr_child(Config) when is_list(Config) ->
@@ -4696,6 +4719,104 @@ inline_comprehension_source(Config) when is_list(Config) ->
     [{_Az, Fun, _Loc}] = maps:get(d, T),
     ?assertEqual(~"ab", Fun()),
     ?assertEqual(#{names => true}, slot_deps(Fun)).
+
+%% ============================================================================
+%% Tracked get/get_lazy on a non-bindings map
+%% ============================================================================
+
+%% Reading a sub-map with the tracked accessor wrongly records the inner key as a
+%% top-level dependency, so it is a compile error.
+tracked_get_submap_errors(Config) when is_list(Config) ->
+    assert_parse_error(
+        "-module(pt_tg_submap). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    Foo = arizona_template:get(foo, Bindings), "
+        "    arizona_template:html({'p', [], [arizona_template:get(bar, Foo)]}). ",
+        fun(R) -> R =:= tracked_get_on_non_bindings_map end
+    ).
+
+%% The az: alias form is flagged too.
+tracked_get_submap_az_errors(Config) when is_list(Config) ->
+    assert_parse_error(
+        "-module(pt_tg_az). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    Foo = az:get(foo, Bindings), "
+        "    arizona_template:html({'p', [], [az:get(bar, Foo)]}). ",
+        fun(R) -> R =:= tracked_get_on_non_bindings_map end
+    ).
+
+%% get_lazy on a sub-map is flagged.
+tracked_get_lazy_submap_errors(Config) when is_list(Config) ->
+    assert_parse_error(
+        "-module(pt_tg_lazy). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    Foo = arizona_template:get(foo, Bindings), "
+        "    arizona_template:html({'p', [], "
+        "        [arizona_template:get_lazy(bar, Foo, fun() -> <<>> end)]}). ",
+        fun(R) -> R =:= tracked_get_on_non_bindings_map end
+    ).
+
+%% maps:get for the sub-field is the correct pattern and compiles clean.
+tracked_get_maps_get_ok(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_tg_mapsget). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    Foo = arizona_template:get(foo, Bindings), "
+        "    Bar = maps:get(bar, Foo), "
+        "    arizona_template:html({'p', [], [Bar]}). "
+    ),
+    ?assert(is_map(Mod:render(#{foo => #{bar => ~"x"}}))).
+
+%% An ?each item read uses the item fun parameter (the per-item bindings), so it
+%% is not flagged.
+tracked_get_each_item_ok(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_tg_each). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:html({'ul', [], [arizona_template:each(fun(Item) -> "
+        "        arizona_template:html({'li', [], [arizona_template:get(name, Item)]}) "
+        "    end, arizona_template:get(items, Bindings))]}). "
+    ),
+    ?assert(is_map(Mod:render(#{items => [#{name => ~"a"}]}))).
+
+%% An alias chain of the bindings is not flagged.
+tracked_get_alias_ok(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_tg_alias). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    B = Bindings, "
+        "    C = B, "
+        "    arizona_template:html({'p', [], [arizona_template:get(x, C)]}). "
+    ),
+    ?assert(is_map(Mod:render(#{x => ~"y"}))).
+
+%% A literal-map second argument (a non-variable) is never flagged.
+tracked_get_literal_map_ok(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_tg_litmap). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    Real = arizona_template:get(real, Bindings), "
+        "    V = arizona_template:get(k, #{k => v}), "
+        "    arizona_template:html({'p', [], [Real, <<\" \">>, V]}). "
+    ),
+    ?assert(is_map(Mod:render(#{real => ~"R"}))).
+
+%% A renamed bindings parameter (not literally `Bindings`) is in scope and passes.
+tracked_get_renamed_param_ok(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_tg_ctx). "
+        "-export([render/1]). "
+        "render(Ctx) -> "
+        "    arizona_template:html({'p', [], [arizona_template:get(name, Ctx)]}). "
+    ),
+    ?assert(is_map(Mod:render(#{name => ~"Ada"}))).
 
 %% Like compile_module/1 but compiles with warnings_as_errors, matching the
 %% project's real erl_opts. Needed because unused-variable / match_underscore_var


### PR DESCRIPTION
# Description

Reading a sub-map with the tracked accessor (`arizona_template:get(bar, Foo)` where `Foo` is not the view bindings) wrongly records the inner key as a top-level slot dependency, so it is now a compile error that points to `maps:get/2` for sub-structures.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
