### PR TITLE
Add az:with/2 tracked projection for handing a bindings subset to a sub-context

### DIFF
--- a/.claude/rules/erlang.md
+++ b/.claude/rules/erlang.md
@@ -175,5 +175,44 @@ Exceptions that stay un-tracked (slot frozen after SSR): a binding destructured
 in the head (`render(#{foo := Foo})`) or through any non-bare-var pattern
 (`{ok, V} = ?get(...)` -- use `?get(foo)` then plain destructuring), a read
 reachable only through a guard, a variable bound inside an `if` or a `case`
-branch whose clause head binds a variable, and a rebound variable. `?get` is for
-top-level bindings; read sub-structures with plain `maps:get/2`.
+branch whose clause head binds a variable, and a rebound variable.
+
+`?get`/`get_lazy`/`with` are for the **view bindings**, not sub-maps: they call
+`track/1` regardless of which map they read, so reading a nested map records the
+inner key as a spurious top-level dep. The parse transform rejects a tracked read
+whose map argument is a local that is not the bindings (or an alias/`with`
+projection of it) with `tracked_get_on_non_bindings_map`. Read sub-structures with
+plain `maps:get/2`: `User = ?get(user), Name = maps:get(name, User)`.
+
+### Handing a bindings subset to a sub-context -- `az:with`
+
+A child template embedded via a **raw function call** (or an explicit nested
+`?html(...)` call returning a template) freezes: the outer slot is
+`fun() -> child(Bindings) end`, building `child` fires no `?get` at the outer level
+(its reads sit in `child`'s own closures), so the outer slot captures empty deps and
+the diff engine skips it forever. Idiomatic composition is `?stateful`/`?stateless`
+(props reads track on the parent slot); an inline nested *element* is also fine (it
+flattens into the parent template).
+
+When you must hand a bindings subset to a sub-context (a helper, a passed-through
+map), declare the dependency with `az:with([keys], Bindings)` -- it tracks each key
+on the enclosing slot (fixing the freeze) and projects to only those keys via
+`maps:with/2`, so the sub-context can't silently read an untracked key (an omitted
+key fails loudly with `missing_binding` instead of freezing).
+
+```erlang
+%% Frozen: outer slot has empty deps, never re-renders.
+?html({p, [], [row(Bindings)]}).
+%% Tracked: `id`/`name` recorded on the outer slot; projection hides the rest.
+?html({p, [], [row(az:with([id, name], Bindings))]}).
+```
+
+There is deliberately no `with_all` -- tracking every key makes the slot depend on
+everything, defeating fine-grained diffing.
+
+### Eager `get/3` defaults over-track
+
+`?get(a, ?get(b))` (i.e. `get(a, B, get(b, B))`) records `b` even when `a` is
+present, because Erlang evaluates the default argument eagerly. Use
+`?get_lazy(a, fun() -> ?get(b) end)` when the default itself reads a binding, so the
+fallback key is tracked only when actually taken.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,6 +56,8 @@ Pure helpers for binding access, descriptor construction, and template compositi
 - `get/2,3`, `get_lazy/3` -- binding access with dep tracking via process dictionary
   (`$arizona_deps`)
 - `track/1` -- manually track a binding key as a dependency
+- `with/2` -- tracked projection: `track/1`s each key then `maps:with(Keys, Bindings)`;
+  hands a bindings subset to a sub-context while declaring its deps
 - `stateful/2` -- returns `#{stateful => Handler, props => Props}` descriptor for child views
 - `stateless/2` -- returns `#{callback => Callback, props => Props}` descriptor (Callback is a
   fun/1)
@@ -225,7 +227,9 @@ written inline. This is purely compile-time; the runtime/diff path is unchanged
 and idiomatic templates (reads written inside `?html`) are unaffected.
 
 - **`collect_inline/1`** builds a per-clause map of top-level `Var = RHS`
-  matches whose RHS transitively reaches a `get`/`get_lazy`/`track` call.
+  matches whose RHS transitively reaches a `get`/`get_lazy`/`track`/`with` call
+  (`with` tracks too, so a hoisted `Sub = with(Keys, Bindings)` must inline back
+  into the slot bracket or its tracking runs outside any bracket and freezes).
   Rebound vars are dropped; a derivation with no read (e.g. `Id = make_uuid()`)
   is left captured, so a pure side effect is never re-run per slot.
 - **`inline_vars/2`** substitutes those variables wherever they appear in a
@@ -251,6 +255,50 @@ itself binds a variable, and a rebound variable. Use `?get` for the top-level
 binding and plain `maps:get/2` for sub-structures (only the `?get` records a dep,
 which is the correct grain). In all these cases the read is left captured and the
 slot keeps its SSR value; the transform never makes valid code uncompilable.
+
+## Tracked accessors, the sub-map diagnostic, and `with/2`
+
+`get/2,3`, `get_lazy/3`, and `with/2` (and their `az:` aliases) are the
+dependency-tracking accessors: each calls `track/1` regardless of which map it
+reads. That makes reading a *nested* map a footgun -- `Foo = ?get(foo), ?get(bar,
+Foo)` records `bar` (a key of `Foo`) as a top-level slot dep, which both
+over-tracks and frantically misfires. The parse transform rejects it at compile
+time (`tracked_get_on_non_bindings_map`): a tracked read whose map argument is a
+local that is not the bindings parameter -- nor an alias of it (`B = Bindings`),
+nor a `with/2` projection of it -- is an error. Read sub-structures with plain
+`maps:get/2`. Non-variable map arguments (a literal map, a `maps:get` result) are
+never flagged.
+
+**Nested-template / passed-bindings freeze.** A child template embedded via a raw
+function call (or an explicit nested `?html(...)` returning a template) renders at
+SSR but never updates: the outer slot is `fun() -> child(Bindings) end`, and
+building `child` fires no `?get` at the outer level (the reads live in `child`'s own
+closures, isolated by `with_saved_deps`), so the outer slot captures empty deps and
+the diff engine skips it forever. Idiomatic composition is `?stateful`/`?stateless`,
+whose props expressions read on the parent slot; an inline nested *element* is also
+fine (it flattens into the parent template). When you must hand a bindings subset to
+a sub-context, `arizona_template:with([keys], Bindings)` is the explicit fix: it
+`track/1`s each key (so the outer slot re-renders when any listed key changes) and
+returns `maps:with(Keys, Bindings)` (so the sub-context cannot silently depend on an
+untracked key -- an omitted key raises `missing_binding` rather than freezing). No
+`with_all`: tracking every key makes the slot depend on everything, defeating
+fine-grained diffing.
+
+**Eager `get/3` defaults over-track.** `?get(a, ?get(b))` records `b` even when `a`
+is present, because Erlang evaluates the default argument eagerly and `?get(b)`
+tracks unconditionally. `?get_lazy(a, fun() -> ?get(b) end)` tracks the fallback key
+only when the default is actually taken.
+
+**Stream items re-evaluate empty deps on purpose.** The main per-dynamic diff path
+skips a slot whose deps are empty (the documented frozen residue above). The `?each`
+item path does the opposite: its reuse predicate in `arizona_eval` (`can_reuse/2`) is
+`map_size(OldDeps) > 0 andalso not deps_changed`, so an empty-deps item is always
+re-evaluated. This is a
+deliberate safety net for item callbacks that head-destructure fields
+(`fun(#{text := T}, _) -> ...`): those reads are untracked, so the item would have
+empty deps and freeze, except the item path re-evaluates it. The asymmetry is the
+boundary: head-destructured *render* reads freeze in top-level slots but stay current
+inside `?each` items.
 
 ## API -- effect commands (`arizona_js` / `arizona_android` / `arizona_effect`)
 

--- a/src/arizona_parse_transform.erl
+++ b/src/arizona_parse_transform.erl
@@ -272,10 +272,12 @@ format_error(cross_target_nesting) ->
     "incompatible statics. Render cross-target content via a separate "
     "stateful/stateless child of the matching target";
 format_error(tracked_get_on_non_bindings_map) ->
-    "arizona_template:get/get_lazy (and the az: aliases) are the dependency-tracking "
-    "accessors for the view bindings, not for nested maps. Read sub-structures with "
-    "maps:get/2, e.g. `User = arizona_template:get(user, Bindings), "
-    "Name = maps:get(name, User)`".
+    "arizona_template:get/get_lazy/with (and the az: aliases) track every read against "
+    "the view bindings, so their map argument must be the bindings -- a parameter or a "
+    "direct alias (`B = Bindings`). This local is not provably the bindings. If it is a "
+    "nested map, read it with maps:get/2 (`User = arizona_template:get(user, Bindings), "
+    "Name = maps:get(name, User)`); if it is a bindings value reached through a "
+    "case/merge the transform cannot see into, alias it directly with `B = Bindings` first".
 
 %% --------------------------------------------------------------------
 %% Internal functions
@@ -284,12 +286,13 @@ format_error(tracked_get_on_non_bindings_map) ->
 parse_error(Reason, Line) ->
     throw({arizona_parse_error, Line, Reason}).
 
-%% `arizona_template:get`/`get_lazy` (and the `az:` aliases) call `track/1`
+%% `arizona_template:get`/`get_lazy`/`with` (and the `az:` aliases) call `track/1`
 %% regardless of which map they read, so reading a sub-map records the inner key
 %% as a top-level slot dependency. Reject a tracked read whose map argument is a
 %% variable that is not in scope as a bindings-like value: a clause/fun parameter
-%% (so `?each` item/key vars pass) or an alias of one. A non-variable map argument
-%% (a literal map, a `maps:get` call, any expression) is never flagged.
+%% (so `?each` item/key vars pass) or an alias of one (including a var bound by a
+%% `with/2` projection). A non-variable map argument (a literal map, a `maps:get`
+%% call, any expression) is never flagged.
 check_tracked_get_targets(Patterns, Body) ->
     Params = collect_fun_param_vars(Body, collect_pattern_vars(Patterns, #{})),
     walk_tracked_gets(Body, alias_closure(Body, Params)).
@@ -316,11 +319,20 @@ collect_clause_param_vars(Clauses, Acc) ->
         Clauses
     ).
 
-%% Grow the scope with every `V = W` (var = var) where W is already in scope, to a
-%% fixpoint (handles `B = Bindings, C = B`).
+%% Grow the scope with every `V = W` (var = var) where W is already in scope, plus
+%% every `V = arizona_template:with(_, W)` / `az:with(_, W)` (a tracked projection of W
+%% is bindings-like), to a fixpoint (handles `B = Bindings, C = B`).
 alias_closure(Body, Scope) ->
-    Aliases = [{V, W} || {match, _, {var, _, V}, {var, _, W}} <- collect_matches(Body, [])],
-    alias_fixpoint(Aliases, Scope).
+    Matches = collect_matches(Body, []),
+    VarAliases = [{V, W} || {match, _, {var, _, V}, {var, _, W}} <- Matches],
+    WithAliases = [
+        {V, W}
+     || {match, _, {var, _, V},
+            {call, _, {remote, _, {atom, _, Mod}, {atom, _, with}}, [_Keys, {var, _, W} | _]}} <-
+            Matches,
+        Mod =:= arizona_template orelse Mod =:= az
+    ],
+    alias_fixpoint(VarAliases ++ WithAliases, Scope).
 
 alias_fixpoint(Aliases, Scope) ->
     Scope1 = lists:foldl(
@@ -336,6 +348,10 @@ alias_fixpoint(Aliases, Scope) ->
         false -> alias_fixpoint(Aliases, Scope1)
     end.
 
+%% Flat across nesting depth and scope-unaware: a `with`/var alias bound inside an inner
+%% fun/case registers its name as bindings-like globally. Like the param collection above,
+%% the only consequence is a dropped flag (a benign over-track if an outer same-named
+%% sub-map read is masked), never a wrong rejection.
 collect_matches(T, Acc) when is_tuple(T) ->
     Acc1 =
         case T of
@@ -361,7 +377,7 @@ flag_tracked_get(
     {call, L, {remote, _, {atom, _, Mod}, {atom, _, F}}, [_Key, {var, _, V} | _]}, Scope
 ) when
     (Mod =:= arizona_template orelse Mod =:= az) andalso
-        (F =:= get orelse F =:= get_lazy) andalso
+        (F =:= get orelse F =:= get_lazy orelse F =:= with) andalso
         not is_map_key(V, Scope)
 ->
     parse_error(tracked_get_on_non_bindings_map, L);
@@ -602,7 +618,7 @@ is_az_view_attr(_) ->
 %% dependency bracket -- exactly as if it had been written inline in the template.
 
 %% Build the inline map for a clause body: top-level `Var = RHS` matches whose RHS
-%% transitively reaches an `arizona_template`/`az` `get`/`get_lazy`/`track` call.
+%% transitively reaches an `arizona_template`/`az` `get`/`get_lazy`/`track`/`with` call.
 %% Variables bound more than once are dropped (ambiguous to inline); a binding-derived
 %% expression with no read (e.g. `Id = make_uuid()`) is left captured so a pure
 %% side effect is never re-run per slot.
@@ -641,11 +657,13 @@ reaching_fixpoint(Candidates, Acc) ->
         false -> reaching_fixpoint(Candidates, Acc1)
     end.
 
-%% True when an AST subtree contains a get/get_lazy/track call, or references a
-%% variable already known to reach one.
+%% True when an AST subtree contains a get/get_lazy/track/with call, or references a
+%% variable already known to reach one. `with` counts: like `get`, it calls `track/1`,
+%% so a hoisted `Sub = with(Keys, Bindings)` must be inlined back into the slot bracket
+%% or its tracking runs outside any bracket (a no-op) and the slot freezes.
 rhs_reaches({call, _, {remote, _, {atom, _, Mod}, {atom, _, F}}, _Args}, _Reaching) when
     (Mod =:= arizona_template orelse Mod =:= az) andalso
-        (F =:= get orelse F =:= get_lazy orelse F =:= track)
+        (F =:= get orelse F =:= get_lazy orelse F =:= track orelse F =:= with)
 ->
     true;
 rhs_reaches({var, _, V}, Reaching) ->

--- a/src/arizona_template.erl
+++ b/src/arizona_template.erl
@@ -51,6 +51,7 @@ render(Bindings) ->
 -export([get/2]).
 -export([get/3]).
 -export([get_lazy/3]).
+-export([with/2]).
 -export([track/1]).
 -export([html/1]).
 -export([native/1]).
@@ -210,6 +211,26 @@ get_lazy(Key, Bindings, DefaultFun) when is_function(DefaultFun, 0) ->
         #{Key := Val} -> Val;
         #{} -> DefaultFun()
     end.
+
+-doc """
+Projects `Bindings` to a sub-map of only `Keys`, tracking each key as a
+dependency.
+
+Use it to hand a bindings subset to a sub-context (a helper, a child, a
+passed-through map) while declaring exactly which keys it depends on: the
+projection means the sub-context cannot silently read an untracked key (an
+omitted key fails loudly with `missing_binding` rather than freezing), and the
+tracking makes the enclosing slot re-render when any listed key changes.
+
+Equivalent to `track/1` on each key followed by `maps:with(Keys, Bindings)`.
+""".
+-spec with(Keys, Bindings) -> Bindings1 when
+    Keys :: [term()],
+    Bindings :: map(),
+    Bindings1 :: map().
+with(Keys, Bindings) ->
+    ok = lists:foreach(fun track/1, Keys),
+    maps:with(Keys, Bindings).
 
 -doc """
 Records `Key` as a dependency of the dynamic element currently being rendered.

--- a/src/az.erl
+++ b/src/az.erl
@@ -33,6 +33,7 @@ binding, used by stateless layouts to render the wrapped page.
 -export([get/2]).
 -export([get/3]).
 -export([get_lazy/3]).
+-export([with/2]).
 -export([inner_content/1]).
 -export([track/1]).
 -export([html/1]).
@@ -52,6 +53,7 @@ binding, used by stateless layouts to render the wrapped page.
     get/2,
     get/3,
     get_lazy/3,
+    with/2,
     inner_content/1,
     track/1,
     html/1,
@@ -134,6 +136,15 @@ Alias for `arizona_template:get_lazy/3`.
     DefaultFun :: fun(() -> term()).
 get_lazy(Key, Bindings, DefaultFun) ->
     arizona_template:get_lazy(Key, Bindings, DefaultFun).
+
+-doc """
+Alias for `arizona_template:with/2`.
+""".
+-spec with(Keys, Bindings) -> map() when
+    Keys :: [term()],
+    Bindings :: map().
+with(Keys, Bindings) ->
+    arizona_template:with(Keys, Bindings).
 
 -doc """
 Returns the `inner_content` binding from a layout's bindings map.

--- a/test/arizona_parse_transform_SUITE.erl
+++ b/test/arizona_parse_transform_SUITE.erl
@@ -172,6 +172,12 @@
     tracked_get_alias_ok/1,
     tracked_get_literal_map_ok/1,
     tracked_get_renamed_param_ok/1,
+    tracked_get_with_projection_ok/1,
+    tracked_get_with_submap_errors/1,
+    tracked_get_case_aliased_bindings_flagged/1,
+    with_handoff_freezes_without_tracking/1,
+    with_handoff_tracks_outer_slot/1,
+    with_handoff_hoisted_tracks_outer_slot/1,
     void_element/1,
     void_in_each_with_children/1,
     void_nested_child_with_children/1,
@@ -385,7 +391,13 @@ groups() ->
             tracked_get_each_item_ok,
             tracked_get_alias_ok,
             tracked_get_literal_map_ok,
-            tracked_get_renamed_param_ok
+            tracked_get_renamed_param_ok,
+            tracked_get_with_projection_ok,
+            tracked_get_with_submap_errors,
+            tracked_get_case_aliased_bindings_flagged,
+            with_handoff_freezes_without_tracking,
+            with_handoff_tracks_outer_slot,
+            with_handoff_hoisted_tracks_outer_slot
         ]},
         %% Tests 68-77c: layout tests
         {layout, [parallel], [
@@ -4817,6 +4829,117 @@ tracked_get_renamed_param_ok(Config) when is_list(Config) ->
         "    arizona_template:html({'p', [], [arizona_template:get(name, Ctx)]}). "
     ),
     ?assert(is_map(Mod:render(#{name => ~"Ada"}))).
+
+%% A var bound by a with/2 projection is bindings-like: reading it with get/2 is not
+%% flagged (the projection already tracked the key on the enclosing slot). The slot
+%% tracks `x` (not just compiles): the hoisted `Sub` is inlined back into the bracket.
+tracked_get_with_projection_ok(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_tg_withproj). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    Sub = arizona_template:with([x], Bindings), "
+        "    arizona_template:html({'p', [], [arizona_template:get(x, Sub)]}). "
+    ),
+    T = Mod:render(#{x => ~"y"}),
+    [{_Az, Fun, _Loc}] = maps:get(d, T),
+    ?assertEqual(~"y", Fun()),
+    ?assertEqual(#{x => true}, slot_deps(Fun)).
+
+%% with/2 is itself a tracking accessor, so projecting a non-bindings sub-map is the
+%% same footgun as get/get_lazy and is flagged.
+tracked_get_with_submap_errors(Config) when is_list(Config) ->
+    assert_parse_error(
+        "-module(pt_tg_withsub). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    Foo = arizona_template:get(foo, Bindings), "
+        "    Sub = arizona_template:with([bar], Foo), "
+        "    arizona_template:html({'p', [], [arizona_template:get(bar, Sub)]}). ",
+        fun(R) -> R =:= tracked_get_on_non_bindings_map end
+    ).
+
+%% A binding reached through a non-bare-var alias (a `case`, `begin`, `maps:merge`, ...)
+%% is intentionally flagged: alias_closure only proves bindings-likeness through `V = W`
+%% and `V = with(_, W)`, so a `case`-aliased binding is indistinguishable from a sub-map.
+%% This documents the limitation and the escape hatch (alias directly with `B = Bindings`,
+%% per the format_error message). The value still renders correctly via that escape.
+tracked_get_case_aliased_bindings_flagged(Config) when is_list(Config) ->
+    assert_parse_error(
+        "-module(pt_tg_casealias). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    B = case Bindings of #{} -> Bindings end, "
+        "    arizona_template:html({'p', [], [arizona_template:get(x, B)]}). ",
+        fun(R) -> R =:= tracked_get_on_non_bindings_map end
+    ).
+
+%% Finding A, baseline: a child template handed off via a raw function call freezes.
+%% The outer slot is `fun() -> inner(Bindings) end`; building `inner` fires no tracked
+%% read at the outer level (its reads sit in inner's own closures), so the outer slot
+%% captures empty deps (proven directly via slot_deps) and the diff engine skips it.
+with_handoff_freezes_without_tracking(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_with_freeze). "
+        "-export([render/1, inner/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:html({'p', [], [inner(Bindings)]}). "
+        "inner(B) -> "
+        "    arizona_template:html({'span', [], [arizona_template:get(x, B)]}). "
+    ),
+    B0 = #{x => ~"Ada"},
+    [{_Az, OuterFun, _Loc}] = maps:get(d, Mod:render(B0)),
+    ?assertEqual(#{}, slot_deps(OuterFun)),
+    {_HTML, Snap0, V0} = arizona_render:render(Mod:render(B0), #{}),
+    B1 = #{x => ~"Grace"},
+    Changed = compute_changed(B0, B1),
+    {Ops, _Snap1, _V1} = arizona_diff:diff(Mod:render(B1), Snap0, V0, Changed),
+    ?assertEqual([], Ops).
+
+%% Finding A, fix (inline form): handing off `with([x], Bindings)` declares the outer
+%% slot's dependency on `x` (proven via slot_deps), so it re-renders when `x` changes
+%% (the frozen baseline above emits no op for the same change).
+with_handoff_tracks_outer_slot(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_with_track). "
+        "-export([render/1, inner/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:html({'p', [], [inner(arizona_template:with([x], Bindings))]}). "
+        "inner(B) -> "
+        "    arizona_template:html({'span', [], [arizona_template:get(x, B)]}). "
+    ),
+    B0 = #{x => ~"Ada"},
+    [{_Az, OuterFun, _Loc}] = maps:get(d, Mod:render(B0)),
+    ?assertEqual(#{x => true}, slot_deps(OuterFun)),
+    {_HTML, Snap0, V0} = arizona_render:render(Mod:render(B0), #{}),
+    B1 = #{x => ~"Grace"},
+    Changed = compute_changed(B0, B1),
+    {Ops, _Snap1, _V1} = arizona_diff:diff(Mod:render(B1), Snap0, V0, Changed),
+    ?assertNotEqual([], Ops).
+
+%% Finding A, fix (HOISTED form): the same handoff with `with` bound to a local first.
+%% This is the regression guard for the rhs_reaches/2 inlining gate: without `with` in
+%% that gate the hoisted `Sub` is not inlined, its tracking runs outside the slot bracket
+%% (a no-op), and the outer slot freezes (slot_deps `#{}`, Ops `[]`). With the fix the
+%% slot tracks `x` exactly like the inline form above.
+with_handoff_hoisted_tracks_outer_slot(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_with_hoist). "
+        "-export([render/1, inner/1]). "
+        "render(Bindings) -> "
+        "    Sub = arizona_template:with([x], Bindings), "
+        "    arizona_template:html({'p', [], [inner(Sub)]}). "
+        "inner(B) -> "
+        "    arizona_template:html({'span', [], [arizona_template:get(x, B)]}). "
+    ),
+    B0 = #{x => ~"Ada"},
+    [{_Az, OuterFun, _Loc}] = maps:get(d, Mod:render(B0)),
+    ?assertEqual(#{x => true}, slot_deps(OuterFun)),
+    {_HTML, Snap0, V0} = arizona_render:render(Mod:render(B0), #{}),
+    B1 = #{x => ~"Grace"},
+    Changed = compute_changed(B0, B1),
+    {Ops, _Snap1, _V1} = arizona_diff:diff(Mod:render(B1), Snap0, V0, Changed),
+    ?assertNotEqual([], Ops).
 
 %% Like compile_module/1 but compiles with warnings_as_errors, matching the
 %% project's real erl_opts. Needed because unused-variable / match_underscore_var

--- a/test/arizona_template_SUITE.erl
+++ b/test/arizona_template_SUITE.erl
@@ -21,7 +21,10 @@
     to_bin_bad_value_routes_through_format_error_2/1,
     parse_transform_not_applied_routes_through_format_error_2/1,
     format_error_missing_binding_suggests_close_match/1,
-    format_error_missing_binding_no_suggestion_for_far_match/1
+    format_error_missing_binding_no_suggestion_for_far_match/1,
+    with_projects_and_tracks_each_key/1,
+    with_absent_key_omitted_but_tracked/1,
+    with_empty_keys_tracks_nothing/1
 ]).
 
 all() ->
@@ -42,7 +45,10 @@ groups() ->
             to_bin_bad_value_routes_through_format_error_2,
             parse_transform_not_applied_routes_through_format_error_2,
             format_error_missing_binding_suggests_close_match,
-            format_error_missing_binding_no_suggestion_for_far_match
+            format_error_missing_binding_no_suggestion_for_far_match,
+            with_projects_and_tracks_each_key,
+            with_absent_key_omitted_but_tracked,
+            with_empty_keys_tracks_nothing
         ]}
     ].
 
@@ -191,3 +197,38 @@ format_error_missing_binding_no_suggestion_for_far_match(Config) when is_list(Co
     #{general := Msg} = arizona_template:format_error(missing_binding, Stack),
     Bin = unicode:characters_to_binary(Msg),
     ?assertEqual(nomatch, binary:match(Bin, <<"Did you mean">>)).
+
+%% --- with/2 tracked projection ---
+
+with_projects_and_tracks_each_key(Config) when is_list(Config) ->
+    %% Under an active deps bracket, with/2 records every listed key as a
+    %% dependency and returns only those keys (maps:with projection).
+    Deps = with_deps_bracket(fun() ->
+        ?assertEqual(
+            #{x => 1, y => 2},
+            arizona_template:with([x, y], #{x => 1, y => 2, z => 3})
+        )
+    end),
+    ?assertEqual(#{x => true, y => true}, Deps).
+
+with_absent_key_omitted_but_tracked(Config) when is_list(Config) ->
+    %% A key not present in Bindings is omitted from the projection (maps:with
+    %% semantics) but is still tracked, so the slot re-renders when it appears.
+    Deps = with_deps_bracket(fun() ->
+        ?assertEqual(#{x => 1}, arizona_template:with([x, absent], #{x => 1}))
+    end),
+    ?assertEqual(#{x => true, absent => true}, Deps).
+
+with_empty_keys_tracks_nothing(Config) when is_list(Config) ->
+    %% Empty Keys tracks nothing and returns the empty projection.
+    Deps = with_deps_bracket(fun() ->
+        ?assertEqual(#{}, arizona_template:with([], #{x => 1}))
+    end),
+    ?assertEqual(#{}, Deps).
+
+%% Runs Fun inside a fresh `$arizona_deps` bracket (mirroring arizona_eval's
+%% per-slot tracking) and returns the deps map that accumulated during the call.
+with_deps_bracket(Fun) ->
+    undefined = erlang:put('$arizona_deps', #{}),
+    ok = Fun(),
+    erlang:erase('$arizona_deps').

--- a/test/az_SUITE.erl
+++ b/test/az_SUITE.erl
@@ -6,6 +6,7 @@
     get_default/1,
     get_lazy/1,
     get/1,
+    with/1,
     html_stub/1,
     stateful/1,
     stateless_2/1,
@@ -23,6 +24,7 @@ groups() ->
             get_default,
             get_lazy,
             get,
+            with,
             html_stub,
             stateful,
             stateless_2,
@@ -40,6 +42,9 @@ get_default(Config) when is_list(Config) ->
 
 get_lazy(Config) when is_list(Config) ->
     ?assertEqual(3, az:get_lazy(z, #{}, fun() -> 3 end)).
+
+with(Config) when is_list(Config) ->
+    ?assertEqual(#{x => 1, y => 2}, az:with([x, y], #{x => 1, y => 2, z => 3})).
 
 track(Config) when is_list(Config) ->
     ?assertEqual(ok, az:track(some_key)).


### PR DESCRIPTION
# Description

Adds `az:with(Keys, Bindings)` (and `arizona_template:with/2`): it tracks each key as a dependency, then projects the bindings to those keys via `maps:with`. Use it when handing a bindings subset to a sub-context (a helper, a child, a passed-through map). A child template embedded via a raw function call otherwise freezes, because the outer slot captures no dependencies; `with` declares them so the slot re-renders, and the projection means the sub-context can't silently read an untracked key (an omitted key raises `missing_binding` instead of freezing).

The parse transform handles `with` like the other tracked accessors: a hoisted `Sub = with(Keys, Bindings)` is inlined back into the slot bracket so its tracking actually runs (without this the hoisted form re-freezes), and the sub-map diagnostic recognizes a `with` projection as bindings-like while flagging `with` on a genuine sub-map. The diagnostic message is reworded so it no longer claims the flagged value is always a nested map (it may be a bindings alias the transform can't prove, e.g. one reached through a `case` or `maps:merge`).

Docs cover the three dependency-tracking footguns this surfaced: the nested-handoff freeze and its `with` fix, an eager `get/3` default over-tracking its fallback key (use `get_lazy/3`), and the deliberate stream-item path that re-evaluates empty-deps items as a safety net for head-destructured reads.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
