### PR TITLE
Harden ?each: reject non-element callback bodies and add wire-dedup coverage

### DIFF
--- a/.claude/rules/erlang.md
+++ b/.claude/rules/erlang.md
@@ -132,7 +132,7 @@ Adding `'az-nodiff'` to an element's attribute list marks it as a compile-time d
 | `?get_lazy(Key, Fun)` | `arizona_template:get_lazy(Key, Bindings, Fun)` |
 | `?html(Elems)` | `arizona_template:html(Elems)` |
 | `?terminal(Elems)` | `arizona_template:terminal(Elems)` -- ANSI render target; tags `line`/`col`/`row`/`text`/`span`/`br` + bare-atom style attrs (see docs/architecture.md "Terminal render target") |
-| `?each(Fun, Source)` | `arizona_template:each(Fun, Source)` -- 1-arg for lists, 2-arg for streams/maps |
+| `?each(Fun, Source)` | `arizona_template:each(Fun, Source)` -- 1-arg for lists, 2-arg for streams/maps. The callback must return an element (see "?each body must return an element") |
 | `?stateful(Handler, Props)` | `arizona_template:stateful(Handler, Props)` |
 | `?stateless(Fun, Props)` | `arizona_template:stateless(fun Fun/1, Props)` |
 | `?stateless(Mod, Fun, Props)` | `arizona_template:stateless(Mod, Fun, Props)` |
@@ -142,6 +142,41 @@ Adding `'az-nodiff'` to an element's attribute list marks it as a compile-time d
 | `?send(ViewId, Msg)` | `arizona_live:send(ViewId, Msg)` -- send to specific view (stateful only) |
 | `?send_after(Time, Msg)` | `arizona_live:send_after(?get(id), Time, Msg)` -- delayed send to current view (stateful only) |
 | `?send_after(ViewId, Time, Msg)` | `arizona_live:send_after(ViewId, Time, Msg)` -- delayed send to specific view (stateful only) |
+
+## `?each` body must return an element
+
+`?each` compiles each item into a per-item template (`#{s, d, f}`) for fine-grained diffing
+(insert/move/update). So the callback's body must be an **element** (`{Tag, Attrs, Children}`),
+a list of elements, or a static/mixed fragment. A bare value, a runtime binary, an `?html(...)`
+call, a `?stateful`/`?stateless` descriptor, a `case`/`if`, or a `fun name/arity` reference
+compiles to one opaque value slot. A scalar value renders and diffs (keyed by content) but
+gets no per-item diffing -- a comprehension is the right tool; a template or descriptor value
+goes further and **crashes on the first diff** (`bad_template_value`, when `to_bin/1` hits the
+stored template/descriptor). A template or descriptor wrapped in a bare list (`[?stateless(...)]`)
+is the same trap. The parse transform rejects all of these at compile time
+(`each_body_not_element` / `each_fun_ref_not_allowed`). A 2-arg (stream/map) callback is
+rejected the same way but with `each_stream_body_not_element`: a stream/map keys each item for
+per-item diffing and has **no comprehension fallback**, so the body must be an element (wrap the
+value: `fun(Item, Key) -> {li, [], [Item]} end`).
+
+- Plain values: use a list comprehension or `lists:map/2` (no per-item diffing, fine for
+  small or static lists).
+- A conditional: put it **inside** an element as a text/value child.
+
+```erlang
+%% rejected (would crash on diff): a case / ?html body
+?each(fun(U) -> case U of #{name := N} -> ?html({li,[],N}); _ -> ~"-" end end, ?get(users))
+%% ok: the conditional is a child of a stable element
+?each(fun(U) -> {li, [], [case U of #{name := N} -> N; _ -> ~"-" end]} end, ?get(users))
+%% plain values: a comprehension, not ?each
+{ul, [], [[<<"#", Tag/binary>> || Tag <- ?get(tags)]]}
+```
+
+**Known limitation:** embedding a component (a `?stateless`/`?stateful` descriptor) as an
+`?each` item child compiles and renders at SSR but **crashes on the first diff** -- the
+per-item diff keys a list item by `to_bin` of its first dynamic, which fails on a nested
+template/descriptor. So a per-item component is not usable yet. The exception is a
+`?stateful` child in a **stream** `?each` (it is its own self-diffing view process).
 
 ## Where to read bindings
 

--- a/assets/js/arizona-worker.test.js
+++ b/assets/js/arizona-worker.test.js
@@ -111,6 +111,53 @@ describe('resolveHtml -- stream type', () => {
 });
 
 // ---------------------------------------------------------------------------
+// resolveHtml -- complex inner templates (each-in-each, component-in-item, deep)
+// ---------------------------------------------------------------------------
+
+describe('resolveHtml -- nested each / components', () => {
+    it('resolves each-in-each (an item dynamic is itself an each payload)', () => {
+        const inner = { t: 0, f: 'ne_inner', s: ['<li>', '</li>'], d: [['x'], ['y']] };
+        const outer = {
+            t: 0,
+            f: 'ne_outer',
+            s: ['<div><h2>', '</h2><ul>', '</ul></div>'],
+            d: [['Sec1', inner]],
+        };
+        expect(resolveHtml(outer)).toBe('<div><h2>Sec1</h2><ul><li>x</li><li>y</li></ul></div>');
+    });
+
+    it('resolves a component embedded inside each item', () => {
+        const comp = { f: 'ci_comp', s: ['<b>', '</b>'], d: ['hi'] };
+        const each = { t: 0, f: 'ci_each', s: ['<li>', '</li>'], d: [[comp], [comp]] };
+        expect(resolveHtml(each)).toBe('<li><b>hi</b></li><li><b>hi</b></li>');
+    });
+
+    it('resolves three levels deep (each > each > component)', () => {
+        const l3 = { f: 'dn_l3', s: ['<i>', '</i>'], d: ['z'] };
+        const l2 = { t: 0, f: 'dn_l2', s: ['<span>', '</span>'], d: [[l3]] };
+        const l1 = { t: 0, f: 'dn_l1', s: ['<div>', '</div>'], d: [[l2]] };
+        expect(resolveHtml(l1)).toBe('<div><span><i>z</i></span></div>');
+    });
+
+    it('resolves nested each when statics were stripped (deduped round-trip)', () => {
+        // First send primes both outer and inner statics into the cache.
+        resolveHtml({
+            t: 0,
+            f: 'rt_outer',
+            s: ['<ul>', '</ul>'],
+            d: [[{ t: 0, f: 'rt_inner', s: ['<li>', '</li>'], d: [['a']] }]],
+        });
+        // Second send omits statics for both fingerprints (as dedup_fps would strip them).
+        const stripped = {
+            t: 0,
+            f: 'rt_outer',
+            d: [[{ t: 0, f: 'rt_inner', d: [['b'], ['c']] }]],
+        };
+        expect(resolveHtml(stripped)).toBe('<ul><li>b</li><li>c</li></ul>');
+    });
+});
+
+// ---------------------------------------------------------------------------
 // zipTemplate
 // ---------------------------------------------------------------------------
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -300,6 +300,34 @@ empty deps and freeze, except the item path re-evaluates it. The asymmetry is th
 boundary: head-destructured *render* reads freeze in top-level slots but stay current
 inside `?each` items.
 
+**`?each` item bodies must be elements.** Because each item compiles into a per-item
+template (`#{s, d, f}`), the callback body must be an element (`{Tag, Attrs, Children}`),
+a list of elements, or a static/mixed fragment. `classify_body/1` in
+`arizona_parse_transform` buckets the body; the only non-template bucket, `text_dynamic`
+(a bare value, a runtime binary, an `?html(...)` template, a `?stateful`/`?stateless`
+descriptor, or a `case`/`if`), compiles to one opaque value slot. A scalar value renders at
+SSR and diffs (the per-item key is `arizona_template:to_bin/1` of its value), but gets no
+per-item template diffing -- pointless where a comprehension is the right tool; a template or
+descriptor value goes further and crashes on the first diff, when `to_bin/1` hits the stored
+template/descriptor and raises `bad_template_value`. So `compile_each` rejects a
+`text_dynamic` body (`each_body_not_element` for a 1-arg/list callback,
+`each_stream_body_not_element` for a 2-arg/stream-or-map callback -- the two differ only in fix
+advice, since a list has a comprehension fallback and a stream/map, keyed per item, does not)
+and a fun reference (`each_fun_ref_not_allowed`, its return can't be inspected) at compile
+time. It also rejects a bare list whose item is a
+template or descriptor (`[?html(...)]`, `[?stateless(...)]`) -- the item lands in the same
+fragile value slot -- while keeping a list of elements or a static/dynamic-text fragment.
+Map plain values with a list comprehension / `lists:map` (no per-item diffing); put a
+conditional inside an element child (`{li, [], [case ... end]}`).
+
+A per-item **component** (`{li, [], [?stateless(...)]}`) compiles and renders but currently
+**crashes on the first diff**: the list-each diff in `arizona_diff` (`diff_list_zip/4`) keys a
+list item by `to_bin` of its first dynamic, which fails on a nested template/descriptor. So a
+component as an `?each`
+item child is not usable yet (the exception is a `?stateful` child in a **stream** `?each` --
+it is its own self-diffing view process). Fixing it means keying list items by position
+instead of by their first dynamic's value (server plus the client's `az-key` lookup).
+
 ## API -- effect commands (`arizona_js` / `arizona_android` / `arizona_effect`)
 
 Client effect commands, built per platform -- `arizona_js` (web), `arizona_android` (native) --

--- a/src/arizona_live.erl
+++ b/src/arizona_live.erl
@@ -61,6 +61,7 @@ fingerprints already shipped in the initial HTML.
 -export([navigate/4]).
 -export([handle_event/4]).
 -export([seed_fps/2]).
+-export([dedup_fps/2]).
 -export([apply_on_mount/2]).
 -export([format_error/2]).
 
@@ -83,6 +84,7 @@ fingerprints already shipped in the initial HTML.
     send/2,
     send_after/3,
     navigate/3,
+    dedup_fps/2,
     format_error/2
 ]).
 

--- a/src/arizona_parse_transform.erl
+++ b/src/arizona_parse_transform.erl
@@ -233,6 +233,23 @@ format_error(invalid_attribute) ->
     "<<\"Name\">> (binary), or {Name, true|false}";
 format_error(invalid_each_fun) ->
     "each/2 expects a fun with a single clause and one or two parameters";
+format_error(each_body_not_element) ->
+    "an ?each callback over a list must return an element ({Tag, Attrs, Children}) or a "
+    "list of elements -- ?each builds a per-item template for fine-grained diffing, so a "
+    "single-value body defeats its purpose (and a template or descriptor value crashes on "
+    "the first diff, keyed by to_bin of the first dynamic). For a list of plain values use a "
+    "list comprehension or lists:map/2. For a conditional, put it inside an element as a "
+    "text/value child: {li, [], [case ... of ... end]}";
+format_error(each_stream_body_not_element) ->
+    "an ?each callback over a stream or map (a 2-arg fun) must return an element ({Tag, "
+    "Attrs, Children}) or a list of elements -- a stream/map keys each item for per-item "
+    "diffing, which a single-value body throws away. Unlike a list there is no comprehension "
+    "fallback (a comprehension has no stream/keyed semantics): wrap the value in an element, "
+    "e.g. fun(Item, Key) -> {li, [], [Item]} end";
+format_error(each_fun_ref_not_allowed) ->
+    "an ?each callback must be an inline fun returning an element; a fun reference can't "
+    "be checked to return one (and a reference returning a template breaks diffing). Inline "
+    "it (fun(I) -> {li, [], [...]} end)";
 format_error(live_render_not_single_element) ->
     "arizona_stateful render/1 must return a single root element, not a list";
 format_error(live_render_missing_id) ->
@@ -939,6 +956,7 @@ compile_each(FunAST, SourceAST, Line, Module, Backend) ->
     case FunAST of
         {'fun', _, {clauses, [{clause, _, [ItemVar, KeyVar], Guards, Body}]}} ->
             {Prefix, LastExpr} = split_fun_body(Body),
+            ok = validate_each_body(stream, classify_body(LastExpr), LastExpr),
             {Statics, DynASTs, Fingerprint, Opts0} = compile_body_parts(
                 LastExpr, Module, false, Backend
             ),
@@ -949,6 +967,7 @@ compile_each(FunAST, SourceAST, Line, Module, Backend) ->
             );
         {'fun', _, {clauses, [{clause, _, [ItemVar], Guards, Body}]}} ->
             {Prefix, LastExpr} = split_fun_body(Body),
+            ok = validate_each_body(list, classify_body(LastExpr), LastExpr),
             {Statics, DynASTs, Fingerprint, Opts0} = compile_body_parts(
                 LastExpr, Module, false, Backend
             ),
@@ -957,35 +976,55 @@ compile_each(FunAST, SourceAST, Line, Module, Backend) ->
             build_each_ast(
                 Line, SourceAST, [ItemVar], Guards, Prefix, S1, D1, Fingerprint, Opts
             );
-        %% `fun name/arity` / `fun Mod:name/arity` -- synthesize an anonymous
-        %% wrapper clause that calls the referenced function with the item
-        %% (and optional key) var, then recurse into the clause path above.
-        {'fun', L, {function, Name, Arity}} when
-            is_atom(Name) andalso (Arity =:= 1 orelse Arity =:= 2)
-        ->
-            compile_each(
-                wrap_fun_ref(L, Arity, {atom, L, Name}, none), SourceAST, Line, Module, Backend
-            );
-        {'fun', L, {function, Mod, Name, {integer, _, Arity}}} when
-            Arity =:= 1 orelse Arity =:= 2
-        ->
-            compile_each(wrap_fun_ref(L, Arity, Name, Mod), SourceAST, Line, Module, Backend);
+        %% `fun name/arity` / `fun Mod:name/arity` -- a reference can't be checked to
+        %% return an element, and a reference returning a template breaks diffing.
+        {'fun', L, {function, _Name, _Arity}} ->
+            parse_error(each_fun_ref_not_allowed, L);
+        {'fun', L, {function, _Mod, _Name, _Arity}} ->
+            parse_error(each_fun_ref_not_allowed, L);
         _ ->
             parse_error(invalid_each_fun, Line)
     end.
 
-%% Build `fun(I) -> Callee(I) end` or `fun(I, K) -> Callee(I, K) end`,
-%% where Callee is either `Name(...)` or `Mod:Name(...)`.
-wrap_fun_ref(L, Arity, NameAST, ModAST) ->
-    VarNames = ['__I', '__K'],
-    Vars = [{var, L, V} || V <- lists:sublist(VarNames, Arity)],
-    Callee =
-        case ModAST of
-            none -> NameAST;
-            _ -> {remote, L, ModAST, NameAST}
-        end,
-    Call = {call, L, Callee, Vars},
-    {'fun', L, {clauses, [{clause, L, Vars, [], [Call]}]}}.
+%% An ?each callback must build a per-item template: its body must be an element, a list
+%% of elements, or a static/mixed fragment. A `text_dynamic` body (a bare value, a runtime
+%% binary, an ?html(...) template, a ?stateful/?stateless descriptor, or a case/if) compiles
+%% to one opaque value slot that renders at SSR but loses per-item diffing (and a template/
+%% descriptor value crashes on diff). Reject it at compile time. `Kind` (list | stream) is the
+%% source shape, inferred from the callback arity (1-arg = list, 2-arg = stream/map): the error
+%% it raises tailors the fix advice, since a list has a comprehension fallback and a stream
+%% does not.
+validate_each_body(Kind, text_dynamic, LastExpr) ->
+    parse_error(each_body_error(Kind), line(LastExpr));
+validate_each_body(Kind, list_ast, LastExpr) ->
+    %% A mixed-list fragment is fine UNLESS an item is a nested template (a transformed
+    %% ?html/?native/?terminal map literal) or a ?stateful/?stateless descriptor: those land
+    %% in a per-item value slot and crash on diff exactly like a bare body. (A component as
+    %% an ?each item child is a known limitation -- it crashes on the per-item diff for now.)
+    walk_each_list_items(Kind, LastExpr);
+validate_each_body(_Kind, _Classification, _LastExpr) ->
+    ok.
+
+each_body_error(list) -> each_body_not_element;
+each_body_error(stream) -> each_stream_body_not_element.
+
+walk_each_list_items(Kind, {cons, _, Item, Tail}) ->
+    case is_fragile_each_item(Item) of
+        true -> parse_error(each_body_error(Kind), line(Item));
+        false -> walk_each_list_items(Kind, Tail)
+    end;
+walk_each_list_items(_Kind, _Nil) ->
+    ok.
+
+%% A list item that compiles to a fragile per-item value slot (renders at SSR, crashes on
+%% diff): a nested template (a transformed ?html/?native/?terminal map literal) or a
+%% ?stateful/?stateless descriptor call.
+is_fragile_each_item({map, _, _}) ->
+    true;
+is_fragile_each_item({call, _, {remote, _, {atom, _, Mod}, {atom, _, F}}, _Args}) ->
+    (Mod =:= arizona_template orelse Mod =:= az) andalso (F =:= stateful orelse F =:= stateless);
+is_fragile_each_item(_Item) ->
+    false.
 
 compile_body_parts(ExprAST, Module, LiveRender, Backend) ->
     compile_classified_body(classify_body(ExprAST), ExprAST, Module, LiveRender, Backend).

--- a/test/arizona_live_SUITE.erl
+++ b/test/arizona_live_SUITE.erl
@@ -10,6 +10,11 @@
     dedup_navigate_nested_dynamics/1,
     dedup_nested_dynamics_first_time/1,
     dedup_nested_dynamics/1,
+    dedup_each_list_of_lists/1,
+    dedup_each_repeated_item_fp/1,
+    dedup_nested_each/1,
+    dedup_component_in_each_item/1,
+    dedup_deep_nesting/1,
     effect_child_event_no_effects/1,
     effect_child_event_with_effects/1,
     effect_child_only_no_ops/1,
@@ -176,7 +181,12 @@ groups() ->
             dedup_item_patch_no_prior_fp,
             dedup_nested_dynamics,
             dedup_nested_dynamics_first_time,
-            dedup_navigate_nested_dynamics
+            dedup_navigate_nested_dynamics,
+            dedup_each_list_of_lists,
+            dedup_each_repeated_item_fp,
+            dedup_nested_each,
+            dedup_component_in_each_item,
+            dedup_deep_nesting
         ]},
         {seed_fps, [parallel], [
             seed_fps_skips_statics,
@@ -1379,6 +1389,106 @@ dedup_nested_dynamics_first_time(Config) when is_list(Config) ->
     ?assert(maps:is_key(<<"p2_fp">>, Fps)),
     ?assert(maps:is_key(<<"c2_fp">>, Fps)).
 
+%% An each wire payload has a list-of-lists `d` (one inner list per item), unlike a flat
+%% template. The dedup walk must record the each's fingerprint and strip its statics on a
+%% second encounter while leaving the per-item dynamics untouched.
+dedup_each_list_of_lists(Config) when is_list(Config) ->
+    Each = #{
+        <<"t">> => 0,
+        <<"f">> => <<"each_fp">>,
+        <<"s">> => [<<"<li>">>, <<"</li>">>],
+        <<"d">> => [[<<"a">>], [<<"b">>]]
+    },
+    Ops = [[?OP_TEXT, <<"0">>, Each]],
+    {[[?OP_TEXT, <<"0">>, P1]], Fps1} = dedup_fps(Ops, #{}),
+    ?assert(maps:is_key(<<"s">>, P1)),
+    ?assert(maps:is_key(<<"each_fp">>, Fps1)),
+    ?assertEqual([[<<"a">>], [<<"b">>]], maps:get(<<"d">>, P1)),
+    {[[?OP_TEXT, <<"0">>, P2]], _} = dedup_fps(Ops, Fps1),
+    ?assertNot(maps:is_key(<<"s">>, P2)),
+    ?assertEqual([[<<"a">>], [<<"b">>]], maps:get(<<"d">>, P2)).
+
+%% Within a SINGLE each payload, items sharing an item-template fingerprint (a list of the
+%% same component) send statics once: the first occurrence keeps them, later ones are
+%% stripped using the fingerprint just recorded.
+dedup_each_repeated_item_fp(Config) when is_list(Config) ->
+    Comp = #{<<"f">> => <<"comp_fp">>, <<"s">> => [<<"<b>">>, <<"</b>">>], <<"d">> => [<<"v">>]},
+    Each = #{
+        <<"t">> => 0,
+        <<"f">> => <<"each_fp2">>,
+        <<"s">> => [<<"<li>">>, <<"</li>">>],
+        <<"d">> => [[Comp], [Comp]]
+    },
+    {[[?OP_TEXT, <<"0">>, P]], _} = dedup_fps([[?OP_TEXT, <<"0">>, Each]], #{}),
+    [[C0], [C1]] = maps:get(<<"d">>, P),
+    ?assert(maps:is_key(<<"s">>, C0)),
+    ?assertNot(maps:is_key(<<"s">>, C1)),
+    ?assertEqual(<<"comp_fp">>, maps:get(<<"f">>, C1)).
+
+%% Each-in-each: an outer each item whose only dynamic is an inner each payload. A
+%% previously-seen inner-each fingerprint is stripped at depth.
+dedup_nested_each(Config) when is_list(Config) ->
+    Inner = #{
+        <<"t">> => 0,
+        <<"f">> => <<"inner_fp">>,
+        <<"s">> => [<<"<span>">>, <<"</span>">>],
+        <<"d">> => [[<<"x">>], [<<"y">>]]
+    },
+    Outer = #{
+        <<"t">> => 0,
+        <<"f">> => <<"outer_fp">>,
+        <<"s">> => [<<"<div>">>, <<"</div>">>],
+        <<"d">> => [[Inner]]
+    },
+    Fps0 = #{<<"inner_fp">> => true},
+    {[[?OP_TEXT, <<"0">>, P]], _} = dedup_fps([[?OP_TEXT, <<"0">>, Outer]], Fps0),
+    ?assert(maps:is_key(<<"s">>, P)),
+    [[InnerP]] = maps:get(<<"d">>, P),
+    ?assertNot(maps:is_key(<<"s">>, InnerP)),
+    ?assertEqual(<<"inner_fp">>, maps:get(<<"f">>, InnerP)),
+    ?assertEqual([[<<"x">>], [<<"y">>]], maps:get(<<"d">>, InnerP)).
+
+%% A component (a plain fingerprinted template, no `t`) embedded inside an each item is
+%% deduped just like any other nested template.
+dedup_component_in_each_item(Config) when is_list(Config) ->
+    Comp = #{<<"f">> => <<"c_fp">>, <<"s">> => [<<"<em>">>, <<"</em>">>], <<"d">> => [<<"w">>]},
+    Each = #{
+        <<"t">> => 0,
+        <<"f">> => <<"e_fp">>,
+        <<"s">> => [<<"<li>">>, <<"</li>">>],
+        <<"d">> => [[Comp]]
+    },
+    Fps0 = #{<<"c_fp">> => true},
+    {[[?OP_TEXT, <<"0">>, P]], _} = dedup_fps([[?OP_TEXT, <<"0">>, Each]], Fps0),
+    [[CompP]] = maps:get(<<"d">>, P),
+    ?assertNot(maps:is_key(<<"s">>, CompP)),
+    ?assertEqual([<<"w">>], maps:get(<<"d">>, CompP)).
+
+%% Three levels (each > each > component), all first-time: every fingerprint is recorded
+%% and statics are kept all the way down -- the recursion must reach arbitrary depth.
+dedup_deep_nesting(Config) when is_list(Config) ->
+    L3 = #{<<"f">> => <<"l3">>, <<"s">> => [<<"<i>">>, <<"</i>">>], <<"d">> => [<<"z">>]},
+    L2 = #{
+        <<"t">> => 0,
+        <<"f">> => <<"l2">>,
+        <<"s">> => [<<"<span>">>, <<"</span>">>],
+        <<"d">> => [[L3]]
+    },
+    L1 = #{
+        <<"t">> => 0,
+        <<"f">> => <<"l1">>,
+        <<"s">> => [<<"<div>">>, <<"</div>">>],
+        <<"d">> => [[L2]]
+    },
+    {[[?OP_TEXT, <<"0">>, P1]], Fps} = dedup_fps([[?OP_TEXT, <<"0">>, L1]], #{}),
+    ?assert(maps:is_key(<<"l1">>, Fps)),
+    ?assert(maps:is_key(<<"l2">>, Fps)),
+    ?assert(maps:is_key(<<"l3">>, Fps)),
+    [[P2]] = maps:get(<<"d">>, P1),
+    [[P3]] = maps:get(<<"d">>, P2),
+    ?assert(maps:is_key(<<"s">>, P2)),
+    ?assert(maps:is_key(<<"s">>, P3)).
+
 dedup_navigate_nested_dynamics(Config) when is_list(Config) ->
     %% Navigate returns fingerprinted payload whose dynamics contain
     %% nested fingerprinted child components. Within a single dedup pass,
@@ -1543,51 +1653,7 @@ seed_fps_idempotent(Config) when is_list(Config) ->
 %% Helpers
 %% =============================================================================
 
-%% Wrapper to call arizona_live's internal dedup_fps for unit testing
+%% Delegate to arizona_live's real (internal) dedup so these unit tests exercise the
+%% production walk directly, not a copy that could silently drift from it.
 dedup_fps(Ops, Fps) ->
-    lists:mapfoldl(fun dedup_fp_op/2, Fps, Ops).
-
-dedup_fp_op([BinId, ChildOps], Fps0) when is_binary(BinId), is_list(ChildOps) ->
-    {ChildOps1, Fps1} = dedup_fps(ChildOps, Fps0),
-    {[BinId, ChildOps1], Fps1};
-dedup_fp_op([OpCode, Target | Rest], Fps0) when is_integer(OpCode) ->
-    {Rest1, Fps1} = dedup_fp_rest(Rest, Fps0),
-    {[OpCode, Target | Rest1], Fps1};
-dedup_fp_op(Op, Fps) ->
-    {Op, Fps}.
-
-dedup_fp_rest([], Fps) ->
-    {[], Fps};
-dedup_fp_rest([H | T], Fps0) ->
-    {H1, Fps1} = dedup_fp_val(H, Fps0),
-    {T1, Fps2} = dedup_fp_rest(T, Fps1),
-    {[H1 | T1], Fps2}.
-
-dedup_fp_val(#{<<"f">> := F, <<"s">> := _, <<"d">> := D} = Val, Fps) ->
-    case Fps of
-        #{F := _} ->
-            {D1, Fps1} = dedup_fp_dlist(D, Fps),
-            {maps:without([<<"s">>], Val#{<<"d">> => D1}), Fps1};
-        #{} ->
-            {D1, Fps1} = dedup_fp_dlist(D, Fps#{F => true}),
-            {Val#{<<"d">> => D1}, Fps1}
-    end;
-dedup_fp_val(#{<<"f">> := F, <<"d">> := D} = Val, Fps) ->
-    {D1, Fps1} = dedup_fp_dlist(D, Fps),
-    Fps2 =
-        case Fps1 of
-            #{F := _} -> Fps1;
-            #{} -> Fps1#{F => true}
-        end,
-    {Val#{<<"d">> => D1}, Fps2};
-dedup_fp_val(Items, Fps) when is_list(Items) ->
-    dedup_fp_dlist(Items, Fps);
-dedup_fp_val(Val, Fps) ->
-    {Val, Fps}.
-
-dedup_fp_dlist([], Fps) ->
-    {[], Fps};
-dedup_fp_dlist([H | T], Fps0) ->
-    {H1, Fps1} = dedup_fp_val(H, Fps0),
-    {T1, Fps2} = dedup_fp_dlist(T, Fps1),
-    {[H1 | T1], Fps2}.
+    arizona_live:dedup_fps(Ops, Fps).

--- a/test/arizona_parse_transform_SUITE.erl
+++ b/test/arizona_parse_transform_SUITE.erl
@@ -9,6 +9,16 @@
     each_with_named_fun_ref/1,
     each_with_named_fun_ref_arity_2/1,
     each_with_remote_fun_ref/1,
+    each_body_html_wrapped_rejected/1,
+    each_body_descriptor_rejected/1,
+    each_body_case_rejected/1,
+    each_body_if_rejected/1,
+    each_body_runtime_binary_rejected/1,
+    each_body_two_arg_value_rejected/1,
+    each_body_two_arg_html_rejected/1,
+    each_body_list_with_descriptor_rejected/1,
+    each_body_mixed_fragment_ok/1,
+    each_body_conditional_child_diffs/1,
     stateless_with_atom_callback/1,
     stateless_with_fun_ref_callback/1,
     stateless_with_remote_fun_ref_callback/1,
@@ -316,6 +326,16 @@ groups() ->
             each_with_named_fun_ref,
             each_with_named_fun_ref_arity_2,
             each_with_remote_fun_ref,
+            each_body_html_wrapped_rejected,
+            each_body_descriptor_rejected,
+            each_body_case_rejected,
+            each_body_if_rejected,
+            each_body_runtime_binary_rejected,
+            each_body_two_arg_value_rejected,
+            each_body_two_arg_html_rejected,
+            each_body_list_with_descriptor_rejected,
+            each_body_mixed_fragment_ok,
+            each_body_conditional_child_diffs,
             stateless_with_atom_callback,
             stateless_with_fun_ref_callback,
             stateless_with_remote_fun_ref_callback
@@ -919,9 +939,9 @@ local_in_each_renders(Config) when is_list(Config) ->
         "render(Bindings) -> "
         "    arizona_template:html("
         "        {'ul', [], [arizona_template:each(fun(Item) -> "
-        "            arizona_template:html({'li', [], ["
+        "            {'li', [], ["
         "                arizona_template:local(<<\"m\">>, <<\"-\">>), "
-        "                arizona_template:get(label, Item)]}) "
+        "                arizona_template:get(label, Item)]} "
         "        end, arizona_template:get(items, Bindings))]}"
         "    ). "
     ),
@@ -2193,28 +2213,22 @@ template1_fragment_render(Config) when is_list(Config) ->
     ),
     ?assertEqual(Expected, iolist_to_binary(HTML)).
 
-%% Test 43: template/2 with non-element expression -- dynamic fallback.
+%% Test 43: a bare-value (non-element) ?each body is rejected -- ?each needs a per-item
+%% element; for plain values use a comprehension.
 template2_non_element_expr(Config) when is_list(Config) ->
-    Mod = compile_module(
+    assert_parse_error(
         "-module(pt_each_non_elem). "
         "-export([render/1]). "
         "render(Bindings) -> "
         "    arizona_template:each(fun(Item) -> "
         "        maps:get(name, Item) "
-        "    end, arizona_template:get(items, Bindings, [])). "
-    ),
-    Result = Mod:render(#{items => []}),
-    Tmpl = maps:get(template, Result),
-    Fp = maps:get(f, Tmpl),
-    ?assertEqual([<<>>, <<>>], maps:get(s, Tmpl)),
-    DFun = maps:get(d, Tmpl),
-    Az0 = <<Fp/binary, "-0">>,
-    [{Az0, Fun, {pt_each_non_elem, 1}}] = DFun(#{name => <<"Alice">>}),
-    ?assertEqual(<<"Alice">>, Fun()).
+        "    end, arizona_template:get(items, Bindings, [])). ",
+        fun(R) -> R =:= each_body_not_element end
+    ).
 
-%% Test 44: template/2 non-element items render to correct HTML.
+%% Test 44: the rejection fires even when the ?each is nested inside an ?html element.
 template2_non_element_render(Config) when is_list(Config) ->
-    Mod = compile_module(
+    assert_parse_error(
         "-module(pt_each_non_elem_render). "
         "-export([render/1]). "
         "render(Bindings) -> "
@@ -2224,18 +2238,9 @@ template2_non_element_render(Config) when is_list(Config) ->
         "                maps:get(name, Item) "
         "            end, arizona_template:get(items, Bindings, []))"
         "        ]}"
-        "    ). "
-    ),
-    Tmpl = Mod:render(#{items => [#{name => <<"Alice">>}, #{name => <<"Bob">>}]}),
-    Fp = maps:get(f, Tmpl),
-    {HTML, _Snap} = arizona_render:render(Tmpl),
-    Expected = iolist_to_binary(
-        scope_s(
-            Fp,
-            [<<"<ul az=\"0\"><!--az:0-->AliceBob<!--/az--></ul>">>]
-        )
-    ),
-    ?assertEqual(Expected, iolist_to_binary(HTML)).
+        "    ). ",
+        fun(R) -> R =:= each_body_not_element end
+    ).
 
 %% Test 45: template/2 with static binary body -- no dynamics.
 template2_static_binary_body(Config) when is_list(Config) ->
@@ -2253,25 +2258,18 @@ template2_static_binary_body(Config) when is_list(Config) ->
     DFun = maps:get(d, Tmpl),
     ?assertEqual([], DFun(anything)).
 
-%% Test 46: template/2 multi-expression body with non-element last expr.
+%% Test 46: a prefix does not exempt -- a non-element last expr is still rejected.
 template2_non_element_multi_expr(Config) when is_list(Config) ->
-    Mod = compile_module(
+    assert_parse_error(
         "-module(pt_each_non_elem_multi). "
         "-export([render/1]). "
         "render(Bindings) -> "
         "    arizona_template:each(fun(Item) -> "
         "        Name = maps:get(name, Item), "
         "        string:uppercase(Name) "
-        "    end, arizona_template:get(items, Bindings, [])). "
-    ),
-    Result = Mod:render(#{items => []}),
-    Tmpl = maps:get(template, Result),
-    Fp = maps:get(f, Tmpl),
-    ?assertEqual([<<>>, <<>>], maps:get(s, Tmpl)),
-    DFun = maps:get(d, Tmpl),
-    Az0 = <<Fp/binary, "-0">>,
-    [{Az0, Fun, {pt_each_non_elem_multi, 1}}] = DFun(#{name => <<"alice">>}),
-    ?assertEqual(<<"ALICE">>, Fun()).
+        "    end, arizona_template:get(items, Bindings, [])). ",
+        fun(R) -> R =:= each_body_not_element end
+    ).
 
 %% Test 47: template/1 with static binary -- no element, no dynamics.
 template1_static_binary(Config) when is_list(Config) ->
@@ -2471,24 +2469,17 @@ template2_map_pattern(Config) when is_list(Config) ->
     ?assertEqual(<<"Alice">>, NameFun()),
     ?assertEqual(30, AgeFun()).
 
-%% Test 55: template/2 with map pattern -- non-element expression body.
+%% Test 55: a map-pattern head does not exempt -- a non-element body is still rejected.
 template2_map_pattern_non_element(Config) when is_list(Config) ->
-    Mod = compile_module(
+    assert_parse_error(
         "-module(pt_each_map_pat_ne). "
         "-export([render/1]). "
         "render(Bindings) -> "
         "    arizona_template:each(fun(#{name := Name}) -> "
         "        Name "
-        "    end, arizona_template:get(items, Bindings, [])). "
-    ),
-    Result = Mod:render(#{items => []}),
-    Tmpl = maps:get(template, Result),
-    Fp = maps:get(f, Tmpl),
-    ?assertEqual([<<>>, <<>>], maps:get(s, Tmpl)),
-    DFun = maps:get(d, Tmpl),
-    Az0 = <<Fp/binary, "-0">>,
-    [{Az0, Fun, {pt_each_map_pat_ne, 1}}] = DFun(#{name => <<"Bob">>}),
-    ?assertEqual(<<"Bob">>, Fun()).
+        "    end, arizona_template:get(items, Bindings, [])). ",
+        fun(R) -> R =:= each_body_not_element end
+    ).
 
 %% Test 56: template/2 prefix with static body -- prefix runs, no dynamics.
 template2_prefix_static_body(Config) when is_list(Config) ->
@@ -3382,54 +3373,176 @@ invalid_element_binary_tag(Config) when is_list(Config) ->
         end
     ).
 
-%% each/2 accepts `fun name/arity` references by synthesizing a wrapper clause.
+%% each/2 rejects `fun name/arity` references -- a reference can't be checked to return
+%% an element, so it must be inlined (or use ?stateless inside an element).
 each_with_named_fun_ref(Config) when is_list(Config) ->
-    Mod = compile_module(
+    assert_parse_error(
         "-module(pt_each_named_ref). "
         "-export([render/1, row/1]). "
         "row(Name) -> <<\"row:\", Name/binary>>. "
         "render(Bindings) -> "
         "    arizona_template:each(fun row/1, "
-        "        arizona_template:get(items, Bindings, [])). "
-    ),
-    Result = Mod:render(#{items => [<<"a">>, <<"b">>]}),
-    ?assertEqual(0, maps:get(t, Result)),
-    Tmpl = maps:get(template, Result),
-    DFun = maps:get(d, Tmpl),
-    ?assert(is_function(DFun, 1)),
-    [{_, Fun, _}] = DFun(<<"a">>),
-    ?assertEqual(<<"row:a">>, Fun()).
+        "        arizona_template:get(items, Bindings, [])). ",
+        fun(R) -> R =:= each_fun_ref_not_allowed end
+    ).
 
-%% each/2 accepts 2-arity fun references for stream/map sources.
+%% each/2 rejects 2-arity fun references too.
 each_with_named_fun_ref_arity_2(Config) when is_list(Config) ->
-    Mod = compile_module(
+    assert_parse_error(
         "-module(pt_each_named_ref_2). "
         "-export([render/1, row/2]). "
         "row(Item, Key) -> <<Key/binary, \"=\", Item/binary>>. "
         "render(Bindings) -> "
         "    arizona_template:each(fun row/2, "
-        "        arizona_template:get(items, Bindings, [])). "
-    ),
-    Tmpl = maps:get(template, Mod:render(#{items => []})),
-    DFun = maps:get(d, Tmpl),
-    ?assert(is_function(DFun, 2)),
-    [{_, Fun, _}] = DFun(<<"v">>, <<"k">>),
-    ?assertEqual(<<"k=v">>, Fun()).
+        "        arizona_template:get(items, Bindings, [])). ",
+        fun(R) -> R =:= each_fun_ref_not_allowed end
+    ).
 
-%% each/2 accepts `fun Mod:Name/Arity` remote references too.
+%% each/2 rejects `fun Mod:Name/Arity` remote references too.
 each_with_remote_fun_ref(Config) when is_list(Config) ->
-    Mod = compile_module(
+    assert_parse_error(
         "-module(pt_each_remote_ref). "
         "-export([render/1]). "
         "render(Bindings) -> "
         "    arizona_template:each(fun erlang:integer_to_binary/1, "
-        "        arizona_template:get(items, Bindings, [])). "
+        "        arizona_template:get(items, Bindings, [])). ",
+        fun(R) -> R =:= each_fun_ref_not_allowed end
+    ).
+
+%% Wrapping the element in ?html(...) yields a template value (a text_dynamic slot that
+%% crashes on diff) -- rejected; return the element literal directly.
+each_body_html_wrapped_rejected(Config) when is_list(Config) ->
+    assert_parse_error(
+        "-module(pt_each_html_wrapped). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:html({'ul', [], [arizona_template:each(fun(X) -> "
+        "        arizona_template:html({'li', [], [X]}) "
+        "    end, arizona_template:get(xs, Bindings))]}). ",
+        fun(R) -> R =:= each_body_not_element end
+    ).
+
+%% A bare ?stateful/?stateless descriptor body is rejected -- wrap it in an element.
+each_body_descriptor_rejected(Config) when is_list(Config) ->
+    assert_parse_error(
+        "-module(pt_each_descriptor). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:html({'ul', [], [arizona_template:each(fun(X) -> "
+        "        arizona_template:stateful(some_component, #{id => X}) "
+        "    end, arizona_template:get(xs, Bindings))]}). ",
+        fun(R) -> R =:= each_body_not_element end
+    ).
+
+%% A case (or any control-flow) body is rejected: put the conditional inside an element.
+each_body_case_rejected(Config) when is_list(Config) ->
+    assert_parse_error(
+        "-module(pt_each_case). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:html({'ul', [], [arizona_template:each(fun(U) -> "
+        "        case U of "
+        "            #{name := N} -> arizona_template:html({'li', [], [N]}); "
+        "            _ -> ~\"-\" "
+        "        end "
+        "    end, arizona_template:get(users, Bindings))]}). ",
+        fun(R) -> R =:= each_body_not_element end
+    ).
+
+%% An `if` (like any branching control flow) is rejected: branches may select different
+%% per-item structures, which is exactly the fragile case -- put it inside an element.
+each_body_if_rejected(Config) when is_list(Config) ->
+    assert_parse_error(
+        "-module(pt_each_if). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:html({'ul', [], [arizona_template:each(fun(X) -> "
+        "        if is_binary(X) -> {'li', [], [X]}; true -> {'span', [], [X]} end "
+        "    end, arizona_template:get(xs, Bindings))]}). ",
+        fun(R) -> R =:= each_body_not_element end
+    ).
+
+%% A runtime binary construction is a plain value -- rejected; use a comprehension.
+each_body_runtime_binary_rejected(Config) when is_list(Config) ->
+    assert_parse_error(
+        "-module(pt_each_runtime_bin). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:each(fun(X) -> "
+        "        <<\"row \", X/binary>> "
+        "    end, arizona_template:get(xs, Bindings, [])). ",
+        fun(R) -> R =:= each_body_not_element end
+    ).
+
+%% The 2-arg (stream/map) callback is validated like the 1-arg one, but raises the
+%% stream-specific error (the fix advice differs: no comprehension fallback for a stream).
+each_body_two_arg_value_rejected(Config) when is_list(Config) ->
+    assert_parse_error(
+        "-module(pt_each_two_arg). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:html({'ul', [], [arizona_template:each(fun(Item, _Key) -> "
+        "        Item "
+        "    end, arizona_template:get(xs, Bindings))]}). ",
+        fun(R) -> R =:= each_stream_body_not_element end
+    ).
+
+%% A 2-arg callback returning an ?html template is rejected with the stream error too.
+each_body_two_arg_html_rejected(Config) when is_list(Config) ->
+    assert_parse_error(
+        "-module(pt_each_two_arg_html). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:html({'ul', [], [arizona_template:each(fun(Item, _Key) -> "
+        "        arizona_template:html({'li', [], [Item]}) "
+        "    end, arizona_template:get(xs, Bindings))]}). ",
+        fun(R) -> R =:= each_stream_body_not_element end
+    ).
+
+%% A bare list whose item is a descriptor (or template) is rejected: the item lands in a
+%% per-item value slot and crashes on diff. Wrap it in an element instead of a bare list.
+each_body_list_with_descriptor_rejected(Config) when is_list(Config) ->
+    assert_parse_error(
+        "-module(pt_each_list_desc). "
+        "-export([render/1, row/1]). "
+        "row(P) -> arizona_template:html({'span', [], [arizona_template:get(t, P)]}). "
+        "render(Bindings) -> "
+        "    arizona_template:html({'ul', [], [arizona_template:each(fun(X) -> "
+        "        [arizona_template:stateless(fun row/1, #{t => X})] "
+        "    end, arizona_template:get(xs, Bindings))]}). ",
+        fun(R) -> R =:= each_body_not_element end
+    ).
+
+%% A mixed static/dynamic list fragment compiles to a per-item template (accepted).
+each_body_mixed_fragment_ok(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_each_mixed). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:html({'ul', [], [arizona_template:each(fun(X) -> "
+        "        [~\"* \", X] "
+        "    end, arizona_template:get(xs, Bindings))]}). "
     ),
-    Result = Mod:render(#{items => [1, 2]}),
-    Tmpl = maps:get(template, Result),
-    DFun = maps:get(d, Tmpl),
-    [{_, Fun, _}] = DFun(42),
-    ?assertEqual(<<"42">>, Fun()).
+    ?assert(is_map(Mod:render(#{xs => [~"a", ~"b"]}))).
+
+%% The diff-safe rewrite of a conditional item: the case is a CHILD of an element literal,
+%% so the item stays a stable per-item template and diffs cleanly (the rejected case-body
+%% above would have crashed on this same diff).
+each_body_conditional_child_diffs(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_each_cond_child). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:html({'ul', [], [arizona_template:each(fun(U) -> "
+        "        {'li', [], [case U of #{name := N} -> N; _ -> ~\"-\" end]} "
+        "    end, arizona_template:get(users, Bindings))]}). "
+    ),
+    B0 = #{users => [#{name => ~"Ada"}]},
+    {_HTML, Snap0, V0} = arizona_render:render(Mod:render(B0), #{}),
+    B1 = #{users => [#{name => ~"Grace"}]},
+    Changed = compute_changed(B0, B1),
+    {Ops, _Snap1, _V1} = arizona_diff:diff(Mod:render(B1), Snap0, V0, Changed),
+    ?assertNotEqual([], Ops).
 
 %% The parse transform rewrites `arizona_template:stateless(atom, Props)` into
 %% `arizona_template:stateless(fun atom/1, Props)` so bare atoms and fun
@@ -4569,7 +4682,7 @@ inline_each_hoisted_source(Config) when is_list(Config) ->
         "render(Bindings) -> "
         "    Items = arizona_template:get(items, Bindings), "
         "    arizona_template:html({'ul', [], [arizona_template:each(fun(I) -> "
-        "        arizona_template:html({'li', [], [I]}) end, Items)]}). "
+        "        {'li', [], [I]} end, Items)]}). "
     ),
     B0 = #{items => [~"a"]},
     {_HTML, Snap0, V0} = arizona_render:render(Mod:render(B0), #{}),
@@ -4791,7 +4904,7 @@ tracked_get_each_item_ok(Config) when is_list(Config) ->
         "-export([render/1]). "
         "render(Bindings) -> "
         "    arizona_template:html({'ul', [], [arizona_template:each(fun(Item) -> "
-        "        arizona_template:html({'li', [], [arizona_template:get(name, Item)]}) "
+        "        {'li', [], [arizona_template:get(name, Item)]} "
         "    end, arizona_template:get(items, Bindings))]}). "
     ),
     ?assert(is_map(Mod:render(#{items => [#{name => ~"a"}]}))).

--- a/test/arizona_render_SUITE.erl
+++ b/test/arizona_render_SUITE.erl
@@ -47,6 +47,7 @@
     ssr_counter/1,
     ssr_counter_with_bindings/1,
     ssr_each_map/1,
+    nested_each_render/1,
     ssr_layouts_empty_list/1,
     ssr_layouts_nest_outer_first/1,
     ssr_page_with_child/1,
@@ -91,6 +92,7 @@ groups() ->
             ssr_local_app,
             ssr_about_page,
             ssr_each_map,
+            nested_each_render,
             ssr_layouts_nest_outer_first,
             ssr_layouts_empty_list,
             resolve_id_binary,
@@ -351,6 +353,22 @@ ssr_each_map(Config) when is_list(Config) ->
     ?assertNotEqual(nomatch, binary:match(HTML, <<"b<!--/az-->">>)),
     ?assertNotEqual(nomatch, binary:match(HTML, <<"1<!--/az-->">>)),
     ?assertNotEqual(nomatch, binary:match(HTML, <<"2<!--/az-->">>)).
+
+%% each-in-each (arizona_bench_nested_each): an outer ?each over sections, each section
+%% wrapping an inner ?each over its items. Grounds the synthetic nested-fingerprint tests
+%% in a real two-level nested render.
+nested_each_render(Config) when is_list(Config) ->
+    %% Uses the fixture's default 10x10 sections (mount-provided).
+    HTML = iolist_to_binary(
+        arizona_render:render_to_iolist(arizona_bench_nested_each, #{})
+    ),
+    %% Outer each renders section titles; inner each renders each section's items.
+    ?assertNotEqual(nomatch, binary:match(HTML, ~"Section 1")),
+    ?assertNotEqual(nomatch, binary:match(HTML, ~"Section 10")),
+    ?assertNotEqual(nomatch, binary:match(HTML, ~"Item 1-1")),
+    ?assertNotEqual(nomatch, binary:match(HTML, ~"Item 10-10")),
+    ?assertNotEqual(nomatch, binary:match(HTML, ~"class=\"section\"")),
+    ?assertNotEqual(nomatch, binary:match(HTML, ~"<ul")).
 
 %% =============================================================================
 %% 4. resolve_id tests

--- a/test/support/arizona_term_demo.erl
+++ b/test/support/arizona_term_demo.erl
@@ -73,13 +73,13 @@ render(Bindings) ->
                 fun(Draft) -> {line, [yellow], [~"Message: ", Draft]} end,
                 input_rows(?get(mode), ?get(draft))
             ),
+            %% Footer keys are plain text concatenated into one dim line, so a list
+            %% comprehension is the right tool -- ?each is for per-item element diffing.
             {line, [dim], [
-                ?each(
-                    fun({Keys, Label, Sep}) ->
-                        <<"[", Keys/binary, "] ", Label/binary, Sep/binary>>
-                    end,
-                    footer_keys(?get(mode))
-                )
+                [
+                    <<"[", Keys/binary, "] ", Label/binary, Sep/binary>>
+                 || {Keys, Label, Sep} <- footer_keys(?get(mode))
+                ]
             ]}
         ]}
     ).


### PR DESCRIPTION
# Description

Reject non-element `?each` callback bodies at compile time. Such a body collapses to one opaque value slot that loses per-item template diffing, and crashes on the first diff when the value is a template or descriptor. The parse transform now emits a source-tailored error: `each_body_not_element` for a list callback (use a comprehension or `lists:map/2` for plain values) and `each_stream_body_not_element` for a stream or map callback (no comprehension fallback, so wrap the value in an element). Fun-reference callbacks are rejected too, since their return cannot be inspected.

Also adds wire fingerprint-dedup test coverage for nested and component `?each` item templates, exercising the real `arizona_live:dedup_fps` walk (now exported) against complex inner templates across the server diff and client reconstruction.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
