### PR TITLE
Lower minimum OTP version to 28

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ across upgrades.
 
 ## Requirements
 
-- Erlang/OTP 29+
+- Erlang/OTP 28+
 
 ## Installation
 

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{minimum_otp_vsn, "29"}.
+{minimum_otp_vsn, "28"}.
 
 {erl_opts, [debug_info, warnings_as_errors]}.
 


### PR DESCRIPTION
# Description

Lowers `minimum_otp_vsn` from `29` to `28`.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
