### PR TITLE
Drop the version pin from the README install example

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Add Arizona to your `rebar.config` dependencies:
 
 ```erlang
 {deps, [
-    {arizona, "~> 0.1"}
+    arizona
 ]}.
 ```
 


### PR DESCRIPTION
# Description

Uses the unpinned bare `arizona` dep in the README install example so it no longer advertises a stale version (`~> 0.1`).

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
