### PR TITLE
Re-render plain-list ?each fully on change

### DIFF
--- a/src/arizona_diff.erl
+++ b/src/arizona_diff.erl
@@ -20,6 +20,18 @@ op codes:
 ?OP_INSERT, ?OP_REMOVE, ?OP_ITEM_PATCH, ?OP_REPLACE, ?OP_MOVE
 ```
 
+## `?each` list vs. stream diffing
+
+A `?each` over a **plain list** is unkeyed: its items render as bare HTML
+with no `az-key`, so there is no per-item DOM address to patch. Any change
+(item content or list length) therefore re-renders the whole list with a
+single `?OP_UPDATE`; an unchanged list emits nothing.
+
+Use an `arizona_stream` when you need **keyed, incremental** updates --
+per-item `?OP_ITEM_PATCH`/`?OP_INSERT`/`?OP_REMOVE`/`?OP_MOVE` and stable
+item identity (e.g. to preserve a stateful child's state across updates). A
+plain list's full re-render re-mounts any such children.
+
 ## Stream diffing
 
 Streams ship with a queue of pending mutations (`insert`, `delete`,
@@ -452,34 +464,42 @@ diff_list(Az, #{source := Items, template := Tmpl}, #{items := OldItemsList}, Vi
     NewSnap = #{t => ?EACH, items => NewItemsList, template => Tmpl},
     case is_list(OldItemsList) of
         false ->
-            HTML = arizona_render:zip_list_fp(Tmpl, NewItemsList),
-            {[[?OP_UPDATE, Az, HTML]], NewSnap, Views1};
+            full_update(Az, Tmpl, NewItemsList, NewSnap, Views1);
         true ->
-            {Ops, NewTail, OldTail, Views2} =
-                diff_list_zip(Az, NewItemsList, OldItemsList, Views1),
-            case {NewTail, OldTail} of
-                {[], []} ->
-                    {Ops, NewSnap, Views2};
+            {Changed, NewTail, OldTail, Views2} =
+                diff_list_zip(NewItemsList, OldItemsList, Views1),
+            %% Empty tails + nothing changed = an identical list -> no op. Any
+            %% content or length change re-renders the whole list: a plain list
+            %% is unkeyed (no per-item `az-key` to address -- that is what
+            %% `arizona_stream` is for), so the only correct patch is a single
+            %% `?OP_UPDATE` of the container's content.
+            case {Changed, NewTail, OldTail} of
+                {false, [], []} ->
+                    {[], NewSnap, Views2};
                 _ ->
-                    HTML = arizona_render:zip_list_fp(Tmpl, NewItemsList),
-                    {[[?OP_UPDATE, Az, HTML]], NewSnap, Views2}
+                    full_update(Az, Tmpl, NewItemsList, NewSnap, Views2)
             end
     end.
 
-diff_list_zip(Az, [NewD | NR], [OldD | OR], Views0) ->
+full_update(Az, Tmpl, NewItemsList, NewSnap, Views) ->
+    HTML = arizona_render:zip_list_fp(Tmpl, NewItemsList),
+    {[[?OP_UPDATE, Az, HTML]], NewSnap, Views}.
+
+%% Walk new/old item dynamics in lockstep to detect whether any item changed and
+%% to thread child views through. Returns `Changed` plus the leftover tails, so
+%% the caller can also see a length change (a non-empty tail). No per-item ops
+%% are produced -- plain-list updates are a full re-render (see `diff_list/4`).
+diff_list_zip([NewD | NR], [OldD | OR], Views0) ->
     {InnerOps, Views1} = diff_item_dynamics_v(NewD, OldD, Views0),
-    {RestOps, NewTail, OldTail, Views2} = diff_list_zip(Az, NR, OR, Views1),
-    Ops =
+    {RestChanged, NewTail, OldTail, Views2} = diff_list_zip(NR, OR, Views1),
+    Changed =
         case InnerOps of
-            [] ->
-                RestOps;
-            _ ->
-                [{_, OldKey, _} | _] = OldD,
-                [[?OP_ITEM_PATCH, Az, arizona_template:to_bin(OldKey), InnerOps] | RestOps]
+            [] -> RestChanged;
+            _ -> true
         end,
-    {Ops, NewTail, OldTail, Views2};
-diff_list_zip(_Az, NewTail, OldTail, Views) ->
-    {[], NewTail, OldTail, Views}.
+    {Changed, NewTail, OldTail, Views2};
+diff_list_zip(NewTail, OldTail, Views) ->
+    {false, NewTail, OldTail, Views}.
 
 smart_reset_items(_Az, [], _Kept, _OldItems, _ItemsMap, _Tmpl, Views, Snaps) ->
     {[], Snaps, Views};

--- a/test/arizona_SUITE.erl
+++ b/test/arizona_SUITE.erl
@@ -798,7 +798,7 @@ list_render_v(Config) when is_list(Config) ->
     ).
 
 list_diff_same_length(Config) when is_list(Config) ->
-    %% Same count, changed values → OP_ITEM_PATCH ops
+    %% Same count, changed values → single OP_UPDATE (plain lists re-render whole)
     Items1 = [#{id => 1, text => <<"A">>}, #{id => 2, text => <<"B">>}],
     Items2 = [#{id => 1, text => <<"X">>}, #{id => 2, text => <<"B">>}],
     Bindings0 = #{id => <<"test">>, items => Items1},
@@ -839,11 +839,11 @@ list_diff_same_length(Config) when is_list(Config) ->
         f => <<"test">>
     },
     {Ops, _Snap1, _V1} = arizona_diff:diff(Tmpl1, Snap0, V0, Changed),
-    %% Only item 1 changed text from A→X, item 2 unchanged
+    %% Plain lists are unkeyed and re-render whole on any change (keyed
+    %% incremental per-item updates are arizona_stream's job), so a same-length
+    %% content change is a single OP_UPDATE.
     ?assertEqual(1, length(Ops)),
-    [[7, <<"0">>, <<"1">>, InnerOps]] = Ops,
-    %% Inner op should update text of the changed dynamic
-    ?assertEqual(1, length(InnerOps)).
+    [[3, <<"0">>, _HTML]] = Ops.
 
 list_diff_same_length_no_change(Config) when is_list(Config) ->
     %% Same count, same values → no ops

--- a/test/arizona_diff_SUITE.erl
+++ b/test/arizona_diff_SUITE.erl
@@ -15,6 +15,11 @@
     diff_only_changed_emits_ops/1,
     diff_remove_node_op/1,
     diff_replace_with_template_op/1,
+    diff_list_content_change_full_update/1,
+    diff_list_first_item_change_full_update/1,
+    diff_list_grew_full_update/1,
+    diff_list_shrank_full_update/1,
+    diff_list_no_change_no_ops/1,
     diff_text_op/1,
     no_diff_diff3/1,
     no_diff_diff4_top_level/1,
@@ -38,6 +43,11 @@ groups() ->
             diff_mixed_op,
             diff_remove_node_op,
             diff_replace_with_template_op,
+            diff_list_content_change_full_update,
+            diff_list_first_item_change_full_update,
+            diff_list_grew_full_update,
+            diff_list_shrank_full_update,
+            diff_list_no_change_no_ops,
             diff_only_changed_emits_ops,
             diff_bool_attr_add,
             diff_bool_attr_remove,
@@ -235,6 +245,76 @@ diff_replace_with_template_op(Config) when is_list(Config) ->
         ],
         Ops
     ).
+
+%% Plain-list `?each` diffing: any change re-renders the whole list with a
+%% single OP_UPDATE -- never a per-item OP_ITEM_PATCH (plain lists are unkeyed,
+%% so there is no `az-key` to patch). Regression for the "stream item az-key=...
+%% not found for patch" bug. These cover every boolean branch of the diff:
+%%   diff_list_zip:  InnerOps =/= [] (head)  |  RestChanged (tail)  |  neither
+%%   diff_list:      Changed  |  NewTail =/= [] (grew)  |  OldTail =/= [] (shrank)
+
+%% Diff a plain-list `?each` of `Old` vs `New` (items are #{name => Bin}); the
+%% each dynamic depends on `names`, which is marked changed so it isn't skipped.
+each_list_diff(Old, New) ->
+    ItemTmpl = #{
+        t => ?EACH,
+        s => [<<"<li az=\"0\">">>, <<"</li>">>],
+        d => fun(I) -> [{<<"0">>, maps:get(name, I)}] end,
+        f => <<"item">>
+    },
+    {OldItems, _} = arizona_eval:render_list_items(Old, ItemTmpl, {#{}, #{}}),
+    OldSnap = #{
+        s => [<<"<ul az=\"0\">">>, <<"</ul>">>],
+        d => [{<<"0">>, #{t => ?EACH, items => OldItems, template => ItemTmpl}}],
+        deps => [#{names => true}],
+        f => <<"parent">>
+    },
+    NewTmpl = #{
+        s => [<<"<ul az=\"0\">">>, <<"</ul>">>],
+        d => [{<<"0">>, fun() -> arizona_template:each(New, ItemTmpl) end, {m, 1}}],
+        f => <<"parent">>
+    },
+    {Ops, _Snap, _Views} = arizona_diff:diff(NewTmpl, OldSnap, #{}, #{names => true}),
+    Ops.
+
+%% Assert exactly one OP_UPDATE (full re-render), no per-item OP_ITEM_PATCH, and
+%% return the rendered item-dynamics list from the (fingerprinted) payload.
+assert_full_update(Ops) ->
+    ?assertMatch([[?OP_UPDATE, <<"0">>, #{<<"t">> := ?EACH}]], Ops),
+    ?assertEqual([], [Op || Op <- Ops, hd(Op) =:= ?OP_ITEM_PATCH]),
+    [[?OP_UPDATE, <<"0">>, #{<<"d">> := ItemDs}]] = Ops,
+    ItemDs.
+
+%% Last item's content changes: head item unchanged (InnerOps == []) so the
+%% change is detected via RestChanged from the tail.
+diff_list_content_change_full_update(Config) when is_list(Config) ->
+    Ops = each_list_diff([#{name => <<"a">>}, #{name => <<"b">>}], [
+        #{name => <<"a">>}, #{name => <<"B">>}
+    ]),
+    ItemDs = assert_full_update(Ops),
+    ?assertEqual([[<<"a">>], [<<"B">>]], ItemDs).
+
+%% First item's content changes: detected via InnerOps =/= [] on the head.
+diff_list_first_item_change_full_update(Config) when is_list(Config) ->
+    Ops = each_list_diff([#{name => <<"a">>}, #{name => <<"b">>}], [
+        #{name => <<"A">>}, #{name => <<"b">>}
+    ]),
+    ?assertEqual([[<<"A">>], [<<"b">>]], assert_full_update(Ops)).
+
+%% List grew: NewTail =/= [] drives the full update.
+diff_list_grew_full_update(Config) when is_list(Config) ->
+    Ops = each_list_diff([#{name => <<"a">>}], [#{name => <<"a">>}, #{name => <<"b">>}]),
+    ?assertEqual([[<<"a">>], [<<"b">>]], assert_full_update(Ops)).
+
+%% List shrank: OldTail =/= [] drives the full update.
+diff_list_shrank_full_update(Config) when is_list(Config) ->
+    Ops = each_list_diff([#{name => <<"a">>}, #{name => <<"b">>}], [#{name => <<"a">>}]),
+    ?assertEqual([[<<"a">>]], assert_full_update(Ops)).
+
+%% No item changed and same length -> no ops (every boolean false).
+diff_list_no_change_no_ops(Config) when is_list(Config) ->
+    Items = [#{name => <<"a">>}, #{name => <<"b">>}],
+    ?assertEqual([], each_list_diff(Items, Items)).
 
 diff_only_changed_emits_ops(Config) when is_list(Config) ->
     OldSnap = #{


### PR DESCRIPTION
Unkeyed plain-list `?each` items silently stopped updating: the diff emitted per-item `OP_ITEM_PATCH` keyed by the first dynamic, but plain-list items have no `az-key` in the DOM so the client dropped the patch.

Plain lists have no real per-item key, so re-render the whole list with one `OP_UPDATE` on any change. Keyed/incremental updates stay `arizona_stream`'s job (`diff_stream` untouched). Server-only.