### PR TITLE
Add MCP tool-call progress over a streaming POST

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1009,8 +1009,10 @@ the tool/resource/prompt registry, the session lifecycle, and the Origin/auth po
 
 MCP's Streamable HTTP maps onto roadrunner response shapes with no new transport feature:
 
-- **POST** -- the client sends one JSON-RPC message; the handler decodes, dispatches, and returns a
-  buffered `application/json` reply.
+- **POST** -- the client sends one JSON-RPC message. The handler decodes and dispatches; it returns
+  a buffered `application/json` reply, or -- for a `tools/call` carrying a `_meta.progressToken` from
+  a client that accepts `text/event-stream` -- answers as an SSE stream (the tool's
+  `notifications/progress`, then the result, then close).
 - **GET** (session mode) -- opens the long-lived server-to-client SSE channel as
   `{loop, 200, [event-stream headers], State}`; `handle_info/3` forwards server-initiated
   notifications and stops the loop on `{roadrunner_disconnect, _}`.
@@ -1019,6 +1021,16 @@ MCP's Streamable HTTP maps onto roadrunner response shapes with no new transport
 The `{loop, ...}` SSE shape is wired on h1, h2, and h3, so the channel works on all three (h2/h3
 multiplex many sessions over one connection with no head-of-line blocking). Every `Push` flushes one
 frame to the wire with no coalescing, so a `notifications/*` message reaches the agent at emit time.
+
+### Progress streaming
+
+When a token-bearing `tools/call` streams (the client accepted SSE), the tool runs off the connection
+process so the loop is free to push its progress as it arrives. In **stateless** mode a worker
+process runs the tool; in **session** mode the session process runs it (state still threads back).
+Either way the tool emits via the `Ctx`
+handed to `handle_tool/4` -- `arizona_mcp:progress/2,3` relays each `notifications/progress` to the
+POST's loop, which frames and pushes it; the final result is the last frame, then the loop stops.
+The context is inert (a no-op) for a non-streaming call, so a tool can always call `progress/2,3`.
 
 ### Stateless vs session mode
 

--- a/src/arizona_mcp.erl
+++ b/src/arizona_mcp.erl
@@ -35,7 +35,7 @@ callbacks. Tools are always available (their callbacks are required).
 
 ## Tool results vs protocol errors
 
-`handle_tool/3` distinguishes two failure kinds, matching the MCP spec:
+`handle_tool/4` distinguishes two failure kinds, matching the MCP spec:
 
 - `{reply, Result, State}` -- the tool succeeded; `Result` becomes a
   `tools/call` result with `isError: false`.
@@ -46,11 +46,26 @@ callbacks. Tools are always available (their callbacks are required).
 
 A protocol-level fault (unknown method, unknown tool name, malformed
 params) is the transport's concern and surfaces as a JSON-RPC error,
-never reaching `handle_tool/3`.
+never reaching `handle_tool/4`.
+
+## Progress
+
+A `tools/call` may carry a `_meta.progressToken`; when it does, the tool can
+stream `notifications/progress` to the client while it runs, before the final
+result. `handle_tool/4`'s third argument is a progress context: call
+`progress/2,3` with it to emit a progress update. When the client sent no
+token (or in any non-streaming call) the context is inert and `progress/2,3`
+is a no-op, so a tool can always call it unconditionally.
+
+Streaming is automatic and transport-owned: a token-bearing `tools/call` from a
+client that accepts `text/event-stream` answers its POST as an SSE stream (the
+progress notifications, then the result, then close) instead of a buffered JSON
+body. A client that does not accept SSE gets the buffered reply and the progress
+is dropped. The tool just emits; it does not choose the transport.
 
 ## State
 
-`init/1` is the state constructor; `handle_tool/3`, `read_resource/2`, and
+`init/1` is the state constructor; `handle_tool/4`, `read_resource/2`, and
 `get_prompt/3` each return a new state alongside their result.
 
 In **session** mode (a route with `sessions => true`) `init/1` runs once on
@@ -108,13 +123,17 @@ the official MCP SDK client.
 
 -export([broadcast/3]).
 -export([notify/3]).
+-export([progress/2]).
+-export([progress/3]).
 
 %% --------------------------------------------------------------------
 %% Ignore xref warnings
 %% --------------------------------------------------------------------
 
-%% The server-push API is called by applications, not from within arizona.
+%% The server-push and progress APIs are called by applications, not from
+%% within arizona.
 -ignore_xref([broadcast/3, notify/3]).
+-ignore_xref([progress/2, progress/3]).
 
 %% --------------------------------------------------------------------
 %% Types exports
@@ -125,6 +144,8 @@ the official MCP SDK client.
 -export_type([server_info/0]).
 -export_type([capabilities/0]).
 -export_type([state/0]).
+-export_type([progress_ctx/0]).
+-export_type([progress_opts/0]).
 -export_type([tool/0]).
 -export_type([content_block/0]).
 -export_type([tool_result/0]).
@@ -155,6 +176,19 @@ the official MCP SDK client.
 -nominal capabilities() :: map().
 
 -nominal state() :: term().
+
+%% Opaque to the app: a streaming `tools/call`'s context carries the client's
+%% progress token and the connection to emit on; an inert context (`token` is
+%% `undefined`) makes `progress/2,3` a no-op for non-streaming calls.
+-nominal progress_ctx() :: #{
+    token := binary() | integer() | undefined,
+    to := pid() | undefined
+}.
+
+-nominal progress_opts() :: #{
+    total => number(),
+    message => binary()
+}.
 
 -nominal tool() :: #{
     name := binary(),
@@ -235,10 +269,14 @@ capability name, so a binary-keyed capability would never be served.
 
 -doc """
 Run one `tools/call`, dispatched by tool name. `Args` is the decoded
-`arguments` object. Return `{reply, Result, State}` on success or
-`{error, ToolError, State}` for an in-band tool failure.
+`arguments` object. `Ctx` is the progress context: pass it to `progress/2,3`
+to stream `notifications/progress` while the tool runs (a no-op when the
+client sent no `_meta.progressToken`). Return `{reply, Result, State}` on
+success or `{error, ToolError, State}` for an in-band tool failure.
 """.
--callback handle_tool(Name :: binary(), Args :: map(), State :: state()) ->
+-callback handle_tool(
+    Name :: binary(), Args :: map(), Ctx :: progress_ctx(), State :: state()
+) ->
     {reply, tool_result(), state()}
     | {error, tool_error(), state()}.
 
@@ -325,4 +363,41 @@ notify(SessionId, Method, Params) ->
     case arizona_mcp_session_registry:lookup(SessionId) of
         {ok, Pid} -> arizona_mcp_session:notify(Pid, Method, Params);
         error -> ok
+    end.
+
+-doc """
+Emit a `notifications/progress` update from a running `tools/call`, using the
+`Ctx` handed to `handle_tool/4`. `Progress` is the amount done so far. A no-op
+when the client sent no `_meta.progressToken` (the context is inert), so a tool
+can call it unconditionally.
+""".
+-spec progress(Ctx, Progress) -> ok when
+    Ctx :: progress_ctx(),
+    Progress :: number().
+progress(Ctx, Progress) ->
+    progress(Ctx, Progress, #{}).
+
+-doc """
+Emit a `notifications/progress` update with extras. `Opts` may carry `total`
+(the expected final amount) and `message` (a human-readable status). A no-op
+when the context is inert.
+""".
+-spec progress(Ctx, Progress, Opts) -> ok when
+    Ctx :: progress_ctx(),
+    Progress :: number(),
+    Opts :: progress_opts().
+progress(#{token := undefined}, _Progress, _Opts) ->
+    ok;
+progress(#{token := Token, to := To}, Progress, Opts) ->
+    Params0 = #{~"progressToken" => Token, ~"progress" => Progress},
+    Params1 = maybe_put_opt(~"total", total, Opts, Params0),
+    Params = maybe_put_opt(~"message", message, Opts, Params1),
+    To ! {mcp_progress, arizona_jsonrpc:notification(~"notifications/progress", Params)},
+    ok.
+
+%% Copy an optional progress field onto the params under its wire name.
+maybe_put_opt(WireKey, OptKey, Opts, Params) ->
+    case Opts of
+        #{OptKey := Value} -> Params#{WireKey => Value};
+        _ -> Params
     end.

--- a/src/arizona_mcp_handler.erl
+++ b/src/arizona_mcp_handler.erl
@@ -27,6 +27,7 @@ protocol contract holds even when a tool raises.
 -export([handle_info/3]).
 -export([dispatch/3]).
 -export([handle_method/4]).
+-export([run_streaming_tool/6]).
 
 %% --------------------------------------------------------------------
 %% Types exports
@@ -149,23 +150,41 @@ method_not_allowed(Opts) ->
     roadrunner_resp:add_header(roadrunner_resp:status(405), ~"allow", Allow).
 
 -doc """
-Roadrunner loop `handle_info/3` callback for the GET SSE channel. Forwards
-server-initiated events from the session to the wire; on client disconnect
-it detaches the channel from the session (which keeps the session alive) and
-stops the loop.
+Roadrunner loop `handle_info/3` callback for the two SSE loops:
+
+- the **GET channel** (`#{session := Pid}`) -- forwards server-initiated events
+  from the session; on client disconnect it detaches from the session (which
+  keeps the session alive) and stops.
+- the **streaming POST** (`#{mcp_post_stream := true}`) -- pushes the running
+  tool's `notifications/progress` as they arrive, then the final result, then
+  stops; a client disconnect just stops the loop.
 """.
 -spec handle_info(Info, Push, State) -> {ok, State} | {stop, State} when
     Info :: term(),
     Push :: roadrunner_handler:push_fun(),
-    State :: #{session := pid()}.
+    State :: #{session := pid()} | #{mcp_post_stream := true}.
 handle_info({mcp_event, Frame}, Push, State) ->
     _ = Push(Frame),
     {ok, State};
+handle_info({mcp_progress, Notification}, Push, State) ->
+    _ = Push(message_frame(Notification)),
+    {ok, State};
+handle_info({mcp_result, Object}, Push, State) ->
+    _ = Push(message_frame(Object)),
+    {stop, State};
 handle_info({roadrunner_disconnect, _Reason}, _Push, #{session := SessionPid} = State) ->
     ok = arizona_mcp_session:detach_channel(SessionPid, self()),
     {stop, State};
+handle_info({roadrunner_disconnect, _Reason}, _Push, #{mcp_post_stream := true} = State) ->
+    {stop, State};
 handle_info(_Info, _Push, State) ->
     {ok, State}.
+
+%% A JSON-RPC message (a progress notification or the final result) framed as a
+%% single SSE `message` event. The streaming POST is request-scoped, so -- unlike
+%% the resumable GET channel -- the events carry no id.
+message_frame(Object) ->
+    roadrunner_sse:event(~"message", iolist_to_binary(json:encode(Object))).
 
 -doc """
 Pure MCP method dispatch. Maps a decoded JSON-RPC request and the app's
@@ -231,9 +250,62 @@ initialize_result(ServerInfo, Caps, Params) ->
 
 handle_post(Req, Opts) ->
     Body = iolist_to_binary(roadrunner_req:body(Req)),
+    case arizona_jsonrpc:decode(Body) of
+        {error, parse_error} ->
+            json(arizona_jsonrpc:error(null, -32700, ~"Parse error"));
+        {error, invalid_request} ->
+            json(arizona_jsonrpc:error(null, -32600, ~"Invalid Request"));
+        {ok, Request} ->
+            serve_request(Request, Req, Opts)
+    end.
+
+%% A `tools/call` carrying a `_meta.progressToken` streams its POST as SSE (the
+%% progress notifications, then the result, then close) -- but only when the
+%% client accepts `text/event-stream`, the Streamable HTTP precondition for an
+%% SSE response. Everything else (and a token-bearing call from a client that
+%% does not accept SSE) is a buffered JSON reply. The streaming decision owns the
+%% response *shape*, so it is made here before the buffered dispatch.
+serve_request(Request, Req, Opts) ->
+    case streaming_progress(Request) of
+        {stream, Call} ->
+            case accepts_sse(Req) of
+                true -> serve_streaming(Call, Req, Opts);
+                false -> serve_buffered(Request, Req, Opts)
+            end;
+        none ->
+            serve_buffered(Request, Req, Opts)
+    end.
+
+%% The client opts into a streamed response by listing `text/event-stream` in
+%% its `Accept`. Absent it, the server must answer with a buffered body.
+accepts_sse(Req) ->
+    case roadrunner_req:header(~"accept", Req) of
+        undefined -> false;
+        Accept -> binary:match(Accept, ~"text/event-stream") =/= nomatch
+    end.
+
+%% Recognise a well-formed token-bearing `tools/call`. A missing/non-binary
+%% name or absent token falls through to the buffered path (which produces the
+%% matching error); declared-ness is checked later, where the handler module is
+%% in hand.
+streaming_progress(#{method := ~"tools/call", id := Id, params := Params}) when
+    Id =/= undefined
+->
+    case Params of
+        #{~"name" := Name, ~"_meta" := #{~"progressToken" := Token}} when is_binary(Name) ->
+            {stream, #{
+                name => Name, args => maps:get(~"arguments", Params, #{}), token => Token, id => Id
+            }};
+        _ ->
+            none
+    end;
+streaming_progress(_Request) ->
+    none.
+
+serve_buffered(Request, Req, Opts) ->
     case sessions_enabled(Opts) of
-        false -> reply_stateless(Body, Opts);
-        true -> reply_session(Body, Req, Opts)
+        false -> reply_stateless(Request, Opts);
+        true -> reply_session(Request, Req, Opts)
     end.
 
 %% A present `Origin` must be in the allowlist; an absent one is allowed
@@ -251,33 +323,18 @@ check_origin(Req, Opts) ->
             end
     end.
 
-%% Stateless mode: every request is self-contained -- decode, dispatch
-%% against a fresh per-request session, encode. No `Mcp-Session-Id`.
-reply_stateless(Body, Opts) ->
-    case arizona_jsonrpc:decode(Body) of
-        {error, parse_error} ->
-            json(arizona_jsonrpc:error(null, -32700, ~"Parse error"));
-        {error, invalid_request} ->
-            json(arizona_jsonrpc:error(null, -32600, ~"Invalid Request"));
-        {ok, Request} ->
-            #{handler := Mod} = Opts,
-            reply_dispatch(Mod, Request)
-    end.
+%% Stateless mode: every request is self-contained -- dispatch against a fresh
+%% per-request session, encode. No `Mcp-Session-Id`.
+reply_stateless(Request, #{handler := Mod}) ->
+    reply_dispatch(Mod, Request).
 
 %% Session mode: `initialize` opens a session and returns its id; every
 %% other request is routed to the session named by `Mcp-Session-Id`.
-reply_session(Body, Req, Opts) ->
-    case arizona_jsonrpc:decode(Body) of
-        {error, parse_error} ->
-            json(arizona_jsonrpc:error(null, -32700, ~"Parse error"));
-        {error, invalid_request} ->
-            json(arizona_jsonrpc:error(null, -32600, ~"Invalid Request"));
-        {ok, #{method := Method, params := Params, id := Id} = Request} ->
-            case Id of
-                undefined -> roadrunner_resp:status(202);
-                _ when Method =:= ~"initialize" -> session_initialize(Params, Id, Opts);
-                _ -> session_request(Method, Params, Id, Request, Req)
-            end
+reply_session(#{method := Method, params := Params, id := Id} = Request, Req, Opts) ->
+    case Id of
+        undefined -> roadrunner_resp:status(202);
+        _ when Method =:= ~"initialize" -> session_initialize(Params, Id, Opts);
+        _ -> session_request(Method, Params, Id, Request, Req)
     end.
 
 session_initialize(Params, Id, #{handler := Mod} = Opts) ->
@@ -314,14 +371,14 @@ session_request(Method, Params, Id, Request, Req) ->
                     {_Tag, Object} = arizona_mcp_session:dispatch(Pid, Method, Params, Id),
                     json(Object)
                 end,
-                %% Unknown or expired session: the client should re-initialize.
-                fun() ->
-                    roadrunner_resp:json(
-                        404, arizona_jsonrpc:error(Id, -32600, ~"Unknown or expired session")
-                    )
-                end
+                fun() -> unknown_session(Id) end
             )
     end.
+
+%% The 404 a session-scoped request gets when its `Mcp-Session-Id` names no live
+%% session -- the client should re-initialize.
+unknown_session(Id) ->
+    roadrunner_resp:json(404, arizona_jsonrpc:error(Id, -32600, ~"Unknown or expired session")).
 
 handle_delete(Req) ->
     case roadrunner_req:header(~"mcp-session-id", Req) of
@@ -375,14 +432,103 @@ with_session(SessionId, Found, NotFound) ->
 attach_or_reject(Pid, LastEventId) ->
     case arizona_mcp_session:attach_channel(Pid, self(), LastEventId) of
         ok ->
-            Headers = [
-                {~"content-type", ~"text/event-stream"},
-                {~"cache-control", ~"no-cache"}
-            ],
-            {loop, 200, Headers, #{session => Pid}};
+            {loop, 200, sse_headers(), #{session => Pid}};
         {error, already_attached} ->
             roadrunner_resp:status(409)
     end.
+
+sse_headers() ->
+    [
+        {~"content-type", ~"text/event-stream"},
+        {~"cache-control", ~"no-cache"}
+    ].
+
+%% Stream a token-bearing `tools/call` over its POST as SSE. The tool runs off
+%% this connection process (a worker in stateless mode, the session process in
+%% session mode); it relays `notifications/progress` and the final result back
+%% as messages, which the loop's `handle_info/3` pushes -- progress events
+%% first, then the result, then stop.
+serve_streaming(#{name := Name, args := Args, token := Token, id := Id}, Req, Opts) ->
+    ConnPid = self(),
+    case sessions_enabled(Opts) of
+        false ->
+            #{handler := Mod} = Opts,
+            %% Stateless: a fresh per-request session; its threaded-back state
+            %% is per-request and discarded. The worker frees the loop to push.
+            {_ServerInfo, Session} = open_session(Mod, #{}),
+            Ctx = #{token => Token, to => ConnPid},
+            _Worker = spawn(fun() ->
+                _Session1 = run_streaming_tool(Session, Name, Args, Id, Ctx, ConnPid)
+            end),
+            stream_loop();
+        true ->
+            case roadrunner_req:header(~"mcp-session-id", Req) of
+                undefined ->
+                    json(arizona_jsonrpc:error(Id, -32600, ~"Missing Mcp-Session-Id"));
+                SessionId ->
+                    with_session(
+                        SessionId,
+                        fun(Pid) ->
+                            ok = arizona_mcp_session:run_streaming_tool(
+                                Pid, Name, Args, Id, Token, ConnPid
+                            ),
+                            stream_loop()
+                        end,
+                        fun() -> unknown_session(Id) end
+                    )
+            end
+    end.
+
+%% The streaming-POST loop: a request-scoped stream (no resumability), tagged so
+%% `handle_info/3` distinguishes it from the GET channel.
+stream_loop() ->
+    {loop, 200, sse_headers(), #{mcp_post_stream => true}}.
+
+-doc """
+Run a streaming `tools/call` against `Session`, relaying the result (and, via
+`Ctx`, any `notifications/progress`) to `ConnPid`, and return the session
+carrying the tool's threaded-back state. Shared by the stateless worker and the
+session process; exported for the latter's cross-module call.
+""".
+-spec run_streaming_tool(Session, Name, Args, Id, Ctx, ConnPid) -> Session when
+    Session :: session(),
+    Name :: binary(),
+    Args :: map(),
+    Id :: arizona_jsonrpc:id(),
+    Ctx :: arizona_mcp:progress_ctx(),
+    ConnPid :: pid().
+run_streaming_tool(#{state := State} = Session, Name, Args, Id, Ctx, ConnPid) ->
+    %% Guard the whole run (the `tools/1` read included), since the session
+    %% process calls this in `handle_cast`: a crash must answer -32603 and leave
+    %% the prior state intact, never kill the session.
+    {Object, NewState} =
+        try
+            run_tool(Session, Name, Args, Id, Ctx)
+        catch
+            Class:Reason:Stacktrace ->
+                logger:error(
+                    "MCP streaming tool crashed: ~ts:~tp~n~tp", [Class, Reason, Stacktrace]
+                ),
+                {arizona_jsonrpc:error(Id, -32603, ~"Internal error"), State}
+        end,
+    ConnPid ! {mcp_result, Object},
+    Session#{state := NewState}.
+
+%% Validate the tool name, run it, and shape the outcome into a
+%% `{ResultObject, NewState}` pair. Unknown name -> a -32602 result with the
+%% prior state; a declared tool -> its result and threaded-back state.
+run_tool(#{mod := Mod, state := State}, Name, Args, Id, Ctx) ->
+    case lists:member(Name, [N || #{name := N} <- Mod:tools(State)]) of
+        false ->
+            {arizona_jsonrpc:error(Id, -32602, <<"Unknown tool: ", Name/binary>>), State};
+        true ->
+            stream_tool_outcome(Mod:handle_tool(Name, Args, Ctx, State), Id)
+    end.
+
+stream_tool_outcome({reply, Result, NewState}, Id) ->
+    {arizona_jsonrpc:result(Id, tool_content(Result, false)), NewState};
+stream_tool_outcome({error, ToolError, NewState}, Id) ->
+    {arizona_jsonrpc:result(Id, tool_content(ToolError, true)), NewState}.
 
 %% A URL-safe, unguessable session id: 128 bits of CSPRNG output as hex.
 generate_session_id() ->
@@ -494,9 +640,15 @@ call_tool(Params, Id, #{mod := Mod, state := State} = Session) ->
         fun(Name) -> arizona_jsonrpc:error(Id, -32602, <<"Unknown tool: ", Name/binary>>) end,
         fun(Name) ->
             Args = maps:get(~"arguments", Params, #{}),
-            tool_reply(Mod:handle_tool(Name, Args, State), Id, Session)
+            tool_reply(Mod:handle_tool(Name, Args, inert_ctx(), State), Id, Session)
         end
     ).
+
+%% The progress context for a buffered (non-streaming) `tools/call`: inert, so
+%% `arizona_mcp:progress/2,3` is a no-op. Streaming calls build a live context
+%% in `serve_streaming/3` instead.
+inert_ctx() ->
+    #{token => undefined, to => undefined}.
 
 read_resource(Params, Id, #{mod := Mod, state := State} = Session) ->
     with_member(

--- a/src/arizona_mcp_session.erl
+++ b/src/arizona_mcp_session.erl
@@ -24,6 +24,7 @@ sends `DELETE`) does not leak; every served request resets it.
 
 -export([start_link/3]).
 -export([dispatch/4]).
+-export([run_streaming_tool/6]).
 -export([attach_channel/3]).
 -export([detach_channel/2]).
 -export([notify/3]).
@@ -105,6 +106,22 @@ dispatch(Pid, Method, Params, Id) ->
     %% connection is already dedicated to this one request. (Bounding this and
     %% cancelling on client disconnect is a later-phase hardening.)
     gen_server:call(Pid, {dispatch, Method, Params, Id}, infinity).
+
+-doc """
+Run a streaming `tools/call` against the session's state, relaying the result
+and any `notifications/progress` to `ConnPid` (the POST's loop process). Async
+(a cast) so `ConnPid` is free to push the relayed frames while the tool runs;
+the tool's returned state threads back into the session.
+""".
+-spec run_streaming_tool(Pid, Name, Args, Id, Token, ConnPid) -> ok when
+    Pid :: pid(),
+    Name :: binary(),
+    Args :: map(),
+    Id :: arizona_jsonrpc:id(),
+    Token :: binary() | integer(),
+    ConnPid :: pid().
+run_streaming_tool(Pid, Name, Args, Id, Token, ConnPid) ->
+    gen_server:cast(Pid, {run_streaming_tool, Name, Args, Id, Token, ConnPid}).
 
 -doc """
 Attach a server-to-client SSE channel (a roadrunner loop process) to the
@@ -198,6 +215,16 @@ handle_cast({detach_channel, ChannelPid}, #state{channel = ChannelPid} = State) 
     {noreply, do_detach(State)};
 handle_cast({notify, Method, Params}, State) ->
     {noreply, emit(Method, Params, State)};
+handle_cast(
+    {run_streaming_tool, Name, Args, Id, Token, ConnPid}, #state{session = Session} = State
+) ->
+    %% Run the tool here (serialized, state threads back) while `ConnPid` pushes
+    %% the relayed progress + result. The context's `to` is the POST loop, so
+    %% `arizona_mcp:progress/2,3` reaches the client's stream, not this session's
+    %% channel.
+    Ctx = #{token => Token, to => ConnPid},
+    Session1 = arizona_mcp_handler:run_streaming_tool(Session, Name, Args, Id, Ctx, ConnPid),
+    {noreply, refresh_ttl(State#state{session = Session1})};
 handle_cast(_Msg, State) ->
     {noreply, State}.
 

--- a/test/arizona_mcp_SUITE.erl
+++ b/test/arizona_mcp_SUITE.erl
@@ -11,6 +11,12 @@
     dispatch_tools_call_structured/1,
     dispatch_tools_call_tool_error/1,
     dispatch_tools_call_stateless_no_accumulate/1,
+    streaming_tool_relays_progress/1,
+    streaming_tool_unknown/1,
+    streaming_tool_crash/1,
+    progress_no_opts/1,
+    progress_with_opts/1,
+    progress_inert_noop/1,
     dispatch_tools_call_unknown_tool/1,
     dispatch_tools_call_missing_name/1,
     dispatch_unknown_method/1,
@@ -55,6 +61,12 @@ all() ->
         dispatch_tools_call_structured,
         dispatch_tools_call_tool_error,
         dispatch_tools_call_stateless_no_accumulate,
+        streaming_tool_relays_progress,
+        streaming_tool_unknown,
+        streaming_tool_crash,
+        progress_no_opts,
+        progress_with_opts,
+        progress_inert_noop,
         dispatch_tools_call_unknown_tool,
         dispatch_tools_call_missing_name,
         dispatch_unknown_method,
@@ -115,7 +127,8 @@ dispatch_ping(_Config) ->
 dispatch_tools_list(_Config) ->
     {reply, #{~"result" := #{~"tools" := Tools}}} = dispatch(~"tools/list", #{}, 3),
     ?assertEqual(
-        [~"add", ~"boom", ~"crash", ~"echo", ~"count"], [maps:get(~"name", T) || T <- Tools]
+        [~"add", ~"boom", ~"crash", ~"echo", ~"count", ~"progress"],
+        [maps:get(~"name", T) || T <- Tools]
     ),
     [Add | _] = Tools,
     %% input_schema is renamed to the wire's inputSchema.
@@ -159,6 +172,54 @@ dispatch_tools_call_stateless_no_accumulate(_Config) ->
     Params = #{~"name" => ~"count", ~"arguments" => #{}},
     ?assertEqual(~"1", stateless_count(Params, 40)),
     ?assertEqual(~"1", stateless_count(Params, 41)).
+
+%% run_streaming_tool/6 relays each progress notification, then the final
+%% result, to the conn pid (here, the test process).
+streaming_tool_relays_progress(_Config) ->
+    Ctx = #{token => ~"t", to => self()},
+    _Session1 = arizona_mcp_handler:run_streaming_tool(session(), ~"progress", #{}, 1, Ctx, self()),
+    ?assertEqual(1, recv_progress()),
+    ?assertEqual(2, recv_progress()),
+    ?assertMatch(
+        #{~"result" := #{~"content" := [#{~"text" := ~"done"}], ~"isError" := false}},
+        recv_result()
+    ).
+
+%% An unknown tool name in a streaming call relays a -32602 result, no crash.
+streaming_tool_unknown(_Config) ->
+    Ctx = #{token => ~"t", to => self()},
+    _Session1 = arizona_mcp_handler:run_streaming_tool(session(), ~"nope", #{}, 1, Ctx, self()),
+    ?assertMatch(#{~"error" := #{~"code" := -32602}}, recv_result()).
+
+%% A crashing tool in a streaming call relays a -32603 result, no crash.
+streaming_tool_crash(_Config) ->
+    Ctx = #{token => ~"t", to => self()},
+    _Session1 = arizona_mcp_handler:run_streaming_tool(session(), ~"crash", #{}, 1, Ctx, self()),
+    ?assertMatch(#{~"error" := #{~"code" := -32603}}, recv_result()).
+
+%% progress/2 (no opts): just the token + amount, no total/message.
+progress_no_opts(_Config) ->
+    ok = arizona_mcp:progress(#{token => ~"t", to => self()}, 7),
+    #{~"method" := ~"notifications/progress", ~"params" := Params} = recv_progress_notification(),
+    ?assertEqual(#{~"progressToken" => ~"t", ~"progress" => 7}, Params).
+
+%% progress/3 with opts: total + message ride along; an integer token is fine.
+progress_with_opts(_Config) ->
+    ok = arizona_mcp:progress(#{token => 9, to => self()}, 3, #{total => 5, message => ~"go"}),
+    #{~"params" := Params} = recv_progress_notification(),
+    ?assertEqual(
+        #{~"progressToken" => 9, ~"progress" => 3, ~"total" => 5, ~"message" => ~"go"}, Params
+    ).
+
+%% An inert context (no client token) makes both arities a no-op: nothing sent.
+progress_inert_noop(_Config) ->
+    Inert = #{token => undefined, to => undefined},
+    ok = arizona_mcp:progress(Inert, 1),
+    ok = arizona_mcp:progress(Inert, 1, #{total => 2}),
+    receive
+        {mcp_progress, _} -> ct:fail(unexpected_progress)
+    after 50 -> ok
+    end.
 
 dispatch_tools_call_unknown_tool(_Config) ->
     Params = #{~"name" => ~"nope", ~"arguments" => #{}},
@@ -343,6 +404,31 @@ stateless_count(Params, Id) ->
     {reply, #{~"result" := #{~"content" := [#{~"text" := Text}]}}} =
         dispatch(~"tools/call", Params, Id),
     Text.
+
+%% A session map for the test server, as the transport builds at initialize.
+session() ->
+    #{mod => ?SERVER, state => #{}, caps => #{tools => #{}, resources => #{}, prompts => #{}}}.
+
+%% Receive one relayed progress notification, returning its `progress` amount.
+recv_progress() ->
+    receive
+        {mcp_progress, #{~"params" := #{~"progress" := Progress}}} -> Progress
+    after 5000 -> ct:fail(no_progress)
+    end.
+
+%% Receive the relayed final result object.
+recv_result() ->
+    receive
+        {mcp_result, Object} -> Object
+    after 5000 -> ct:fail(no_result)
+    end.
+
+%% Receive one relayed progress notification (the whole JSON-RPC object).
+recv_progress_notification() ->
+    receive
+        {mcp_progress, Notification} -> Notification
+    after 5000 -> ct:fail(no_progress)
+    end.
 
 dispatch_on(Mod, Method, Params, Id) ->
     Request = #{method => Method, params => Params, id => Id},

--- a/test/arizona_mcp_e2e_SUITE.erl
+++ b/test/arizona_mcp_e2e_SUITE.erl
@@ -7,6 +7,8 @@
     post_initialize/1,
     post_tools_list/1,
     post_tools_call/1,
+    post_streaming_progress/1,
+    post_progress_without_accept_buffered/1,
     post_resources_read/1,
     post_prompts_get/1,
     get_returns_405/1,
@@ -23,6 +25,7 @@
     session_second_channel_409/1,
     session_survives_channel_disconnect/1,
     session_resumes_with_last_event_id/1,
+    session_streaming_progress/1,
     auth_missing_token_401/1,
     auth_valid_token_ok/1,
     session_init_crash_internal_error/1
@@ -36,6 +39,8 @@ all() ->
         post_initialize,
         post_tools_list,
         post_tools_call,
+        post_streaming_progress,
+        post_progress_without_accept_buffered,
         post_resources_read,
         post_prompts_get,
         get_returns_405,
@@ -52,6 +57,7 @@ all() ->
         session_second_channel_409,
         session_survives_channel_disconnect,
         session_resumes_with_last_event_id,
+        session_streaming_progress,
         auth_missing_token_401,
         auth_valid_token_ok,
         session_init_crash_internal_error
@@ -138,6 +144,44 @@ post_tools_call(Config) ->
     #{~"result" := Result} = body_json(Resp),
     ?assertEqual(
         #{~"content" => [#{~"type" => ~"text", ~"text" => ~"5"}], ~"isError" => false},
+        Result
+    ).
+
+post_streaming_progress(Config) ->
+    %% A token-bearing tools/call answers its POST as an SSE stream: the
+    %% progress notifications (carrying the client's token) arrive before the
+    %% result. Stateless mode runs the tool in a conn-side worker.
+    Body =
+        ~"""
+    {"jsonrpc":"2.0","id":8,"method":"tools/call",
+     "params":{"name":"progress","arguments":{},"_meta":{"progressToken":"tok-1"}}}
+    """,
+    Data = post_stream_until(Config, "/mcp", [], Body, ~"\"done\""),
+    ?assertNotEqual(nomatch, binary:match(Data, ~"text/event-stream")),
+    ?assertNotEqual(nomatch, binary:match(Data, ~"notifications/progress")),
+    ?assertNotEqual(nomatch, binary:match(Data, ~"\"progressToken\":\"tok-1\"")),
+    ?assertNotEqual(nomatch, binary:match(Data, ~"step 1")),
+    ?assertNotEqual(nomatch, binary:match(Data, ~"step 2")),
+    %% The progress events precede the final result on the wire.
+    {Step1, _} = binary:match(Data, ~"step 1"),
+    {Done, _} = binary:match(Data, ~"\"done\""),
+    ?assert(Step1 < Done).
+
+post_progress_without_accept_buffered(Config) ->
+    %% A token-bearing tools/call from a client that does NOT accept SSE (no
+    %% `Accept: text/event-stream`) falls back to a buffered JSON reply: the tool
+    %% still runs, the progress notifications are simply dropped.
+    Body =
+        ~"""
+    {"jsonrpc":"2.0","id":10,"method":"tools/call",
+     "params":{"name":"progress","arguments":{},"_meta":{"progressToken":"tok-2"}}}
+    """,
+    Resp = post(Config, "/mcp", [], Body),
+    ?assertEqual(200, status_code(Resp)),
+    ?assertNotEqual(nomatch, binary:match(headers(Resp), ~"application/json")),
+    #{~"result" := Result} = body_json(Resp),
+    ?assertEqual(
+        #{~"content" => [#{~"type" => ~"text", ~"text" => ~"done"}], ~"isError" => false},
         Result
     ).
 
@@ -298,6 +342,21 @@ session_resumes_with_last_event_id(Config) ->
     gen_tcp:close(Sock),
     ?assertNotEqual(nomatch, binary:match(Data, ~"\"seq\":2")).
 
+session_streaming_progress(Config) ->
+    %% Same streaming contract in session mode -- the session runs the tool and
+    %% relays progress + result to the POST's stream. Uses an integer token.
+    SessionId = open_session(Config),
+    Body =
+        ~"""
+    {"jsonrpc":"2.0","id":9,"method":"tools/call",
+     "params":{"name":"progress","arguments":{},"_meta":{"progressToken":42}}}
+    """,
+    Data = post_stream_until(Config, "/mcp-session", session_header(SessionId), Body, ~"\"done\""),
+    ?assertNotEqual(nomatch, binary:match(Data, ~"text/event-stream")),
+    ?assertNotEqual(nomatch, binary:match(Data, ~"notifications/progress")),
+    ?assertNotEqual(nomatch, binary:match(Data, ~"\"progressToken\":42")),
+    ?assertNotEqual(nomatch, binary:match(Data, ~"\"done\"")).
+
 %% --------------------------------------------------------------------
 %% Auth-gated tests (/mcp-auth, auth => bearer hook)
 %% --------------------------------------------------------------------
@@ -357,6 +416,34 @@ send_channel_get(Config, SessionId, ExtraHeaders) ->
     ],
     ok = gen_tcp:send(Sock, Req),
     Sock.
+
+%% Send a POST and read its streamed (SSE) response until `Needle` appears. The
+%% response has no Content-Length (it is chunked), so the buffered `recv_response`
+%% does not apply.
+post_stream_until(Config, Path, ExtraHeaders, Body, Needle) ->
+    Port = ?config(port, Config),
+    {ok, Sock} = gen_tcp:connect("localhost", Port, [binary, {active, false}]),
+    Req = [
+        "POST ",
+        Path,
+        " HTTP/1.1\r\n",
+        "Host: localhost:",
+        integer_to_list(Port),
+        "\r\n",
+        "Content-Type: application/json\r\n",
+        %% The Streamable HTTP precondition for an SSE response.
+        "Accept: application/json, text/event-stream\r\n",
+        "Content-Length: ",
+        integer_to_list(byte_size(Body)),
+        "\r\n",
+        ExtraHeaders,
+        "\r\n",
+        Body
+    ],
+    ok = gen_tcp:send(Sock, Req),
+    Data = recv_until(Sock, Needle, 5000),
+    gen_tcp:close(Sock),
+    Data.
 
 %% Accumulate socket data until `Needle` appears or time runs out.
 recv_until(Sock, Needle, Timeout) ->

--- a/test/conformance/mcp_client.mjs
+++ b/test/conformance/mcp_client.mjs
@@ -47,6 +47,18 @@ try {
   check("tools/call add => '5'", call.content?.[0]?.text === '5');
   check('tools/call isError false', call.isError === false);
 
+  // A token-bearing tools/call streams notifications/progress before the
+  // result. Passing onProgress makes the SDK attach a progressToken and the
+  // server answer over SSE; the callback fires per progress notification.
+  const seen = [];
+  const streamed = await client.callTool(
+    { name: 'progress', arguments: {} },
+    undefined,
+    { onprogress: (p) => seen.push(p.progress) },
+  );
+  check('tools/call progress streamed', seen.length >= 1);
+  check("tools/call streamed result => 'done'", streamed.content?.[0]?.text === 'done');
+
   const resources = await client.listResources();
   check(
     'resources/list has mem://greeting',

--- a/test/support/arizona_mcp_crashing_server.erl
+++ b/test/support/arizona_mcp_crashing_server.erl
@@ -5,7 +5,7 @@
 
 -export([init/1]).
 -export([tools/1]).
--export([handle_tool/3]).
+-export([handle_tool/4]).
 
 init(_InitParams) ->
     error(intentional_init_crash).
@@ -13,5 +13,5 @@ init(_InitParams) ->
 tools(_State) ->
     [].
 
-handle_tool(_Name, _Args, State) ->
+handle_tool(_Name, _Args, _Ctx, State) ->
     {reply, ~"", State}.

--- a/test/support/arizona_mcp_minimal_server.erl
+++ b/test/support/arizona_mcp_minimal_server.erl
@@ -6,7 +6,7 @@
 
 -export([init/1]).
 -export([tools/1]).
--export([handle_tool/3]).
+-export([handle_tool/4]).
 
 init(_InitParams) ->
     {ok, #{name => ~"minimal", version => ~"1.0.0"}, #{tools => #{}}, #{}}.
@@ -14,5 +14,5 @@ init(_InitParams) ->
 tools(_State) ->
     [].
 
-handle_tool(Name, _Args, State) ->
+handle_tool(Name, _Args, _Ctx, State) ->
     {error, <<"no such tool: ", Name/binary>>, State}.

--- a/test/support/arizona_mcp_test_server.erl
+++ b/test/support/arizona_mcp_test_server.erl
@@ -4,7 +4,7 @@
 
 -export([init/1]).
 -export([tools/1]).
--export([handle_tool/3]).
+-export([handle_tool/4]).
 -export([resources/1]).
 -export([read_resource/2]).
 -export([prompts/1]).
@@ -50,23 +50,28 @@ tools(_State) ->
             name => ~"count",
             description => ~"Increments and returns a per-session counter",
             input_schema => #{type => ~"object", properties => #{}}
+        },
+        #{
+            name => ~"progress",
+            description => ~"Emits two progress notifications then returns",
+            input_schema => #{type => ~"object", properties => #{}}
         }
     ].
 
-handle_tool(~"add", #{~"a" := A, ~"b" := B}, State) ->
+handle_tool(~"add", #{~"a" := A, ~"b" := B}, _Ctx, State) ->
     {reply, integer_to_binary(A + B), State};
-handle_tool(~"boom", _Args, State) ->
+handle_tool(~"boom", _Args, _Ctx, State) ->
     {error, ~"kaboom", State};
-handle_tool(~"crash", _Args, _State) ->
+handle_tool(~"crash", _Args, _Ctx, _State) ->
     error(intentional_crash);
-handle_tool(~"echo", Args, State) ->
+handle_tool(~"echo", Args, _Ctx, State) ->
     {reply,
         #{
             content => [#{type => ~"text", text => ~"echo"}],
             structured_content => Args
         },
         State};
-handle_tool(~"count", Args, State) ->
+handle_tool(~"count", Args, _Ctx, State) ->
     %% Stateful: each call increments the session-held counter, proving the
     %% returned state threads back. `fail => true` returns the in-band error
     %% outcome (still advancing the counter), proving the error path threads
@@ -76,7 +81,13 @@ handle_tool(~"count", Args, State) ->
     case Args of
         #{~"fail" := true} -> {error, integer_to_binary(Count), State1};
         _ -> {reply, integer_to_binary(Count), State1}
-    end.
+    end;
+handle_tool(~"progress", _Args, Ctx, State) ->
+    %% Emits progress while it runs, proving the streaming-POST path. The Ctx is
+    %% inert for a non-streaming (no progressToken) call, so these are no-ops.
+    ok = arizona_mcp:progress(Ctx, 1, #{total => 2, message => ~"step 1"}),
+    ok = arizona_mcp:progress(Ctx, 2, #{total => 2, message => ~"step 2"}),
+    {reply, ~"done", State}.
 
 resources(_State) ->
     [


### PR DESCRIPTION
# Description

Adds MCP `notifications/progress` for `tools/call`, the second chunk of the MCP server completion work (state threading landed in #541).

A `tools/call` carrying `_meta.progressToken` from a client that accepts `text/event-stream` is answered as an SSE stream (the progress notifications, then the result, then close), reusing the `{loop, ...}` transport; everything else stays a buffered JSON reply.

- `handle_tool/3` -> `handle_tool/4`, gaining a progress `Ctx`; `arizona_mcp:progress/2,3` emits updates (a no-op when the client sent no token, so a tool can always call it).
- Stateless calls run the tool in a conn-side worker; session calls run it in the session process (returned state still threads back), both relaying progress + result to the POST's stream.
- Streaming is gated on the client's `Accept: text/event-stream`; without it the call falls back to a buffered reply.

Verified against the official `@modelcontextprotocol/sdk` client (its `onprogress` fires and the streamed result is correct), plus raw-socket e2e (stateless + session) and unit tests. `docs/architecture.md` updated.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
