### PR TITLE
Decode the halt redirect in the transport, not in arizona_http

### DIFF
--- a/src/arizona_http.erl
+++ b/src/arizona_http.erl
@@ -14,8 +14,9 @@ transport's native reply shape.
 ## Flow
 
 1. Run `arizona_middleware:apply_middlewares/3` with the route's `bindings`.
-2. On `{halt, HaltReq}` -- return `{halt, RawReq}`; the caller ships
-   the reply the middleware already wrote.
+2. On `{halt, HaltReq}` -- return `{halt, HaltReq}` unchanged; the
+   caller decodes the stashed redirect (`arizona_req:halted_redirect/1`)
+   and ships the reply (or a 204/400 when the middleware wrote its own).
 3. On `{cont, Req1, Bindings1}` -- call
    `arizona_render:render_view_to_iolist/2` with the route's
    `layout`/`on_mount`. Return `{ok, 200, Page}` or, on crash or a
@@ -47,8 +48,7 @@ transport's native reply shape.
 }.
 
 -nominal result() ::
-    {halt, arizona_req:raw()}
-    | {redirect, arizona_req:redirect_status(), binary()}
+    {halt, arizona_req:request()}
     | {ok, 200, iolist()}
     | {error, 500, iolist()}.
 
@@ -69,10 +69,9 @@ render(Handler, ArzReq, Opts) ->
     Middlewares = maps:get(middlewares, Opts, []),
     case arizona_middleware:apply_middlewares(Middlewares, ArzReq, Bindings) of
         {halt, HaltReq} ->
-            case arizona_req:halted_redirect(HaltReq) of
-                {Status, Location} -> {redirect, Status, Location};
-                undefined -> {halt, arizona_req:raw(HaltReq)}
-            end;
+            %% Leave the halt intact -- the transport decodes the stashed
+            %% redirect (and any response headers/cookies) off the req.
+            {halt, HaltReq};
         {cont, _ArzReq1, Bindings1} ->
             do_render(Handler, Bindings1, Opts)
     end.

--- a/src/arizona_roadrunner_http.erl
+++ b/src/arizona_roadrunner_http.erl
@@ -35,15 +35,22 @@ handle(Req) ->
     #{handler := H} = State,
     ArzReq = arizona_roadrunner_req:new(Req),
     case arizona_http:render(H, ArzReq, State) of
-        {halt, RawReq} ->
-            %% Middleware emitted its own response via direct roadrunner
-            %% calls (rare). Pass through as a 204 to satisfy the result
-            %% shape; the middleware should have already shipped bytes.
-            {roadrunner_resp:no_content(), RawReq};
-        {redirect, Status, Location} ->
-            {roadrunner_resp:redirect(Status, Location), Req};
+        {halt, HaltReq} ->
+            {halt_response(HaltReq), arizona_req:raw(HaltReq)};
         {ok, Status, Body} ->
             {roadrunner_resp:html(Status, Body), Req};
         {error, Status, Body} ->
             {roadrunner_resp:html(Status, Body), Req}
+    end.
+
+%% --------------------------------------------------------------------
+%% Internal functions
+%% --------------------------------------------------------------------
+
+%% Middleware halted before render. Ship a stashed redirect, or a 204 when
+%% the middleware emitted its own response via direct roadrunner calls.
+halt_response(HaltReq) ->
+    case arizona_req:halted_redirect(HaltReq) of
+        {Status, Location} -> roadrunner_resp:redirect(Status, Location);
+        undefined -> roadrunner_resp:no_content()
     end.


### PR DESCRIPTION
Pure refactor, no behavior change.

`arizona_http:render/3` returned a pre-decoded `{redirect, Status, Location}` result, even though the WS transport (`arizona_roadrunner_ws`) already decodes the stashed redirect itself via `arizona_req:halted_redirect/1`. Unify the two: `render/3` returns the halted req as `{halt, HaltReq}`, and `arizona_roadrunner_http` decodes the redirect (else 204) the same way the WS transport does.

Already covered by existing redirect integration tests (`middleware_halt_redirects`, `http_halt_redirect_via_req`).