### PR TITLE
Add arizona_req response headers/cookies, flushed by transports

### DIFF
--- a/src/arizona_http.erl
+++ b/src/arizona_http.erl
@@ -19,8 +19,9 @@ transport's native reply shape.
    and ships the reply (or a 204/400 when the middleware wrote its own).
 3. On `{cont, Req1, Bindings1}` -- call
    `arizona_render:render_view_to_iolist/2` with the route's
-   `layout`/`on_mount`. Return `{ok, 200, Page}` or, on crash or a
-   stashed hot-reload error, `{error, 500, ErrorPage}`.
+   `layout`/`on_mount`. Return `{ok, 200, Page, Req1}` or, on crash or a
+   stashed hot-reload error, `{error, 500, ErrorPage, Req1}` (the threaded
+   req carries any response headers/cookies for the transport to flush).
 """.
 
 %% --------------------------------------------------------------------
@@ -49,8 +50,8 @@ transport's native reply shape.
 
 -nominal result() ::
     {halt, arizona_req:request()}
-    | {ok, 200, iolist()}
-    | {error, 500, iolist()}.
+    | {ok, 200, iolist(), arizona_req:request()}
+    | {error, 500, iolist(), arizona_req:request()}.
 
 %% --------------------------------------------------------------------
 %% API Functions
@@ -72,8 +73,10 @@ render(Handler, ArzReq, Opts) ->
             %% Leave the halt intact -- the transport decodes the stashed
             %% redirect (and any response headers/cookies) off the req.
             {halt, HaltReq};
-        {cont, _ArzReq1, Bindings1} ->
-            do_render(Handler, Bindings1, Opts)
+        {cont, ArzReq1, Bindings1} ->
+            %% Thread the req so the transport can flush response headers/cookies
+            %% a middleware stashed before rendering.
+            do_render(Handler, ArzReq1, Bindings1, Opts)
     end.
 
 %% --------------------------------------------------------------------
@@ -85,7 +88,7 @@ render(Handler, ArzReq, Opts) ->
 reload_url() ->
     persistent_term:get(arizona_reload_url, undefined).
 
-do_render(H, Bindings, Opts) ->
+do_render(H, ArzReq, Bindings, Opts) ->
     case arizona_reloader:get_error() of
         undefined ->
             try
@@ -95,7 +98,7 @@ do_render(H, Bindings, Opts) ->
                     on_mount => maps:get(on_mount, Opts, [])
                 },
                 Page = arizona_render:render_view_to_iolist(H, RenderOpts),
-                {ok, 200, Page}
+                {ok, 200, Page, ArzReq}
             catch
                 Class:Reason:Stacktrace ->
                     ErrorInfo = #{
@@ -104,7 +107,7 @@ do_render(H, Bindings, Opts) ->
                         stacktrace => Stacktrace,
                         reload_url => reload_url()
                     },
-                    {error, 500, render_error_body(Bindings, ErrorInfo)}
+                    {error, 500, render_error_body(Bindings, ErrorInfo), ArzReq}
             end;
         #{errors := Errors} ->
             ErrorInfo = #{
@@ -113,7 +116,7 @@ do_render(H, Bindings, Opts) ->
                 stacktrace => [],
                 reload_url => reload_url()
             },
-            {error, 500, render_error_body(Bindings, ErrorInfo)}
+            {error, 500, render_error_body(Bindings, ErrorInfo), ArzReq}
     end.
 
 render_error_body(Bindings, ErrorInfo) ->

--- a/src/arizona_req.erl
+++ b/src/arizona_req.erl
@@ -59,6 +59,10 @@ Method = arizona_req:method(Req).          %% eager, no thread
 -export([redirect/2]).
 -export([redirect/3]).
 -export([halted_redirect/1]).
+-export([put_resp_header/3]).
+-export([put_resp_cookie/4]).
+-export([resp_headers/1]).
+-export([resp_cookies/1]).
 
 %% --------------------------------------------------------------------
 %% Ignore xref warnings
@@ -77,6 +81,10 @@ Method = arizona_req:method(Req).          %% eager, no thread
 -ignore_xref([redirect/2]).
 -ignore_xref([redirect/3]).
 -ignore_xref([halted_redirect/1]).
+-ignore_xref([put_resp_header/3]).
+-ignore_xref([put_resp_cookie/4]).
+-ignore_xref([resp_headers/1]).
+-ignore_xref([resp_cookies/1]).
 
 %% --------------------------------------------------------------------
 %% Types exports
@@ -93,6 +101,7 @@ Method = arizona_req:method(Req).          %% eager, no thread
 -export_type([headers/0]).
 -export_type([body/0]).
 -export_type([redirect_status/0]).
+-export_type([resp_cookie_opts/0]).
 -export_type([qs/0]).
 
 %% --------------------------------------------------------------------
@@ -110,7 +119,9 @@ Method = arizona_req:method(Req).          %% eager, no thread
     cookies => cookies(),
     headers => headers(),
     body => body(),
-    redirect => {redirect_status(), binary()}
+    redirect => {redirect_status(), binary()},
+    resp_headers => [{binary(), iodata()}],
+    resp_cookies => [{binary(), binary(), resp_cookie_opts()}]
 }.
 
 -nominal adapter() :: module().
@@ -129,6 +140,18 @@ Method = arizona_req:method(Req).          %% eager, no thread
 %% is allowed so rarer codes (300 multiple choices, 304 not modified,
 %% etc.) remain expressible -- callers pick the semantics they want.
 -nominal redirect_status() :: 300..399.
+
+%% Response cookie options stashed by `put_resp_cookie/4` and serialized by
+%% the transport. Mirrors the transport cookie serializer's options.
+-nominal resp_cookie_opts() :: #{
+    domain => binary(),
+    path => binary(),
+    max_age => non_neg_integer(),
+    expires => binary(),
+    secure => boolean(),
+    http_only => boolean(),
+    same_site => strict | lax | none
+}.
 
 %% Query string passed to `resolve_route/3` for SPA navigate.
 -nominal qs() :: binary().
@@ -335,3 +358,44 @@ client-visible response.
     Request :: request().
 halted_redirect(#{redirect := Redirect}) -> Redirect;
 halted_redirect(_) -> undefined.
+
+-doc """
+Stashes a response header on `Request`. Transports flush stashed headers
+onto the outgoing response (redirect, rendered page, or halt). Repeated
+calls accumulate (newest first).
+""".
+-spec put_resp_header(Request, Name, Value) -> Request when
+    Request :: request(),
+    Name :: binary(),
+    Value :: iodata().
+put_resp_header(Req, Name, Value) when is_binary(Name) ->
+    Headers = maps:get(resp_headers, Req, []),
+    Req#{resp_headers => [{Name, Value} | Headers]}.
+
+-doc """
+Stashes a response cookie on `Request`, serialized by the transport when the
+response is built. Lets a middleware set a cookie alongside a `redirect/2,3`
+or a rendered page. `Opts` follows `resp_cookie_opts()`.
+""".
+-spec put_resp_cookie(Request, Name, Value, Opts) -> Request when
+    Request :: request(),
+    Name :: binary(),
+    Value :: binary(),
+    Opts :: resp_cookie_opts().
+put_resp_cookie(Req, Name, Value, Opts) when
+    is_binary(Name), is_binary(Value), is_map(Opts)
+->
+    Cookies = maps:get(resp_cookies, Req, []),
+    Req#{resp_cookies => [{Name, Value, Opts} | Cookies]}.
+
+-doc "Returns the stashed response headers (newest first), or `[]`.".
+-spec resp_headers(Request) -> [{binary(), iodata()}] when
+    Request :: request().
+resp_headers(#{resp_headers := Headers}) -> Headers;
+resp_headers(_) -> [].
+
+-doc "Returns the stashed response cookies (newest first), or `[]`.".
+-spec resp_cookies(Request) -> [{binary(), binary(), resp_cookie_opts()}] when
+    Request :: request().
+resp_cookies(#{resp_cookies := Cookies}) -> Cookies;
+resp_cookies(_) -> [].

--- a/src/arizona_roadrunner_http.erl
+++ b/src/arizona_roadrunner_http.erl
@@ -37,10 +37,10 @@ handle(Req) ->
     case arizona_http:render(H, ArzReq, State) of
         {halt, HaltReq} ->
             {halt_response(HaltReq), arizona_req:raw(HaltReq)};
-        {ok, Status, Body} ->
-            {roadrunner_resp:html(Status, Body), Req};
-        {error, Status, Body} ->
-            {roadrunner_resp:html(Status, Body), Req}
+        {ok, Status, Body, ArzReq1} ->
+            {flush_resp(ArzReq1, roadrunner_resp:html(Status, Body)), Req};
+        {error, Status, Body, ArzReq1} ->
+            {flush_resp(ArzReq1, roadrunner_resp:html(Status, Body)), Req}
     end.
 
 %% --------------------------------------------------------------------
@@ -48,9 +48,25 @@ handle(Req) ->
 %% --------------------------------------------------------------------
 
 %% Middleware halted before render. Ship a stashed redirect, or a 204 when
-%% the middleware emitted its own response via direct roadrunner calls.
+%% the middleware emitted its own response via direct roadrunner calls, then
+%% flush any stashed response headers/cookies (put_resp_header/put_resp_cookie).
 halt_response(HaltReq) ->
-    case arizona_req:halted_redirect(HaltReq) of
-        {Status, Location} -> roadrunner_resp:redirect(Status, Location);
-        undefined -> roadrunner_resp:no_content()
-    end.
+    Resp =
+        case arizona_req:halted_redirect(HaltReq) of
+            {Status, Location} -> roadrunner_resp:redirect(Status, Location);
+            undefined -> roadrunner_resp:no_content()
+        end,
+    flush_resp(HaltReq, Resp).
+
+%% Fold stashed response headers and cookies onto Resp.
+flush_resp(ArzReq, Resp0) ->
+    Resp1 = lists:foldl(
+        fun({Name, Value}, R) -> roadrunner_resp:add_header(R, Name, Value) end,
+        Resp0,
+        arizona_req:resp_headers(ArzReq)
+    ),
+    lists:foldl(
+        fun({Name, Value, Opts}, R) -> roadrunner_resp:set_cookie(R, Name, Value, Opts) end,
+        Resp1,
+        arizona_req:resp_cookies(ArzReq)
+    ).

--- a/src/arizona_roadrunner_ws.erl
+++ b/src/arizona_roadrunner_ws.erl
@@ -132,9 +132,25 @@ to_roadrunner({close, Code, Reason, Sock}, State) ->
     {close, Code, Reason, State#{socket => Sock}}.
 
 %% Middleware halted before the upgrade — emit a stashed redirect or a
-%% bare 400 if the middleware did not write its own response.
+%% bare 400 if the middleware did not write its own response, then flush any
+%% stashed response headers/cookies (put_resp_header/put_resp_cookie).
 halt_response(HaltReq) ->
-    case arizona_req:halted_redirect(HaltReq) of
-        {Status, Location} -> roadrunner_resp:redirect(Status, Location);
-        undefined -> roadrunner_resp:bad_request()
-    end.
+    Resp =
+        case arizona_req:halted_redirect(HaltReq) of
+            {Status, Location} -> roadrunner_resp:redirect(Status, Location);
+            undefined -> roadrunner_resp:bad_request()
+        end,
+    flush_resp(HaltReq, Resp).
+
+%% Fold stashed response headers and cookies onto Resp.
+flush_resp(ArzReq, Resp0) ->
+    Resp1 = lists:foldl(
+        fun({Name, Value}, R) -> roadrunner_resp:add_header(R, Name, Value) end,
+        Resp0,
+        arizona_req:resp_headers(ArzReq)
+    ),
+    lists:foldl(
+        fun({Name, Value, Opts}, R) -> roadrunner_resp:set_cookie(R, Name, Value, Opts) end,
+        Resp1,
+        arizona_req:resp_cookies(ArzReq)
+    ).

--- a/test/arizona_http_SUITE.erl
+++ b/test/arizona_http_SUITE.erl
@@ -1,0 +1,57 @@
+-module(arizona_http_SUITE).
+-include_lib("stdlib/include/assert.hrl").
+
+-export([all/0]).
+-export([groups/0]).
+
+-export([halt_keeps_redirect_and_cookie/1]).
+-export([render_threads_cookie/1]).
+
+all() ->
+    [{group, render}].
+
+groups() ->
+    [
+        {render, [parallel], [
+            halt_keeps_redirect_and_cookie,
+            render_threads_cookie
+        ]}
+    ].
+
+%% --------------------------------------------------------------------
+%% Response stash survives the render pipeline
+%% --------------------------------------------------------------------
+
+%% A middleware that halts with a redirect and a stashed cookie. render/3 leaves
+%% the halt intact (the transport decodes the redirect), and the cookie rides
+%% along on the same request -- this is the login path.
+halt_keeps_redirect_and_cookie(Config) when is_list(Config) ->
+    Req = arizona_req_test_adapter:new(#{}),
+    Mw = [
+        fun(R, _B) ->
+            R1 = arizona_req:put_resp_cookie(R, ~"session", ~"abc", #{path => ~"/"}),
+            {halt, arizona_req:redirect(R1, 303, ~"/")}
+        end
+    ],
+    {halt, HaltReq} = arizona_http:render(arizona_about, Req, #{middlewares => Mw}),
+    ?assertEqual({303, ~"/"}, arizona_req:halted_redirect(HaltReq)),
+    ?assertEqual(
+        [{~"session", ~"abc", #{path => ~"/"}}],
+        arizona_req:resp_cookies(HaltReq)
+    ).
+
+%% A middleware that stashes a cookie then continues. The rendered result threads
+%% the request out so the transport can flush the cookie onto the page response.
+render_threads_cookie(Config) when is_list(Config) ->
+    Req = arizona_req_test_adapter:new(#{}),
+    Mw = [
+        fun(R, B) ->
+            R1 = arizona_req:put_resp_cookie(R, ~"theme", ~"dark", #{path => ~"/"}),
+            {cont, R1, B}
+        end
+    ],
+    {ok, 200, _Body, ReqOut} = arizona_http:render(arizona_about, Req, #{middlewares => Mw}),
+    ?assertEqual(
+        [{~"theme", ~"dark", #{path => ~"/"}}],
+        arizona_req:resp_cookies(ReqOut)
+    ).

--- a/test/arizona_req_SUITE.erl
+++ b/test/arizona_req_SUITE.erl
@@ -15,6 +15,9 @@
 -export([user_agent_returns_header/1]).
 -export([user_agent_absent_is_empty/1]).
 -export([body_threads_updated_raw/1]).
+-export([put_resp_header_accumulates/1]).
+-export([put_resp_cookie_accumulates/1]).
+-export([resp_stash_defaults_empty/1]).
 -export([call_resolve_route_dispatches_to_adapter/1]).
 
 all() ->
@@ -33,7 +36,10 @@ groups() ->
             headers_lazy_loads_and_caches,
             user_agent_returns_header,
             user_agent_absent_is_empty,
-            body_threads_updated_raw
+            body_threads_updated_raw,
+            put_resp_header_accumulates,
+            put_resp_cookie_accumulates,
+            resp_stash_defaults_empty
         ]},
         {resolve_route, [parallel], [
             call_resolve_route_dispatches_to_adapter
@@ -133,6 +139,34 @@ body_threads_updated_raw(Config) when is_list(Config) ->
     {Body, Req1} = arizona_req:body(Req0),
     ?assertEqual(~"hello", Body),
     ?assertEqual(#{body => ~"hello", body_read => true}, arizona_req:raw(Req1)).
+
+%% --------------------------------------------------------------------
+%% Response stash -- put_resp_header/3, put_resp_cookie/4
+%% --------------------------------------------------------------------
+
+put_resp_header_accumulates(Config) when is_list(Config) ->
+    Req0 = arizona_req_test_adapter:new(#{}),
+    ?assertEqual([], arizona_req:resp_headers(Req0)),
+    Req1 = arizona_req:put_resp_header(Req0, ~"x-a", ~"1"),
+    Req2 = arizona_req:put_resp_header(Req1, ~"x-b", ~"2"),
+    %% Newest first.
+    ?assertEqual([{~"x-b", ~"2"}, {~"x-a", ~"1"}], arizona_req:resp_headers(Req2)).
+
+put_resp_cookie_accumulates(Config) when is_list(Config) ->
+    Req0 = arizona_req_test_adapter:new(#{}),
+    ?assertEqual([], arizona_req:resp_cookies(Req0)),
+    Opts = #{path => ~"/", http_only => true},
+    Req1 = arizona_req:put_resp_cookie(Req0, ~"session", ~"abc", Opts),
+    Req2 = arizona_req:put_resp_cookie(Req1, ~"theme", ~"dark", #{}),
+    ?assertEqual(
+        [{~"theme", ~"dark", #{}}, {~"session", ~"abc", Opts}],
+        arizona_req:resp_cookies(Req2)
+    ).
+
+resp_stash_defaults_empty(Config) when is_list(Config) ->
+    Req = arizona_req_test_adapter:new(#{}),
+    ?assertEqual([], arizona_req:resp_headers(Req)),
+    ?assertEqual([], arizona_req:resp_cookies(Req)).
 
 %% --------------------------------------------------------------------
 %% resolve_route -- exercises the optional callback wiring

--- a/test/arizona_ws_SUITE.erl
+++ b/test/arizona_ws_SUITE.erl
@@ -27,6 +27,8 @@
     middleware_halt_redirects_on_navigate/1,
     middleware_cont_on_navigate/1,
     http_halt_redirect_via_req/1,
+    http_halt_sets_cookie/1,
+    http_render_sets_cookie/1,
     http_render_crash_emits_error_page/1,
     http_reads_cookies_headers_body/1,
     http_exposes_roadrunner_request_id/1,
@@ -81,6 +83,8 @@ groups() ->
         middleware_halt_redirects_on_navigate,
         middleware_cont_on_navigate,
         http_halt_redirect_via_req,
+        http_halt_sets_cookie,
+        http_render_sets_cookie,
         http_render_crash_emits_error_page,
         http_reads_cookies_headers_body,
         http_exposes_roadrunner_request_id,
@@ -174,6 +178,30 @@ init_per_group(roadrunner, Config) ->
         {live, <<"/halt_redirect_req">>, arizona_crashable, #{
             middlewares => [
                 fun(Req, _B) -> {halt, arizona_req:redirect(Req, <<"/login">>)} end
+            ]
+        }},
+        %% Stash a cookie then halt with a redirect: the transport flushes
+        %% Set-Cookie onto the 303 response.
+        {live, <<"/halt_set_cookie">>, arizona_crashable, #{
+            middlewares => [
+                fun(Req, _B) ->
+                    Req1 = arizona_req:put_resp_cookie(Req, <<"session">>, <<"abc">>, #{
+                        path => <<"/">>, http_only => true
+                    }),
+                    {halt, arizona_req:redirect(Req1, 303, <<"/">>)}
+                end
+            ]
+        }},
+        %% Stash a cookie then continue: the rendered page response carries
+        %% Set-Cookie.
+        {live, <<"/render_set_cookie">>, arizona_crashable, #{
+            middlewares => [
+                fun(Req, B) ->
+                    Req1 = arizona_req:put_resp_cookie(Req, <<"theme">>, <<"dark">>, #{
+                        path => <<"/">>
+                    }),
+                    {cont, Req1, B}
+                end
             ]
         }},
         {live, <<"/crash_on_render_http">>, arizona_crashable, #{
@@ -410,6 +438,43 @@ middleware_halt_redirects(Config) ->
     gen_tcp:close(Sock),
     ?assertNotEqual(nomatch, binary:match(Resp, <<"302">>)),
     ?assertNotEqual(nomatch, binary:match(Resp, <<"/login">>)).
+
+http_halt_sets_cookie(Config) ->
+    %% HTTP: middleware stashes a cookie then halts with a redirect; the
+    %% transport flushes Set-Cookie onto the 303. The cookie value only
+    %% appears in a Set-Cookie header (the redirect body is empty).
+    Port = proplists:get_value(port, Config),
+    {ok, Sock} = gen_tcp:connect("localhost", Port, [binary, {active, false}]),
+    Req = [
+        "GET /halt_set_cookie HTTP/1.1\r\n",
+        "Host: localhost:",
+        integer_to_list(Port),
+        "\r\n",
+        "\r\n"
+    ],
+    ok = gen_tcp:send(Sock, Req),
+    {ok, Resp} = gen_tcp:recv(Sock, 0, 5000),
+    gen_tcp:close(Sock),
+    ?assertNotEqual(nomatch, binary:match(Resp, <<"303">>)),
+    ?assertNotEqual(nomatch, binary:match(Resp, <<"session=abc">>)).
+
+http_render_sets_cookie(Config) ->
+    %% HTTP: middleware stashes a cookie then continues; the rendered page
+    %% response carries Set-Cookie (the cookie value is not in the body).
+    Port = proplists:get_value(port, Config),
+    {ok, Sock} = gen_tcp:connect("localhost", Port, [binary, {active, false}]),
+    Req = [
+        "GET /render_set_cookie HTTP/1.1\r\n",
+        "Host: localhost:",
+        integer_to_list(Port),
+        "\r\n",
+        "\r\n"
+    ],
+    ok = gen_tcp:send(Sock, Req),
+    {ok, Resp} = gen_tcp:recv(Sock, 0, 5000),
+    gen_tcp:close(Sock),
+    ?assertNotEqual(nomatch, binary:match(Resp, <<"200">>)),
+    ?assertNotEqual(nomatch, binary:match(Resp, <<"theme=dark">>)).
 
 middleware_halt_rejects_ws(Config) ->
     %% WS: middleware halts -- upgrade never happens, HTTP response returned


### PR DESCRIPTION
Adds `arizona_req:put_resp_header/3` and `put_resp_cookie/4` (plus `resp_headers/1` / `resp_cookies/1`), stashed on the request like `redirect/2,3` and flushed by the transports onto redirect, rendered, and WS-halt responses. Lets a middleware set a cookie — e.g. a login session — alongside a redirect or a page render, which previously wasn't possible.

Tests: `arizona_req` stash unit tests, `arizona_http` render-threading tests (halt + render), and real-HTTP `Set-Cookie` integration tests on both paths in `arizona_ws_SUITE`.

Stacked on #544 (retarget to main once it merges).