### PR TITLE
Add arizona_req:put_resp_status/2 for non-200 page renders

### DIFF
--- a/src/arizona_http.erl
+++ b/src/arizona_http.erl
@@ -50,7 +50,7 @@ transport's native reply shape.
 
 -nominal result() ::
     {halt, arizona_req:request()}
-    | {ok, 200, iolist(), arizona_req:request()}
+    | {ok, arizona_req:resp_status(), iolist(), arizona_req:request()}
     | {error, 500, iolist(), arizona_req:request()}.
 
 %% --------------------------------------------------------------------
@@ -98,7 +98,14 @@ do_render(H, ArzReq, Bindings, Opts) ->
                     on_mount => maps:get(on_mount, Opts, [])
                 },
                 Page = arizona_render:render_view_to_iolist(H, RenderOpts),
-                {ok, 200, Page, ArzReq}
+                %% A view or middleware may stash a non-200 status (e.g. 401)
+                %% while still rendering a body; default to 200.
+                OkStatus =
+                    case arizona_req:resp_status(ArzReq) of
+                        undefined -> 200;
+                        Status -> Status
+                    end,
+                {ok, OkStatus, Page, ArzReq}
             catch
                 Class:Reason:Stacktrace ->
                     ErrorInfo = #{

--- a/src/arizona_req.erl
+++ b/src/arizona_req.erl
@@ -61,8 +61,10 @@ Method = arizona_req:method(Req).          %% eager, no thread
 -export([halted_redirect/1]).
 -export([put_resp_header/3]).
 -export([put_resp_cookie/4]).
+-export([put_resp_status/2]).
 -export([resp_headers/1]).
 -export([resp_cookies/1]).
+-export([resp_status/1]).
 
 %% --------------------------------------------------------------------
 %% Ignore xref warnings
@@ -83,8 +85,10 @@ Method = arizona_req:method(Req).          %% eager, no thread
 -ignore_xref([halted_redirect/1]).
 -ignore_xref([put_resp_header/3]).
 -ignore_xref([put_resp_cookie/4]).
+-ignore_xref([put_resp_status/2]).
 -ignore_xref([resp_headers/1]).
 -ignore_xref([resp_cookies/1]).
+-ignore_xref([resp_status/1]).
 
 %% --------------------------------------------------------------------
 %% Types exports
@@ -101,6 +105,7 @@ Method = arizona_req:method(Req).          %% eager, no thread
 -export_type([headers/0]).
 -export_type([body/0]).
 -export_type([redirect_status/0]).
+-export_type([resp_status/0]).
 -export_type([resp_cookie_opts/0]).
 -export_type([qs/0]).
 
@@ -121,7 +126,8 @@ Method = arizona_req:method(Req).          %% eager, no thread
     body => body(),
     redirect => {redirect_status(), binary()},
     resp_headers => [{binary(), iodata()}],
-    resp_cookies => [{binary(), binary(), resp_cookie_opts()}]
+    resp_cookies => [{binary(), binary(), resp_cookie_opts()}],
+    resp_status => resp_status()
 }.
 
 -nominal adapter() :: module().
@@ -140,6 +146,10 @@ Method = arizona_req:method(Req).          %% eager, no thread
 %% is allowed so rarer codes (300 multiple choices, 304 not modified,
 %% etc.) remain expressible -- callers pick the semantics they want.
 -nominal redirect_status() :: 300..399.
+
+%% Any HTTP response status. Stashed by `put_resp_status/2` and used as the OK
+%% status of a rendered page (default 200) -- e.g. a 401 from an auth gate.
+-nominal resp_status() :: 100..599.
 
 %% Response cookie options stashed by `put_resp_cookie/4` and serialized by
 %% the transport. Mirrors the transport cookie serializer's options.
@@ -399,3 +409,21 @@ resp_headers(_) -> [].
     Request :: request().
 resp_cookies(#{resp_cookies := Cookies}) -> Cookies;
 resp_cookies(_) -> [].
+
+-doc """
+Stashes the HTTP status for a rendered page. Lets a view or middleware return
+a non-200 status (e.g. `401` from an auth gate, `404` from a not-found page)
+while still rendering a body. Ignored for redirects and halts, which carry
+their own status.
+""".
+-spec put_resp_status(Request, Status) -> Request when
+    Request :: request(),
+    Status :: resp_status().
+put_resp_status(Req, Status) when is_integer(Status), Status >= 100, Status =< 599 ->
+    Req#{resp_status => Status}.
+
+-doc "Returns the stashed response status, or `undefined`.".
+-spec resp_status(Request) -> resp_status() | undefined when
+    Request :: request().
+resp_status(#{resp_status := Status}) -> Status;
+resp_status(_) -> undefined.

--- a/test/arizona_req_SUITE.erl
+++ b/test/arizona_req_SUITE.erl
@@ -17,6 +17,7 @@
 -export([body_threads_updated_raw/1]).
 -export([put_resp_header_accumulates/1]).
 -export([put_resp_cookie_accumulates/1]).
+-export([put_resp_status_stashes/1]).
 -export([resp_stash_defaults_empty/1]).
 -export([call_resolve_route_dispatches_to_adapter/1]).
 
@@ -39,6 +40,7 @@ groups() ->
             body_threads_updated_raw,
             put_resp_header_accumulates,
             put_resp_cookie_accumulates,
+            put_resp_status_stashes,
             resp_stash_defaults_empty
         ]},
         {resolve_route, [parallel], [
@@ -141,7 +143,7 @@ body_threads_updated_raw(Config) when is_list(Config) ->
     ?assertEqual(#{body => ~"hello", body_read => true}, arizona_req:raw(Req1)).
 
 %% --------------------------------------------------------------------
-%% Response stash -- put_resp_header/3, put_resp_cookie/4
+%% Response stash -- put_resp_header/3, put_resp_cookie/4, put_resp_status/2
 %% --------------------------------------------------------------------
 
 put_resp_header_accumulates(Config) when is_list(Config) ->
@@ -163,10 +165,20 @@ put_resp_cookie_accumulates(Config) when is_list(Config) ->
         arizona_req:resp_cookies(Req2)
     ).
 
+put_resp_status_stashes(Config) when is_list(Config) ->
+    Req0 = arizona_req_test_adapter:new(#{}),
+    ?assertEqual(undefined, arizona_req:resp_status(Req0)),
+    Req1 = arizona_req:put_resp_status(Req0, 401),
+    ?assertEqual(401, arizona_req:resp_status(Req1)),
+    %% Last write wins.
+    Req2 = arizona_req:put_resp_status(Req1, 404),
+    ?assertEqual(404, arizona_req:resp_status(Req2)).
+
 resp_stash_defaults_empty(Config) when is_list(Config) ->
     Req = arizona_req_test_adapter:new(#{}),
     ?assertEqual([], arizona_req:resp_headers(Req)),
-    ?assertEqual([], arizona_req:resp_cookies(Req)).
+    ?assertEqual([], arizona_req:resp_cookies(Req)),
+    ?assertEqual(undefined, arizona_req:resp_status(Req)).
 
 %% --------------------------------------------------------------------
 %% resolve_route -- exercises the optional callback wiring

--- a/test/arizona_ws_SUITE.erl
+++ b/test/arizona_ws_SUITE.erl
@@ -29,6 +29,7 @@
     http_halt_redirect_via_req/1,
     http_halt_sets_cookie/1,
     http_render_sets_cookie/1,
+    http_render_sets_status/1,
     http_render_crash_emits_error_page/1,
     http_reads_cookies_headers_body/1,
     http_exposes_roadrunner_request_id/1,
@@ -85,6 +86,7 @@ groups() ->
         http_halt_redirect_via_req,
         http_halt_sets_cookie,
         http_render_sets_cookie,
+        http_render_sets_status,
         http_render_crash_emits_error_page,
         http_reads_cookies_headers_body,
         http_exposes_roadrunner_request_id,
@@ -201,6 +203,15 @@ init_per_group(roadrunner, Config) ->
                         path => <<"/">>
                     }),
                     {cont, Req1, B}
+                end
+            ]
+        }},
+        %% Stash a non-200 status then continue: the rendered page response
+        %% carries that status (e.g. an auth gate returning 401 with a body).
+        {live, <<"/render_set_status">>, arizona_crashable, #{
+            middlewares => [
+                fun(Req, B) ->
+                    {cont, arizona_req:put_resp_status(Req, 401), B}
                 end
             ]
         }},
@@ -475,6 +486,23 @@ http_render_sets_cookie(Config) ->
     gen_tcp:close(Sock),
     ?assertNotEqual(nomatch, binary:match(Resp, <<"200">>)),
     ?assertNotEqual(nomatch, binary:match(Resp, <<"theme=dark">>)).
+
+http_render_sets_status(Config) ->
+    %% HTTP: middleware stashes a 401 then continues; the rendered page
+    %% response carries the 401 status (with a body).
+    Port = proplists:get_value(port, Config),
+    {ok, Sock} = gen_tcp:connect("localhost", Port, [binary, {active, false}]),
+    Req = [
+        "GET /render_set_status HTTP/1.1\r\n",
+        "Host: localhost:",
+        integer_to_list(Port),
+        "\r\n",
+        "\r\n"
+    ],
+    ok = gen_tcp:send(Sock, Req),
+    {ok, Resp} = gen_tcp:recv(Sock, 0, 5000),
+    gen_tcp:close(Sock),
+    ?assertNotEqual(nomatch, binary:match(Resp, <<"HTTP/1.1 401">>)).
 
 middleware_halt_rejects_ws(Config) ->
     %% WS: middleware halts -- upgrade never happens, HTTP response returned


### PR DESCRIPTION
Adds `arizona_req:put_resp_status/2` (+ `resp_status/1`) so a view or middleware can render a page with a non-200 status (e.g. 401 from an auth gate) while still serving a body. Defaults to 200; redirects and halts keep their own status.

Mirrors the #545 response stash.