### PR TITLE
Keep raw/1 public and add the missing az:raw/1 alias

### DIFF
--- a/src/arizona_template.erl
+++ b/src/arizona_template.erl
@@ -89,6 +89,8 @@ render(Bindings) ->
 %% never called directly (no az alias, unlike each/2).
 -ignore_xref([native_each/2]).
 -ignore_xref([terminal_each/2]).
+%% Public escape opt-out for template authors; no internal callers by design.
+-ignore_xref([raw/1]).
 
 %% --------------------------------------------------------------------
 %% Types exports

--- a/src/az.erl
+++ b/src/az.erl
@@ -44,6 +44,7 @@ binding, used by stateless layouts to render the wrapped page.
 -export([stateless/3]).
 -export([each/2]).
 -export([local/2]).
+-export([raw/1]).
 
 %% --------------------------------------------------------------------
 %% Ignore xref warnings
@@ -63,7 +64,8 @@ binding, used by stateless layouts to render the wrapped page.
     stateless/2,
     stateless/3,
     each/2,
-    local/2
+    local/2,
+    raw/1
 ]).
 
 %% --------------------------------------------------------------------
@@ -245,3 +247,11 @@ Alias for `arizona_template:local/2`.
     Init :: term().
 local(Key, Init) ->
     arizona_template:local(Key, Init).
+
+-doc """
+Alias for `arizona_template:raw/1`.
+""".
+-spec raw(Value) -> {arizona_raw, term()} when
+    Value :: term().
+raw(Value) ->
+    arizona_template:raw(Value).

--- a/test/arizona_parse_transform_SUITE.erl
+++ b/test/arizona_parse_transform_SUITE.erl
@@ -238,6 +238,7 @@
     ssr_escapes_attr_value/1,
     ssr_escape_all_unsafe_chars/1,
     raw_opt_out_not_escaped/1,
+    az_raw_opt_out_not_escaped/1,
     block_value_not_escaped/1,
     value_template_inner_escaped/1,
     diff_value_stays_raw/1,
@@ -391,6 +392,7 @@ groups() ->
             ssr_escapes_attr_value,
             ssr_escape_all_unsafe_chars,
             raw_opt_out_not_escaped,
+            az_raw_opt_out_not_escaped,
             block_value_not_escaped,
             value_template_inner_escaped,
             diff_value_stays_raw,
@@ -1388,6 +1390,20 @@ raw_opt_out_not_escaped(Config) when is_list(Config) ->
         "    arizona_template:html({'div', [], ["
         "        arizona_template:raw(arizona_template:get(x, Bindings))"
         "    ]}). "
+    ),
+    {HTML0, _Snap} = arizona_render:render(Mod:render(#{x => <<"<b>raw</b>">>})),
+    HTML = iolist_to_binary(HTML0),
+    ?assertNotEqual(nomatch, binary:match(HTML, <<"<b>raw</b>">>)),
+    ?assertEqual(nomatch, binary:match(HTML, <<"&lt;b&gt;">>)).
+
+%% The az facade's raw/1 behaves identically (the parse transform classifies
+%% az:raw as a block, so the az:raw/1 runtime alias must exist and opt out).
+az_raw_opt_out_not_escaped(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_esc_az_raw). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    az:html({'div', [], [az:raw(az:get(x, Bindings))]}). "
     ),
     {HTML0, _Snap} = arizona_render:render(Mod:render(#{x => <<"<b>raw</b>">>})),
     HTML = iolist_to_binary(HTML0),
@@ -2591,11 +2607,10 @@ template2_fragment_multi_expr(Config) when is_list(Config) ->
     DFun = maps:get(d, Tmpl),
     Az0 = <<Fp/binary, "-0">>,
     Az1 = <<Fp/binary, "-1">>,
-    [{Az0, {esc, NameFun}, {pt_each_frag_multi, 1}}, {Az1, {esc, AgeFun}, {pt_each_frag_multi, 1}}] = DFun(
-        #{
-            name => <<"alice">>, age => 25
-        }
-    ),
+    [
+        {Az0, {esc, NameFun}, {pt_each_frag_multi, 1}},
+        {Az1, {esc, AgeFun}, {pt_each_frag_multi, 1}}
+    ] = DFun(#{name => <<"alice">>, age => 25}),
     ?assertEqual(<<"ALICE">>, NameFun()),
     ?assertEqual(25, AgeFun()).
 
@@ -2638,11 +2653,10 @@ template2_map_pattern(Config) when is_list(Config) ->
     DFun = maps:get(d, Tmpl),
     Az0 = <<Fp/binary, "-0">>,
     Az1 = <<Fp/binary, "-1">>,
-    [{Az0, {esc, NameFun}, {pt_each_map_pat, 1}}, {Az1, {esc, AgeFun}, {pt_each_map_pat, 1}}] = DFun(
-        #{
-            name => <<"Alice">>, age => 30
-        }
-    ),
+    [
+        {Az0, {esc, NameFun}, {pt_each_map_pat, 1}},
+        {Az1, {esc, AgeFun}, {pt_each_map_pat, 1}}
+    ] = DFun(#{name => <<"Alice">>, age => 30}),
     ?assertEqual(<<"Alice">>, NameFun()),
     ?assertEqual(30, AgeFun()).
 


### PR DESCRIPTION
Restores `arizona_template:raw/1`, the public escape opt-out that #546's design is built around. It was dropped while clearing an xref `unused export` warning, but that warning is a false positive: `raw/1` has no internal callers by design, it is for downstream template code. Suppressed with `-ignore_xref([raw/1])`, matching this module's other API-only functions.

Also adds the missing `az:raw/1` alias. The parse transform already classifies `az:raw(...)` as a block, so without the alias a template author writing `az:raw(Trusted)` compiles fine then crashes at render with `undefined function az:raw/1`.

`raw/1` stays the supported way to render trusted HTML, so the internal `{arizona_raw, _}` tuple is not exposed to users.