### PR TITLE
Add a signed one-time flash carried across a redirect

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -117,6 +117,8 @@
 {hank, [
     {ignore, [
         {"test/arizona_app_SUITE.erl", [unnecessary_function_arguments]},
+        {"test/arizona_flash_SUITE.erl", [unnecessary_function_arguments]},
+        {"test/arizona_req_SUITE.erl", [unnecessary_function_arguments]},
         {"test/arizona_jsonrpc_SUITE.erl", [unnecessary_function_arguments]},
         {"test/arizona_mcp_SUITE.erl", [unnecessary_function_arguments]},
         {"test/arizona_mcp_e2e_SUITE.erl", [unnecessary_function_arguments]},

--- a/src/arizona_flash.erl
+++ b/src/arizona_flash.erl
@@ -1,0 +1,165 @@
+-module(arizona_flash).
+-moduledoc """
+Signed, one-time flash cookie codec.
+
+A flash is a small map of short-lived display messages carried across a single
+redirect (the Post/Redirect/Get pattern). It rides a dedicated cookie that is
+signed (HMAC-SHA256) with the `arizona` `secret_key` application env, so a client
+cannot forge one, and is consumed on the next request that reads it.
+
+This module owns the wire format: encode/decode the payload and build the
+`Set-Cookie` tuples. `arizona_req` integrates it into the request/response stash
+(`put_flash/3`, `flash/1`, `read_flash/1`), and the `arizona_middleware:fetch_flash/2`
+step reads it into the `flash` binding.
+
+The cookie value is `payload "." signature`, both URL-safe base64 without padding;
+`payload` is the JSON of the flash map and `signature` is its HMAC.
+""".
+
+%% --------------------------------------------------------------------
+%% API function exports
+%% --------------------------------------------------------------------
+
+-export([cookie_name/0]).
+-export([encode/1]).
+-export([decode/1]).
+-export([set_cookie/1]).
+-export([clear_cookie/0]).
+-export([resp_cookie/2]).
+-export([key/1]).
+-export([secret/0]).
+
+%% --------------------------------------------------------------------
+%% Ignore xref warnings
+%% --------------------------------------------------------------------
+
+%% Public codec, exercised by arizona_req; no other internal callers by design.
+-ignore_xref([cookie_name/0]).
+-ignore_xref([encode/1]).
+-ignore_xref([decode/1]).
+-ignore_xref([set_cookie/1]).
+-ignore_xref([clear_cookie/0]).
+-ignore_xref([resp_cookie/2]).
+-ignore_xref([key/1]).
+-ignore_xref([secret/0]).
+
+%% Flash cookie name and lifetime. The flash is consumed on the very next
+%% request, so the max-age is only a safety net if that request never arrives.
+-define(COOKIE, ~"az_flash").
+-define(MAX_AGE, 60).
+
+%% --------------------------------------------------------------------
+%% API Functions
+%% --------------------------------------------------------------------
+
+-doc "The flash cookie name.".
+-spec cookie_name() -> binary().
+cookie_name() ->
+    ?COOKIE.
+
+-doc """
+Encodes a flash map into a signed cookie value. Errors if `secret_key` is unset.
+""".
+-spec encode(Flash) -> binary() when
+    Flash :: arizona_req:flash().
+encode(Flash) ->
+    Payload = iolist_to_binary(json:encode(Flash)),
+    Sig = crypto:mac(hmac, sha256, secret(), Payload),
+    <<(b64(Payload))/binary, ".", (b64(Sig))/binary>>.
+
+-doc """
+Decodes and verifies a cookie value into a flash map, returning `#{}` when the
+signature does not match or the value is malformed.
+""".
+-spec decode(Value) -> arizona_req:flash() when
+    Value :: binary().
+decode(Value) ->
+    try
+        [B64Payload, B64Sig] = binary:split(Value, ~"."),
+        Payload = unb64(B64Payload),
+        Expected = crypto:mac(hmac, sha256, secret(), Payload),
+        true = crypto:hash_equals(unb64(B64Sig), Expected),
+        case json:decode(Payload) of
+            Flash when is_map(Flash) -> Flash;
+            _ -> #{}
+        end
+    catch
+        _:_ -> #{}
+    end.
+
+-doc "The `Set-Cookie` tuple that carries `Flash` to the next request.".
+-spec set_cookie(Flash) -> {binary(), binary(), arizona_req:resp_cookie_opts()} when
+    Flash :: arizona_req:flash().
+set_cookie(Flash) ->
+    {?COOKIE, encode(Flash), cookie_opts(?MAX_AGE)}.
+
+-doc "The `Set-Cookie` tuple that clears a consumed flash.".
+-spec clear_cookie() -> {binary(), binary(), arizona_req:resp_cookie_opts()}.
+clear_cookie() ->
+    {?COOKIE, <<>>, cookie_opts(0)}.
+
+-doc """
+The flash `Set-Cookie` a response should carry, given the outgoing flash and
+whether an incoming one was consumed: a freshly set flash (signed), a clearing
+cookie when one was consumed and none was set, or `none`.
+""".
+-spec resp_cookie(FlashOut, Consumed) ->
+    {binary(), binary(), arizona_req:resp_cookie_opts()} | none
+when
+    FlashOut :: arizona_req:flash(),
+    Consumed :: boolean().
+resp_cookie(FlashOut, _Consumed) when map_size(FlashOut) > 0 ->
+    set_cookie(FlashOut);
+resp_cookie(_FlashOut, true) ->
+    clear_cookie();
+resp_cookie(_FlashOut, false) ->
+    none.
+
+-doc "Normalizes a flash key (an atom is converted to a binary).".
+-spec key(atom() | binary()) -> binary().
+key(Key) when is_atom(Key) -> atom_to_binary(Key, utf8);
+key(Key) when is_binary(Key) -> Key.
+
+-doc """
+Returns the configured flash signing secret from the `arizona` `secret_key`
+application env, erroring if it is unset or empty.
+""".
+-spec secret() -> binary().
+secret() ->
+    case application:get_env(arizona, secret_key) of
+        {ok, Secret} when is_binary(Secret), Secret =/= <<>> ->
+            Secret;
+        _ ->
+            error(
+                {arizona_flash, secret_key_not_configured},
+                none,
+                [
+                    {error_info, #{
+                        cause =>
+                            <<
+                                "flash requires a signing key: set the arizona "
+                                "`secret_key` application env to a random binary"
+                            >>
+                    }}
+                ]
+            )
+    end.
+
+%% --------------------------------------------------------------------
+%% Internal functions
+%% --------------------------------------------------------------------
+
+cookie_opts(MaxAge) ->
+    #{
+        http_only => true,
+        same_site => lax,
+        path => ~"/",
+        max_age => MaxAge,
+        secure => application:get_env(arizona, flash_secure, false)
+    }.
+
+b64(Bin) ->
+    base64:encode(Bin, #{mode => urlsafe, padding => false}).
+
+unb64(Bin) ->
+    base64:decode(Bin, #{mode => urlsafe, padding => false}).

--- a/src/arizona_middleware.erl
+++ b/src/arizona_middleware.erl
@@ -22,6 +22,8 @@ view; a route lists its steps under the `middlewares` key of
   headers, ...) into bindings so a handler reads it with `?get(Key)`.
 - `put_request/2` -- the escape hatch: expose the whole request under the
   `request` binding for lazy access.
+- `fetch_flash/2` -- read the incoming flash (set on the prior request via
+  `arizona_req:put_flash/3`) into the `flash` binding, consuming it.
 
 ```erlang
 #{middlewares => [arizona_middleware:extract([path_bindings, params])]}
@@ -35,6 +37,7 @@ view; a route lists its steps under the `middlewares` key of
 -export([apply_middlewares/3]).
 -export([extract/1]).
 -export([put_request/2]).
+-export([fetch_flash/2]).
 
 %% --------------------------------------------------------------------
 %% Ignore xref warnings
@@ -42,6 +45,7 @@ view; a route lists its steps under the `middlewares` key of
 
 -ignore_xref([extract/1]).
 -ignore_xref([put_request/2]).
+-ignore_xref([fetch_flash/2]).
 
 %% --------------------------------------------------------------------
 %% Types exports
@@ -125,6 +129,23 @@ into the live process or carry across an SPA navigate.
 -spec put_request(arizona_req:request(), az:bindings()) -> middleware_result().
 put_request(Req, Bindings) ->
     {cont, Req, Bindings#{request => Req}}.
+
+-doc """
+Middleware that reads the incoming flash into the `flash` binding (read with
+`?get(flash)`, a map; `#{}` when there is none).
+
+Opt in on routes that display flash messages. Reading consumes the flash: the
+response clears its cookie, so a refresh shows nothing. Pair it with
+`arizona_req:put_flash/3` before a redirect (the Post/Redirect/Get pattern).
+
+```erlang
+#{middlewares => [{arizona_middleware, fetch_flash}]}
+```
+""".
+-spec fetch_flash(arizona_req:request(), az:bindings()) -> middleware_result().
+fetch_flash(Req, Bindings) ->
+    {Flash, Req1} = arizona_req:read_flash(Req),
+    {cont, Req1, Bindings#{flash => Flash}}.
 
 %% --------------------------------------------------------------------
 %% Internal functions

--- a/src/arizona_req.erl
+++ b/src/arizona_req.erl
@@ -38,6 +38,12 @@ Method = arizona_req:method(Req).          %% eager, no thread
 ```
 """.
 
+%% This module is the HTTP request API surface: one lazy accessor per request
+%% field plus the response stash (headers, cookies, status, flash). That is a
+%% cohesive set of small accessors, so it legitimately exceeds the god-module
+%% function count.
+-elvis([{elvis_style, no_god_modules, disable}]).
+
 %% --------------------------------------------------------------------
 %% API function exports
 %% --------------------------------------------------------------------
@@ -65,6 +71,9 @@ Method = arizona_req:method(Req).          %% eager, no thread
 -export([resp_headers/1]).
 -export([resp_cookies/1]).
 -export([resp_status/1]).
+-export([put_flash/3]).
+-export([flash/1]).
+-export([read_flash/1]).
 
 %% --------------------------------------------------------------------
 %% Ignore xref warnings
@@ -89,6 +98,8 @@ Method = arizona_req:method(Req).          %% eager, no thread
 -ignore_xref([resp_headers/1]).
 -ignore_xref([resp_cookies/1]).
 -ignore_xref([resp_status/1]).
+-ignore_xref([put_flash/3]).
+-ignore_xref([flash/1]).
 
 %% --------------------------------------------------------------------
 %% Types exports
@@ -106,6 +117,7 @@ Method = arizona_req:method(Req).          %% eager, no thread
 -export_type([body/0]).
 -export_type([redirect_status/0]).
 -export_type([resp_status/0]).
+-export_type([flash/0]).
 -export_type([resp_cookie_opts/0]).
 -export_type([qs/0]).
 
@@ -127,7 +139,10 @@ Method = arizona_req:method(Req).          %% eager, no thread
     redirect => {redirect_status(), binary()},
     resp_headers => [{binary(), iodata()}],
     resp_cookies => [{binary(), binary(), resp_cookie_opts()}],
-    resp_status => resp_status()
+    resp_status => resp_status(),
+    flash_out => flash(),
+    flash_in => flash(),
+    flash_consumed => boolean()
 }.
 
 -nominal adapter() :: module().
@@ -150,6 +165,11 @@ Method = arizona_req:method(Req).          %% eager, no thread
 %% Any HTTP response status. Stashed by `put_resp_status/2` and used as the OK
 %% status of a rendered page (default 200) -- e.g. a 401 from an auth gate.
 -nominal resp_status() :: 100..599.
+
+%% A flash payload: short-lived display messages carried across one redirect.
+%% Keys are binaries (an atom key passed to `put_flash/3` is normalized); values
+%% are anything `json:encode/1` accepts (typically display strings).
+-nominal flash() :: #{binary() => term()}.
 
 %% Response cookie options stashed by `put_resp_cookie/4` and serialized by
 %% the transport. Mirrors the transport cookie serializer's options.
@@ -404,11 +424,22 @@ put_resp_cookie(Req, Name, Value, Opts) when
 resp_headers(#{resp_headers := Headers}) -> Headers;
 resp_headers(_) -> [].
 
--doc "Returns the stashed response cookies (newest first), or `[]`.".
+-doc """
+Returns the stashed response cookies (newest first), or `[]`, plus the flash
+cookie when one is warranted: a freshly `put_flash/3`-set flash serializes to a
+signed `Set-Cookie`, and a consumed incoming flash (no new one set) serializes to
+a clearing cookie. Transports flush this list verbatim.
+""".
 -spec resp_cookies(Request) -> [{binary(), binary(), resp_cookie_opts()}] when
     Request :: request().
-resp_cookies(#{resp_cookies := Cookies}) -> Cookies;
-resp_cookies(_) -> [].
+resp_cookies(Req) ->
+    Stashed = maps:get(resp_cookies, Req, []),
+    FlashOut = maps:get(flash_out, Req, #{}),
+    Consumed = maps:get(flash_consumed, Req, false),
+    case arizona_flash:resp_cookie(FlashOut, Consumed) of
+        none -> Stashed;
+        Cookie -> Stashed ++ [Cookie]
+    end.
 
 -doc """
 Stashes the HTTP status for a rendered page. Lets a view or middleware return
@@ -427,3 +458,57 @@ put_resp_status(Req, Status) when is_integer(Status), Status >= 100, Status =< 5
     Request :: request().
 resp_status(#{resp_status := Status}) -> Status;
 resp_status(_) -> undefined.
+
+-doc """
+Stashes a flash message to carry across one redirect (the Post/Redirect/Get
+pattern). On the response it serializes to a signed, short-lived `Set-Cookie`;
+the next request reads it once via `flash/1` (or the auto-injected `flash`
+binding) and it is then cleared. `Key` may be an atom or binary (normalized to a
+binary); repeated calls accumulate, last write wins per key.
+
+Requires `secret_key` in the `arizona` application env (used to sign the cookie);
+errors if it is unset.
+""".
+-spec put_flash(Request, Key, Value) -> Request when
+    Request :: request(),
+    Key :: atom() | binary(),
+    Value :: term().
+put_flash(Req, Key, Value) ->
+    %% Fail fast at the call site if signing is unconfigured, rather than later
+    %% when the response serializes the cookie.
+    _ = arizona_flash:secret(),
+    FlashOut = maps:get(flash_out, Req, #{}),
+    Req#{flash_out => FlashOut#{arizona_flash:key(Key) => Value}}.
+
+-doc """
+Returns the incoming flash read from the request, or `#{}`. Populated by
+`read_flash/1` (which the HTTP render pipeline runs before the view), so views
+can also read it through the auto-injected `flash` binding.
+""".
+-spec flash(Request) -> flash() when
+    Request :: request().
+flash(#{flash_in := Flash}) -> Flash;
+flash(_) -> #{}.
+
+-doc """
+Reads, verifies, and decodes the incoming flash cookie into the request, marking
+it consumed so the response clears it (read-once). Returns the flash map (`#{}`
+when absent, unsigned-mismatch, or malformed) and the updated request. Idempotent:
+a second call returns the cached value without re-marking.
+
+Run by the HTTP render pipeline; apps normally use `flash/1` or the `flash`
+binding rather than calling this directly.
+""".
+-spec read_flash(Request) -> {flash(), Request} when
+    Request :: request().
+read_flash(#{flash_in := Flash} = Req) ->
+    {Flash, Req};
+read_flash(Req0) ->
+    {Cookies, Req} = cookies(Req0),
+    case lists:keyfind(arizona_flash:cookie_name(), 1, Cookies) of
+        {_, Value} ->
+            Flash = arizona_flash:decode(Value),
+            {Flash, Req#{flash_in => Flash, flash_consumed => true}};
+        false ->
+            {#{}, Req#{flash_in => #{}}}
+    end.

--- a/test/arizona_flash_SUITE.erl
+++ b/test/arizona_flash_SUITE.erl
@@ -1,0 +1,83 @@
+-module(arizona_flash_SUITE).
+-include_lib("stdlib/include/assert.hrl").
+
+-export([all/0]).
+-export([init_per_suite/1]).
+-export([end_per_suite/1]).
+
+-export([cookie_name_is_az_flash/1]).
+-export([encode_decode_round_trips/1]).
+-export([decode_rejects_tampered_signature/1]).
+-export([decode_rejects_malformed/1]).
+-export([key_normalizes_atom/1]).
+-export([resp_cookie_sets_when_flash_present/1]).
+-export([resp_cookie_clears_when_consumed/1]).
+-export([resp_cookie_none_when_idle/1]).
+-export([secret_errors_when_unset/1]).
+
+%% Sequential (not parallel): the cases share the `secret_key` application env,
+%% and secret_errors_when_unset/1 toggles it.
+all() ->
+    [
+        cookie_name_is_az_flash,
+        encode_decode_round_trips,
+        decode_rejects_tampered_signature,
+        decode_rejects_malformed,
+        key_normalizes_atom,
+        resp_cookie_sets_when_flash_present,
+        resp_cookie_clears_when_consumed,
+        resp_cookie_none_when_idle,
+        secret_errors_when_unset
+    ].
+
+init_per_suite(Config) ->
+    application:set_env(arizona, secret_key, ~"test-secret-key-0123456789abcdef"),
+    Config.
+
+end_per_suite(_Config) ->
+    application:unset_env(arizona, secret_key),
+    ok.
+
+cookie_name_is_az_flash(Config) when is_list(Config) ->
+    ?assertEqual(~"az_flash", arizona_flash:cookie_name()).
+
+encode_decode_round_trips(Config) when is_list(Config) ->
+    Flash = #{~"error" => ~"Invalid email or password.", ~"info" => ~"hi"},
+    ?assertEqual(Flash, arizona_flash:decode(arizona_flash:encode(Flash))).
+
+decode_rejects_tampered_signature(Config) when is_list(Config) ->
+    Encoded = arizona_flash:encode(#{~"error" => ~"boom"}),
+    %% Corrupt the trailing signature byte; the HMAC check must fail closed.
+    ?assertEqual(#{}, arizona_flash:decode(<<Encoded/binary, "x">>)).
+
+decode_rejects_malformed(Config) when is_list(Config) ->
+    ?assertEqual(#{}, arizona_flash:decode(~"not-a-flash")),
+    ?assertEqual(#{}, arizona_flash:decode(~"")).
+
+key_normalizes_atom(Config) when is_list(Config) ->
+    ?assertEqual(~"error", arizona_flash:key(error)),
+    ?assertEqual(~"error", arizona_flash:key(~"error")).
+
+resp_cookie_sets_when_flash_present(Config) when is_list(Config) ->
+    {Name, Value, Opts} = arizona_flash:resp_cookie(#{~"error" => ~"x"}, false),
+    ?assertEqual(~"az_flash", Name),
+    ?assertNotEqual(<<>>, Value),
+    ?assert(maps:get(max_age, Opts) > 0),
+    ?assertEqual(true, maps:get(http_only, Opts)).
+
+resp_cookie_clears_when_consumed(Config) when is_list(Config) ->
+    {Name, Value, Opts} = arizona_flash:resp_cookie(#{}, true),
+    ?assertEqual(~"az_flash", Name),
+    ?assertEqual(<<>>, Value),
+    ?assertEqual(0, maps:get(max_age, Opts)).
+
+resp_cookie_none_when_idle(Config) when is_list(Config) ->
+    ?assertEqual(none, arizona_flash:resp_cookie(#{}, false)).
+
+secret_errors_when_unset(Config) when is_list(Config) ->
+    application:unset_env(arizona, secret_key),
+    try
+        ?assertError({arizona_flash, secret_key_not_configured}, arizona_flash:secret())
+    after
+        application:set_env(arizona, secret_key, ~"test-secret-key-0123456789abcdef")
+    end.

--- a/test/arizona_req_SUITE.erl
+++ b/test/arizona_req_SUITE.erl
@@ -3,6 +3,8 @@
 
 -export([all/0]).
 -export([groups/0]).
+-export([init_per_suite/1]).
+-export([end_per_suite/1]).
 
 -export([new_stores_adapter_method_and_path/1]).
 -export([new_accepts_prepopulated_fields/1]).
@@ -19,6 +21,9 @@
 -export([put_resp_cookie_accumulates/1]).
 -export([put_resp_status_stashes/1]).
 -export([resp_stash_defaults_empty/1]).
+-export([put_flash_serializes_into_resp_cookies/1]).
+-export([read_flash_round_trips_and_clears/1]).
+-export([read_flash_absent_is_empty/1]).
 -export([call_resolve_route_dispatches_to_adapter/1]).
 
 all() ->
@@ -41,12 +46,23 @@ groups() ->
             put_resp_header_accumulates,
             put_resp_cookie_accumulates,
             put_resp_status_stashes,
-            resp_stash_defaults_empty
+            resp_stash_defaults_empty,
+            put_flash_serializes_into_resp_cookies,
+            read_flash_round_trips_and_clears,
+            read_flash_absent_is_empty
         ]},
         {resolve_route, [parallel], [
             call_resolve_route_dispatches_to_adapter
         ]}
     ].
+
+init_per_suite(Config) ->
+    application:set_env(arizona, secret_key, ~"test-secret-key-0123456789abcdef"),
+    Config.
+
+end_per_suite(_Config) ->
+    application:unset_env(arizona, secret_key),
+    ok.
 
 %% --------------------------------------------------------------------
 %% Accessor cases
@@ -179,6 +195,33 @@ resp_stash_defaults_empty(Config) when is_list(Config) ->
     ?assertEqual([], arizona_req:resp_headers(Req)),
     ?assertEqual([], arizona_req:resp_cookies(Req)),
     ?assertEqual(undefined, arizona_req:resp_status(Req)).
+
+put_flash_serializes_into_resp_cookies(Config) when is_list(Config) ->
+    Req0 = arizona_req_test_adapter:new(#{}),
+    Req1 = arizona_req:put_flash(Req0, error, ~"Invalid email or password."),
+    %% resp_cookies includes the signed flash cookie, which round-trips back.
+    [{Name, Value, Opts}] = arizona_req:resp_cookies(Req1),
+    ?assertEqual(~"az_flash", Name),
+    ?assert(maps:get(max_age, Opts) > 0),
+    ?assertEqual(#{~"error" => ~"Invalid email or password."}, arizona_flash:decode(Value)).
+
+read_flash_round_trips_and_clears(Config) when is_list(Config) ->
+    %% A request carrying a valid flash cookie reads it, and the response clears
+    %% it (read-once).
+    Encoded = arizona_flash:encode(#{~"error" => ~"nope"}),
+    Req0 = arizona_req_test_adapter:new(#{cookies => [{~"az_flash", Encoded}]}),
+    {Flash, Req1} = arizona_req:read_flash(Req0),
+    ?assertEqual(#{~"error" => ~"nope"}, Flash),
+    ?assertEqual(Flash, arizona_req:flash(Req1)),
+    [{~"az_flash", <<>>, Opts}] = arizona_req:resp_cookies(Req1),
+    ?assertEqual(0, maps:get(max_age, Opts)).
+
+read_flash_absent_is_empty(Config) when is_list(Config) ->
+    Req0 = arizona_req_test_adapter:new(#{cookies => []}),
+    {Flash, Req1} = arizona_req:read_flash(Req0),
+    ?assertEqual(#{}, Flash),
+    %% Nothing consumed and nothing set -> no flash cookie on the response.
+    ?assertEqual([], arizona_req:resp_cookies(Req1)).
 
 %% --------------------------------------------------------------------
 %% resolve_route -- exercises the optional callback wiring

--- a/test/arizona_ws_SUITE.erl
+++ b/test/arizona_ws_SUITE.erl
@@ -30,6 +30,7 @@
     http_halt_sets_cookie/1,
     http_render_sets_cookie/1,
     http_render_sets_status/1,
+    http_flash_round_trip/1,
     http_render_crash_emits_error_page/1,
     http_reads_cookies_headers_body/1,
     http_exposes_roadrunner_request_id/1,
@@ -87,6 +88,7 @@ groups() ->
         http_halt_sets_cookie,
         http_render_sets_cookie,
         http_render_sets_status,
+        http_flash_round_trip,
         http_render_crash_emits_error_page,
         http_reads_cookies_headers_body,
         http_exposes_roadrunner_request_id,
@@ -123,6 +125,8 @@ groups() ->
 init_per_group(roadrunner, Config) ->
     {ok, _} = application:ensure_all_started(arizona),
     {ok, _} = application:ensure_all_started(roadrunner),
+    %% Signing key for the flash cookie (see the set_flash/show_flash routes).
+    application:set_env(arizona, secret_key, ~"ws-suite-secret-key-0123456789ab"),
     Port = pick_port(),
     %% Tests that assert on URL data in rendered HTML opt into the framework's
     %% `arizona_middleware:extract/1` middleware on their routes; the framework itself
@@ -215,6 +219,26 @@ init_per_group(roadrunner, Config) ->
                 end
             ]
         }},
+        %% PRG flash: set a flash then redirect (the 303 carries Set-Cookie
+        %% az_flash). /show_flash reads it via the fetch_flash middleware, projects
+        %% it into `status` for the rendered body, and the response clears it.
+        {live, <<"/set_flash">>, arizona_crashable, #{
+            middlewares => [
+                fun(Req, _B) ->
+                    Req1 = arizona_req:put_flash(Req, error, <<"flashed">>),
+                    {halt, arizona_req:redirect(Req1, 303, <<"/show_flash">>)}
+                end
+            ]
+        }},
+        {live, <<"/show_flash">>, arizona_crashable, #{
+            middlewares => [
+                {arizona_middleware, fetch_flash},
+                fun(Req, B) ->
+                    Flash = maps:get(flash, B, #{}),
+                    {cont, Req, B#{status => maps:get(<<"error">>, Flash, <<"none">>)}}
+                end
+            ]
+        }},
         {live, <<"/crash_on_render_http">>, arizona_crashable, #{
             bindings => #{crash_on_mount => true}
         }},
@@ -274,6 +298,7 @@ init_per_group(_Group, Config) ->
 end_per_group(roadrunner, Config) ->
     ServerMod = ?config(server_mod, Config),
     _ = ServerMod:stop(ws_test),
+    _ = application:unset_env(arizona, secret_key),
     _ = application:stop(arizona),
     ok;
 end_per_group(_Group, _Config) ->
@@ -503,6 +528,40 @@ http_render_sets_status(Config) ->
     {ok, Resp} = gen_tcp:recv(Sock, 0, 5000),
     gen_tcp:close(Sock),
     ?assertNotEqual(nomatch, binary:match(Resp, <<"HTTP/1.1 401">>)).
+
+http_flash_round_trip(Config) ->
+    %% PRG flash end-to-end: /set_flash redirects (303) with Set-Cookie az_flash;
+    %% /show_flash reads it via fetch_flash (body shows the message) and clears it.
+    Port = proplists:get_value(port, Config),
+    Resp1 = flash_http_get(Port, "/set_flash", []),
+    ?assertNotEqual(nomatch, binary:match(Resp1, <<"303">>)),
+    {match, [Cookie]} = re:run(
+        Resp1, "set-cookie: (az_flash=[^;\r\n]*)", [caseless, {capture, [1], binary}]
+    ),
+    ?assertNotEqual(<<"az_flash=">>, Cookie),
+    Resp2 = flash_http_get(Port, "/show_flash", [Cookie]),
+    %% The flash message reached the view, and the response clears the cookie.
+    ?assertNotEqual(nomatch, binary:match(Resp2, <<"flashed">>)),
+    ?assertNotEqual(nomatch, binary:match(Resp2, <<"az_flash=;">>)),
+    ?assertNotEqual(nomatch, binary:match(Resp2, <<"Max-Age=0">>)).
+
+flash_http_get(Port, Path, CookieHeaders) ->
+    {ok, Sock} = gen_tcp:connect("localhost", Port, [binary, {active, false}]),
+    Cookies = [["Cookie: ", C, "\r\n"] || C <- CookieHeaders],
+    Req = [
+        "GET ",
+        Path,
+        " HTTP/1.1\r\n",
+        "Host: localhost:",
+        integer_to_list(Port),
+        "\r\n",
+        Cookies,
+        "\r\n"
+    ],
+    ok = gen_tcp:send(Sock, Req),
+    {ok, Resp} = gen_tcp:recv(Sock, 0, 5000),
+    gen_tcp:close(Sock),
+    Resp.
 
 middleware_halt_rejects_ws(Config) ->
     %% WS: middleware halts -- upgrade never happens, HTTP response returned


### PR DESCRIPTION
Generic flash for the Post/Redirect/Get pattern: set a short-lived message before a redirect, read it once after, then it is gone. No HTML or CSS, just the data.

- `arizona_req:put_flash/3` stashes a message; on the response it serializes to a signed, short-lived `Set-Cookie`.
- `arizona_middleware:fetch_flash/2` is the opt-in step a route adds to read the flash into the `flash` binding; reading consumes it, so a refresh shows nothing.
- `arizona_flash` owns the wire format (HMAC-SHA256 over the JSON payload, URL-safe base64), keyed by the `arizona` `secret_key` application env so a client cannot forge one.

Nothing is injected unless a route opts in via the middleware.