### PR TITLE
Accept bare element tuples in control-flow branch tails without an ?html wrap

### DIFF
--- a/.claude/rules/erlang.md
+++ b/.claude/rules/erlang.md
@@ -161,7 +161,9 @@ value: `fun(Item, Key) -> {li, [], [Item]} end`).
 
 - Plain values: use a list comprehension or `lists:map/2` (no per-item diffing, fine for
   small or static lists).
-- A conditional: put it **inside** an element as a text/value child.
+- A conditional: put it **inside** an element as a text/value child. Only the `?each`
+  **body** must be a direct element -- a conditional sitting in a content slot may itself
+  return a bare element tuple (see "Bare element tuples in conditional tails" below).
 
 ```erlang
 %% rejected (would crash on diff): a case / ?html body
@@ -171,6 +173,30 @@ value: `fun(Item, Key) -> {li, [], [Item]} end`).
 %% plain values: a comprehension, not ?each
 {ul, [], [[<<"#", Tag/binary>> || Tag <- ?get(tags)]]}
 ```
+
+## Bare element tuples in conditional tails
+
+A `case`, `if`, or `begin` in a **content slot** may return a bare element tuple, an
+element list, or a mixed fragment (static text/values interleaved with elements)
+directly from a branch -- the parse transform compiles each branch tail into a nested
+template, exactly as a literal `?html`/`?native`/`?terminal` there would, inheriting the
+enclosing render target. No `?html` wrap is needed:
+
+```erlang
+%% both branches accepted: <<>> renders empty, the tuple becomes a nested template
+{main, [], [
+    case ?get(error) of
+        undefined -> <<>>;
+        Message -> {p, [{class, ~"login-error"}], Message}
+    end
+]}
+```
+
+A branch returning a plain value (binary, integer, variable, or a pure value list) still
+renders as a scalar, unchanged. Nested conditionals are walked recursively. `try`/`receive`
+tails are **not** descended into -- a bare element there still needs an explicit `?html`. (This
+mirrors `?each`, whose callback body already accepts bare elements; the difference is
+that `?each` keys items for per-item diffing while a conditional is a single slot.)
 
 **Known limitation:** embedding a component (a `?stateless`/`?stateful` descriptor) as an
 `?each` item child compiles and renders at SSR but **crashes on the first diff** -- the

--- a/.claude/rules/erlang.md
+++ b/.claude/rules/erlang.md
@@ -176,11 +176,12 @@ value: `fun(Item, Key) -> {li, [], [Item]} end`).
 
 ## Bare element tuples in conditional tails
 
-A `case`, `if`, or `begin` in a **content slot** may return a bare element tuple, an
-element list, or a mixed fragment (static text/values interleaved with elements)
-directly from a branch -- the parse transform compiles each branch tail into a nested
-template, exactly as a literal `?html`/`?native`/`?terminal` there would, inheriting the
-enclosing render target. No `?html` wrap is needed:
+A control-flow expression in a **content slot** -- `case`, `if`, `begin`, `receive`,
+`try`, or `maybe` -- may return a bare element tuple, an element list, or a mixed fragment
+(static text/values interleaved with elements) directly from a tail position. The parse
+transform compiles each tail into a nested template, exactly as a literal
+`?html`/`?native`/`?terminal` there would, inheriting the enclosing render target. No
+`?html` wrap is needed:
 
 ```erlang
 %% both branches accepted: <<>> renders empty, the tuple becomes a nested template
@@ -192,11 +193,15 @@ enclosing render target. No `?html` wrap is needed:
 ]}
 ```
 
-A branch returning a plain value (binary, integer, variable, or a pure value list) still
-renders as a scalar, unchanged. Nested conditionals are walked recursively. `try`/`receive`
-tails are **not** descended into -- a bare element there still needs an explicit `?html`. (This
-mirrors `?each`, whose callback body already accepts bare elements; the difference is
-that `?each` keys items for per-item diffing while a conditional is a single slot.)
+The walked tail positions are the value-producing ones: clause bodies (`case`/`if`/`try`
+`of`+`catch`/`maybe` `else`/`receive`), block last expressions, a `receive` `after` body,
+and a `try` body. A `try`/`receive` timeout and a `try` `after` body are **not** tails
+(their values are discarded). A branch returning a plain value (binary, integer, variable,
+or a pure value list) still renders as a scalar, unchanged; nested control flow is walked
+recursively. The set of forms and tail positions is defined once in `map_tail_exprs/3`,
+shared with the live-render-root transform. (This mirrors `?each`, whose callback body
+already accepts bare elements; the difference is that `?each` keys items for per-item
+diffing while a conditional is a single slot.)
 
 **Known limitation:** embedding a component (a `?stateless`/`?stateful` descriptor) as an
 `?each` item child compiles and renders at SSR but **crashes on the first diff** -- the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -135,9 +135,10 @@ render(Bindings) ->
     ).
 ```
 
-**Conditional rows:** a `case`/`if`/`begin` returning a bare element tuple in a
-content slot is compiled into a nested template (inheriting the enclosing target),
-just as a literal `?html`/`?terminal` there would be -- no wrap needed:
+**Conditional rows:** a control-flow expression (`case`/`if`/`begin`/`receive`/`try`/
+`maybe`) returning a bare element tuple from a tail in a content slot is compiled into a
+nested template (inheriting the enclosing target), just as a literal `?html`/`?terminal`
+there would be -- no wrap needed:
 
 ```erlang
 {col, [], [

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -135,9 +135,20 @@ render(Bindings) ->
     ).
 ```
 
-**Conditional rows:** a `case` returning a bare element tuple reaches the diff as a
-dynamic value and crashes `arizona_template:to_bin/1`. Render a 0-or-1 element with
-`?each` over a list instead:
+**Conditional rows:** a `case`/`if`/`begin` returning a bare element tuple in a
+content slot is compiled into a nested template (inheriting the enclosing target),
+just as a literal `?html`/`?terminal` there would be -- no wrap needed:
+
+```erlang
+{col, [], [
+    case ?get(mode) of
+        warn -> {line, [yellow], [~"check your input"]};
+        _ -> <<>>
+    end
+]}
+```
+
+For 0-or-N rows, `?each` over a list still applies:
 
 ```erlang
 ?each(fun(Msg) -> {line, [yellow], [Msg]} end, status_rows(?get(mode)))

--- a/src/arizona_parse_transform.erl
+++ b/src/arizona_parse_transform.erl
@@ -506,9 +506,20 @@ transform_live_render_clause({clause, L, Patterns, Guards, Body}, Module) ->
     Body1 = TransformedInit ++ [TransformedLast],
     {clause, L, Patterns, Guards, suppress_unused_inline_matches(Body1, Inline)}.
 
+%% The render clause's last expression carries the live-root template -- a direct
+%% ?html/?native call, or a control-flow expression whose every tail carries a
+%% root. Walk each tail position (shared with content-slot expansion via
+%% map_tail_exprs/3), compiling the root at each leaf; non-tail sub-expressions
+%% are transformed normally.
 transform_live_render_last(Expr, Module, Inline) ->
-    N = erl_syntax:revert(Expr),
-    case N of
+    map_tail_exprs(
+        Expr,
+        fun(Leaf) -> transform_live_render_leaf(Leaf, Module, Inline) end,
+        fun(NonTail) -> transform_expr(NonTail, Module, Inline) end
+    ).
+
+transform_live_render_leaf(Expr, Module, Inline) ->
+    case erl_syntax:revert(Expr) of
         {call, L, {remote, _, {atom, _, Mod}, {atom, _, html}}, [Arg]} when
             Mod =:= arizona_template; Mod =:= az
         ->
@@ -521,52 +532,61 @@ transform_live_render_last(Expr, Module, Inline) ->
             validate_live_root(Arg, L, Inline),
             Arg1 = transform_expr(Arg, Module, Inline),
             compile_template(inline_vars(Arg1, Inline), L, Module, true, arizona_native);
-        {'case', L, CaseExpr, Clauses} ->
-            {'case', L, transform_expr(CaseExpr, Module, Inline), [
-                transform_live_render_branch(C, Module, Inline)
-             || C <- Clauses
-            ]};
-        {'if', L, Clauses} ->
-            {'if', L, [transform_live_render_branch(C, Module, Inline) || C <- Clauses]};
-        {block, L, Body} ->
-            transform_live_render_block(L, Body, Module, Inline);
-        {'receive', L, Clauses} ->
-            {'receive', L, [transform_live_render_branch(C, Module, Inline) || C <- Clauses]};
-        {'receive', L, Clauses, AfterExpr, AfterBody} ->
-            {'receive', L, [transform_live_render_branch(C, Module, Inline) || C <- Clauses],
-                transform_expr(AfterExpr, Module, Inline),
-                transform_live_render_block_body(AfterBody, Module, Inline)};
-        {'try', L, Body, OfClauses, CatchClauses, AfterBody} ->
-            {'try', L, transform_live_render_block_body(Body, Module, Inline),
-                [transform_live_render_branch(C, Module, Inline) || C <- OfClauses],
-                [transform_live_render_branch(C, Module, Inline) || C <- CatchClauses], [
-                    transform_expr(E, Module, Inline)
-                 || E <- AfterBody
-                ]};
-        {'maybe', L, Body} ->
-            {'maybe', L, transform_live_render_block_body(Body, Module, Inline)};
-        {'maybe', L, Body, {'else', L2, ElseClauses}} ->
-            {'maybe', L, transform_live_render_block_body(Body, Module, Inline),
-                {'else', L2, [
-                    transform_live_render_branch(C, Module, Inline)
-                 || C <- ElseClauses
-                ]}};
         _ ->
             transform_expr(Expr, Module, Inline)
     end.
 
-transform_live_render_block(L, Body, Module, Inline) ->
-    {block, L, transform_live_render_block_body(Body, Module, Inline)}.
+%% Walk the tail (value-producing) positions of a control-flow expression,
+%% applying `TailFun` at each tail leaf (a tail that is not itself control-flow)
+%% and `NonTailFun` at every non-tail sub-expression: a `case` scrutinee, the
+%% init statements before a body's last expression, a `receive` timeout, a `try`
+%% `after` body. Tails that are themselves control-flow recurse; a
+%% non-control-flow `Expr` is itself a tail leaf. This is the single definition
+%% of "tail position" shared by the live-render-root transform
+%% (transform_live_render_last/3) and the content-slot element expansion
+%% (expand_block_element_tails/3). `try` body last is treated as a tail even with
+%% `of` clauses (its value is then matched by `of`, but this mirrors the original
+%% live-render behaviour and never matters for real templates).
+map_tail_exprs(Expr, TailFun, NonTailFun) ->
+    case erl_syntax:revert(Expr) of
+        {'case', L, Scrutinee, Clauses} ->
+            {'case', L, NonTailFun(Scrutinee), [
+                map_tail_clause(C, TailFun, NonTailFun)
+             || C <- Clauses
+            ]};
+        {'if', L, Clauses} ->
+            {'if', L, [map_tail_clause(C, TailFun, NonTailFun) || C <- Clauses]};
+        {block, L, Body} ->
+            {block, L, map_tail_body(Body, TailFun, NonTailFun)};
+        {'receive', L, Clauses} ->
+            {'receive', L, [map_tail_clause(C, TailFun, NonTailFun) || C <- Clauses]};
+        {'receive', L, Clauses, AfterExpr, AfterBody} ->
+            {'receive', L, [map_tail_clause(C, TailFun, NonTailFun) || C <- Clauses],
+                NonTailFun(AfterExpr), map_tail_body(AfterBody, TailFun, NonTailFun)};
+        {'try', L, Body, OfClauses, CatchClauses, AfterBody} ->
+            {'try', L, map_tail_body(Body, TailFun, NonTailFun),
+                [map_tail_clause(C, TailFun, NonTailFun) || C <- OfClauses],
+                [map_tail_clause(C, TailFun, NonTailFun) || C <- CatchClauses], [
+                    NonTailFun(E)
+                 || E <- AfterBody
+                ]};
+        {'maybe', L, Body} ->
+            {'maybe', L, map_tail_body(Body, TailFun, NonTailFun)};
+        {'maybe', L, Body, {'else', L2, ElseClauses}} ->
+            {'maybe', L, map_tail_body(Body, TailFun, NonTailFun),
+                {'else', L2, [map_tail_clause(C, TailFun, NonTailFun) || C <- ElseClauses]}};
+        _ ->
+            TailFun(Expr)
+    end.
 
-transform_live_render_block_body(Body, Module, Inline) ->
-    {Init, [Last]} = lists:split(length(Body) - 1, Body),
-    [transform_expr(E, Module, Inline) || E <- Init] ++
-        [transform_live_render_last(Last, Module, Inline)].
+map_tail_clause({clause, L, Patterns, Guards, Body}, TailFun, NonTailFun) ->
+    {clause, L, Patterns, Guards, map_tail_body(Body, TailFun, NonTailFun)}.
 
-transform_live_render_branch({clause, L, Patterns, Guards, Body}, Module, Inline) ->
+%% Only a body's last expression is a tail (recursing through map_tail_exprs/3 so
+%% a control-flow last is walked too); the init statements are non-tail.
+map_tail_body(Body, TailFun, NonTailFun) ->
     {Init, [Last]} = lists:split(length(Body) - 1, Body),
-    TransInit = [transform_expr(E, Module, Inline) || E <- Init],
-    {clause, L, Patterns, Guards, TransInit ++ [transform_live_render_last(Last, Module, Inline)]}.
+    [NonTailFun(E) || E <- Init] ++ [map_tail_exprs(Last, TailFun, NonTailFun)].
 
 validate_live_root({tuple, _, [_Tag, Attrs | _]}, L, Inline) ->
     validate_id_expr(Attrs, L, Inline);
@@ -1560,50 +1580,36 @@ make_esc_text_dynamic_ast(AzBin, ExprAST0, Module, ExprLine, Backend) ->
     {tuple, 0, [ast_binary(AzBin), esc_spec(Backend, ExprAST, FunAST), LocAST]}.
 
 %% A content slot's value can be the result of a control-flow expression
-%% (`case`/`if`/`begin`). Those result positions are themselves content
-%% positions: an element tuple (or element list) sitting in a clause/block tail
-%% is compiled into a nested template -- exactly as a literal ?html(...) there
-%% would be -- so conditional branches don't need an explicit ?html wrap. The
-%% current Backend is threaded through, so a bare element in a branch under
-%% ?native/?terminal inherits that target (mirroring how ?each does). Non-element
-%% tails and plain values are left untouched (they render as escaped scalars, as
-%% before). `try`/`receive` tails are intentionally not descended into -- a bare
-%% element there still requires an explicit ?html.
-expand_block_element_tails({'case', L, Expr, Clauses}, Module, Backend) ->
-    {'case', L, Expr, [expand_clause_tail(C, Module, Backend) || C <- Clauses]};
-expand_block_element_tails({'if', L, Clauses}, Module, Backend) ->
-    {'if', L, [expand_clause_tail(C, Module, Backend) || C <- Clauses]};
-expand_block_element_tails({block, L, Exprs}, Module, Backend) ->
-    {block, L, expand_last_expr(Exprs, Module, Backend)};
-expand_block_element_tails(Other, _Module, _Backend) ->
-    Other.
+%% (`case`/`if`/`begin`/`receive`/`try`/`maybe`). Those tail positions are
+%% themselves content positions: an element tuple (or element list, or mixed
+%% fragment) sitting in a tail is compiled into a nested template -- exactly as a
+%% literal ?html(...) there would be -- so branches don't need an explicit ?html
+%% wrap. The current Backend is threaded through, so a bare element under
+%% ?native/?terminal inherits that target (mirroring how ?each does). Non-tail
+%% sub-expressions and non-element tails are left untouched (a non-element tail
+%% renders as an escaped scalar, as before). The set of walked forms is shared
+%% with the live-render-root transform via map_tail_exprs/3.
+expand_block_element_tails(Expr, Module, Backend) ->
+    map_tail_exprs(
+        Expr,
+        fun(Leaf) -> expand_element_leaf(Leaf, Module, Backend) end,
+        fun(NonTail) -> NonTail end
+    ).
 
-expand_clause_tail({clause, L, Patterns, Guards, Body}, Module, Backend) ->
-    {clause, L, Patterns, Guards, expand_last_expr(Body, Module, Backend)}.
-
-%% Rewrite only the last (result) expression of a clause/block body.
-expand_last_expr([], _Module, _Backend) ->
-    [];
-expand_last_expr([Last], Module, Backend) ->
-    [expand_tail_expr(Last, Module, Backend)];
-expand_last_expr([Expr | Rest], Module, Backend) ->
-    [Expr | expand_last_expr(Rest, Module, Backend)].
-
-expand_tail_expr(Expr, Module, Backend) ->
+%% At a tail leaf, compile a bare element tuple / element list (or a mixed list
+%% that contains an element tuple) into a nested template, as a literal ?html
+%% there would; leave plain values (and pure value lists) untouched.
+expand_element_leaf(Expr, Module, Backend) ->
     case classify_body(Expr) of
         Class when Class =:= element_tuple; Class =:= element_list ->
             compile_template(Expr, line(Expr), Module, false, Backend);
         list_ast ->
-            %% A mixed list (static text / values interleaved with element
-            %% tuples) is compiled as a fragment only when it actually contains
-            %% an element tuple -- a pure value list keeps its scalar/iolist
-            %% semantics (a single value slot), unchanged.
             case list_has_element_tuple(Expr) of
                 true -> compile_template(Expr, line(Expr), Module, false, Backend);
                 false -> Expr
             end;
         _ ->
-            expand_block_element_tails(Expr, Module, Backend)
+            Expr
     end.
 
 list_has_element_tuple({cons, _, Head, Tail}) ->

--- a/src/arizona_parse_transform.erl
+++ b/src/arizona_parse_transform.erl
@@ -1553,10 +1553,63 @@ make_text_dynamic_ast(AzBin, ExprAST, Module, ExprLine) ->
 %% template, ?each, ?inner_content, ?stateful/?stateless, a map, or raw/1 -- is
 %% left untagged and rendered structurally (escaping is decided at compile time
 %% so the runtime can never confuse user scalars with spliced framework HTML).
-make_esc_text_dynamic_ast(AzBin, ExprAST, Module, ExprLine, Backend) ->
+make_esc_text_dynamic_ast(AzBin, ExprAST0, Module, ExprLine, Backend) ->
+    ExprAST = expand_block_element_tails(ExprAST0, Module, Backend),
     LocAST = loc_ast(Module, ExprLine),
     FunAST = {'fun', 0, {clauses, [{clause, 0, [], [], [ExprAST]}]}},
     {tuple, 0, [ast_binary(AzBin), esc_spec(Backend, ExprAST, FunAST), LocAST]}.
+
+%% A content slot's value can be the result of a control-flow expression
+%% (`case`/`if`/`begin`). Those result positions are themselves content
+%% positions: an element tuple (or element list) sitting in a clause/block tail
+%% is compiled into a nested template -- exactly as a literal ?html(...) there
+%% would be -- so conditional branches don't need an explicit ?html wrap. The
+%% current Backend is threaded through, so a bare element in a branch under
+%% ?native/?terminal inherits that target (mirroring how ?each does). Non-element
+%% tails and plain values are left untouched (they render as escaped scalars, as
+%% before). `try`/`receive` tails are intentionally not descended into -- a bare
+%% element there still requires an explicit ?html.
+expand_block_element_tails({'case', L, Expr, Clauses}, Module, Backend) ->
+    {'case', L, Expr, [expand_clause_tail(C, Module, Backend) || C <- Clauses]};
+expand_block_element_tails({'if', L, Clauses}, Module, Backend) ->
+    {'if', L, [expand_clause_tail(C, Module, Backend) || C <- Clauses]};
+expand_block_element_tails({block, L, Exprs}, Module, Backend) ->
+    {block, L, expand_last_expr(Exprs, Module, Backend)};
+expand_block_element_tails(Other, _Module, _Backend) ->
+    Other.
+
+expand_clause_tail({clause, L, Patterns, Guards, Body}, Module, Backend) ->
+    {clause, L, Patterns, Guards, expand_last_expr(Body, Module, Backend)}.
+
+%% Rewrite only the last (result) expression of a clause/block body.
+expand_last_expr([], _Module, _Backend) ->
+    [];
+expand_last_expr([Last], Module, Backend) ->
+    [expand_tail_expr(Last, Module, Backend)];
+expand_last_expr([Expr | Rest], Module, Backend) ->
+    [Expr | expand_last_expr(Rest, Module, Backend)].
+
+expand_tail_expr(Expr, Module, Backend) ->
+    case classify_body(Expr) of
+        Class when Class =:= element_tuple; Class =:= element_list ->
+            compile_template(Expr, line(Expr), Module, false, Backend);
+        list_ast ->
+            %% A mixed list (static text / values interleaved with element
+            %% tuples) is compiled as a fragment only when it actually contains
+            %% an element tuple -- a pure value list keeps its scalar/iolist
+            %% semantics (a single value slot), unchanged.
+            case list_has_element_tuple(Expr) of
+                true -> compile_template(Expr, line(Expr), Module, false, Backend);
+                false -> Expr
+            end;
+        _ ->
+            expand_block_element_tails(Expr, Module, Backend)
+    end.
+
+list_has_element_tuple({cons, _, Head, Tail}) ->
+    is_element_tuple(Head) orelse list_has_element_tuple(Tail);
+list_has_element_tuple(_) ->
+    false.
 
 %% Tag a value interpolation `{esc, Fun}` (escaped at the HTML boundary) or leave
 %% it bare. Only the HTML backend escapes -- native/terminal output is plain text,
@@ -1609,7 +1662,8 @@ make_attr_dynamic_ast(AzBin, AttrNameBin, ExprAST, Module, ExprLine) ->
 %% nodiff (layout) path: a value interpolation (e.g. a layout `title`) is tagged
 %% `{esc, Fun}` so SSR HTML-escapes it; a block (?inner_content, nested template)
 %% is left untagged and spliced raw.
-make_nodiff_dynamic_ast(ExprAST, Module, ExprLine, Backend) ->
+make_nodiff_dynamic_ast(ExprAST0, Module, ExprLine, Backend) ->
+    ExprAST = expand_block_element_tails(ExprAST0, Module, Backend),
     LocAST = loc_ast(Module, ExprLine),
     FunAST = {'fun', 0, {clauses, [{clause, 0, [], [], [ExprAST]}]}},
     {tuple, 0, [{atom, 0, undefined}, esc_spec(Backend, ExprAST, FunAST), LocAST]}.

--- a/test/arizona_parse_transform_SUITE.erl
+++ b/test/arizona_parse_transform_SUITE.erl
@@ -254,7 +254,10 @@
     cond_case_diff_transition/1,
     cond_case_element_list_tail/1,
     cond_case_mixed_fragment_tail/1,
-    cond_begin_block_tail/1
+    cond_begin_block_tail/1,
+    cond_try_bare_element/1,
+    cond_maybe_bare_element/1,
+    cond_receive_bare_element/1
 ]).
 
 all() ->
@@ -422,7 +425,10 @@ groups() ->
             cond_case_diff_transition,
             cond_case_element_list_tail,
             cond_case_mixed_fragment_tail,
-            cond_begin_block_tail
+            cond_begin_block_tail,
+            cond_try_bare_element,
+            cond_maybe_bare_element,
+            cond_receive_bare_element
         ]},
         %% Binding-read inlining: reads hoisted out of ?html still track per-slot
         {inline, [parallel], [
@@ -1721,6 +1727,62 @@ cond_begin_block_tail(Config) when is_list(Config) ->
     ?assertNotEqual(nomatch, binary:match(Bin, <<"<p ">>)),
     ?assertNotEqual(nomatch, binary:match(Bin, <<"hi">>)),
     ?assertNotEqual(nomatch, binary:match(Bin, <<"</p>">>)).
+
+%% A `try` body (no `of` clauses) is a tail -- a bare element there is expanded.
+cond_try_bare_element(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_cond_try). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:html({'div', [], ["
+        "        try {'p', [], [arizona_template:get(msg, Bindings)]} "
+        "        catch _:_ -> <<\"\">> "
+        "        end "
+        "    ]}). "
+    ),
+    {HTML, _} = arizona_render:render(Mod:render(#{msg => <<"ok">>})),
+    Bin = iolist_to_binary(HTML),
+    ?assertNotEqual(nomatch, binary:match(Bin, <<"<p ">>)),
+    ?assertNotEqual(nomatch, binary:match(Bin, <<"ok">>)).
+
+%% A `maybe ... else ... end`: the body's last expression and the else-clause
+%% bodies are tails.
+cond_maybe_bare_element(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_cond_maybe). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:html({'div', [], ["
+        "        maybe "
+        "            {ok, M} ?= arizona_template:get(result, Bindings), "
+        "            {'p', [], [M]} "
+        "        else _ -> <<\"\">> "
+        "        end "
+        "    ]}). "
+    ),
+    {HTML, _} = arizona_render:render(Mod:render(#{result => {ok, <<"hi">>}})),
+    Bin = iolist_to_binary(HTML),
+    ?assertNotEqual(nomatch, binary:match(Bin, <<"<p ">>)),
+    ?assertNotEqual(nomatch, binary:match(Bin, <<"hi">>)),
+    {Empty, _} = arizona_render:render(Mod:render(#{result => error})),
+    ?assertEqual(nomatch, binary:match(iolist_to_binary(Empty), <<"<p ">>)).
+
+%% A `receive ... after ... end`: the `after` body is a tail (the receive
+%% clauses are too); `after 0` fires immediately so SSR never blocks.
+cond_receive_bare_element(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_cond_receive). "
+        "-export([render/1]). "
+        "render(_Bindings) -> "
+        "    arizona_template:html({'div', [], ["
+        "        receive "
+        "            never -> <<\"\">> "
+        "        after 0 -> {'p', [], [<<\"timeout\">>]} "
+        "        end "
+        "    ]}). "
+    ),
+    {HTML, _} = arizona_render:render(Mod:render(#{})),
+    ?assertNotEqual(nomatch, binary:match(iolist_to_binary(HTML), <<"<p>timeout</p>">>)).
 
 %% Test 14: Two dynamic attributes -- both share az, statics split between both.
 two_dynamic_attrs(Config) when is_list(Config) ->

--- a/test/arizona_parse_transform_SUITE.erl
+++ b/test/arizona_parse_transform_SUITE.erl
@@ -245,6 +245,17 @@
     fingerprint_escapes_value/1,
     native_backend_not_escaped/1
 ]).
+-export([
+    cond_case_bare_element_renders/1,
+    cond_case_bare_matches_html/1,
+    cond_if_bare_element/1,
+    cond_nested_case_bare_element/1,
+    cond_case_terminal_inherits_target/1,
+    cond_case_diff_transition/1,
+    cond_case_element_list_tail/1,
+    cond_case_mixed_fragment_tail/1,
+    cond_begin_block_tail/1
+]).
 
 all() ->
     [
@@ -253,6 +264,7 @@ all() ->
         {group, each},
         {group, integration},
         {group, escaping},
+        {group, conditional_elements},
         {group, inline},
         {group, tracked_get},
         {group, layout},
@@ -398,6 +410,19 @@ groups() ->
             diff_value_stays_raw,
             fingerprint_escapes_value,
             native_backend_not_escaped
+        ]},
+        %% Bare element tuples as case/if/begin branch results -- compiled into
+        %% nested templates (no ?html wrap), inheriting the enclosing target.
+        {conditional_elements, [parallel], [
+            cond_case_bare_element_renders,
+            cond_case_bare_matches_html,
+            cond_if_bare_element,
+            cond_nested_case_bare_element,
+            cond_case_terminal_inherits_target,
+            cond_case_diff_transition,
+            cond_case_element_list_tail,
+            cond_case_mixed_fragment_tail,
+            cond_begin_block_tail
         ]},
         %% Binding-read inlining: reads hoisted out of ?html still track per-slot
         {inline, [parallel], [
@@ -1496,6 +1521,206 @@ native_backend_not_escaped(Config) when is_list(Config) ->
     [{_Az, Fun, _Loc}] = maps:get(d, T),
     ?assert(is_function(Fun, 0)),
     ?assertEqual(<<"<not-escaped>">>, Fun()).
+
+%% A bare element tuple as a `case` branch result is compiled into a nested
+%% template (no ?html wrap needed): the block renders structurally, a value
+%% interpolated inside is still escaped, and the empty branch renders nothing.
+cond_case_bare_element_renders(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_cond_case_bare). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:html({'div', [], ["
+        "        case arizona_template:get(msg, Bindings) of "
+        "            undefined -> <<\"\">>; "
+        "            Msg -> {'p', [{class, <<\"err\">>}], [Msg]} "
+        "        end "
+        "    ]}). "
+    ),
+    {HTML0, _Snap} = arizona_render:render(Mod:render(#{msg => <<"<script>">>})),
+    HTML = iolist_to_binary(HTML0),
+    ?assertNotEqual(nomatch, binary:match(HTML, <<"<p">>)),
+    ?assertEqual(nomatch, binary:match(HTML, <<"<script>">>)),
+    ?assertNotEqual(nomatch, binary:match(HTML, <<"&lt;script&gt;">>)),
+    {Empty0, _} = arizona_render:render(Mod:render(#{msg => undefined})),
+    ?assertEqual(nomatch, binary:match(iolist_to_binary(Empty0), <<"<p">>)).
+
+%% The bare form is byte-for-byte equivalent to the explicit ?html form: both
+%% branch tails compile to the same nested template.
+cond_case_bare_matches_html(Config) when is_list(Config) ->
+    Bare = compile_module(
+        "-module(pt_cond_bare_eq). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:html({'div', [], ["
+        "        case arizona_template:get(msg, Bindings) of "
+        "            undefined -> <<\"\">>; "
+        "            Msg -> {'p', [{class, <<\"err\">>}], [Msg]} "
+        "        end "
+        "    ]}). "
+    ),
+    Wrap = compile_module(
+        "-module(pt_cond_html_eq). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:html({'div', [], ["
+        "        case arizona_template:get(msg, Bindings) of "
+        "            undefined -> <<\"\">>; "
+        "            Msg -> arizona_template:html({'p', [{class, <<\"err\">>}], [Msg]}) "
+        "        end "
+        "    ]}). "
+    ),
+    B = #{msg => <<"boom">>},
+    {BareHTML, _} = arizona_render:render(Bare:render(B)),
+    {WrapHTML, _} = arizona_render:render(Wrap:render(B)),
+    ?assertEqual(iolist_to_binary(WrapHTML), iolist_to_binary(BareHTML)).
+
+%% An `if` branch returning a bare element is expanded the same way.
+cond_if_bare_element(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_cond_if_bare). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    Show = arizona_template:get(show, Bindings), "
+        "    arizona_template:html({'div', [], ["
+        "        if "
+        "            Show -> {'p', [], [<<\"yes\">>]}; "
+        "            true -> <<\"\">> "
+        "        end "
+        "    ]}). "
+    ),
+    {Shown, _} = arizona_render:render(Mod:render(#{show => true})),
+    ?assertNotEqual(nomatch, binary:match(iolist_to_binary(Shown), <<"<p>yes</p>">>)),
+    {Hidden, _} = arizona_render:render(Mod:render(#{show => false})),
+    ?assertEqual(nomatch, binary:match(iolist_to_binary(Hidden), <<"<p">>)).
+
+%% A bare element in the tail of a nested `case`-of-`case` is reached by the
+%% recursive tail walk.
+cond_nested_case_bare_element(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_cond_nested). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:html({'div', [], ["
+        "        case arizona_template:get(a, Bindings) of "
+        "            1 -> "
+        "                case arizona_template:get(b, Bindings) of "
+        "                    2 -> {'p', [], [<<\"both\">>]}; "
+        "                    _ -> <<\"\">> "
+        "                end; "
+        "            _ -> <<\"\">> "
+        "        end "
+        "    ]}). "
+    ),
+    {Hit, _} = arizona_render:render(Mod:render(#{a => 1, b => 2})),
+    ?assertNotEqual(nomatch, binary:match(iolist_to_binary(Hit), <<"<p>both</p>">>)),
+    {Miss, _} = arizona_render:render(Mod:render(#{a => 1, b => 9})),
+    ?assertEqual(nomatch, binary:match(iolist_to_binary(Miss), <<"<p">>)).
+
+%% Under ?terminal the branch element inherits the terminal backend (ANSI, not
+%% HTML): proving the render target threads through the tail walk.
+cond_case_terminal_inherits_target(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_cond_term). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:terminal({col, [], ["
+        "        case arizona_template:get(warn, Bindings) of "
+        "            true -> {line, [green], [arizona_template:get(msg, Bindings)]}; "
+        "            false -> <<\"\">> "
+        "        end "
+        "    ]}). "
+    ),
+    {Output, _Snap} = arizona_render:render(Mod:render(#{warn => true, msg => ~"hi"})),
+    Bin = iolist_to_binary(Output),
+    ?assertNotEqual(nomatch, binary:match(Bin, ~"\e[32m")),
+    ?assertNotEqual(nomatch, binary:match(Bin, ~"hi")),
+    ?assertEqual(nomatch, binary:match(Bin, ~"<line")).
+
+%% Live diff: the conditional slot transitions empty (scalar) <-> element branch
+%% across renders -- the real login-error appear/disappear behaviour. make_op
+%% must handle scalar->template (OP_UPDATE) and template->scalar (OP_TEXT).
+cond_case_diff_transition(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_cond_diff). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:html({'div', [], ["
+        "        case arizona_template:get(error, Bindings) of "
+        "            undefined -> <<\"\">>; "
+        "            Message -> {'p', [{class, <<\"login-error\">>}], [Message]} "
+        "        end "
+        "    ]}). "
+    ),
+    %% undefined -> message: the <p> appears (statics + dynamic in the payload)
+    {_H0, Snap0} = arizona_render:render(Mod:render(#{error => undefined})),
+    {AppearOps, Snap1} = arizona_diff:diff(Mod:render(#{error => <<"boom">>}), Snap0),
+    AppearStr = iolist_to_binary(io_lib:format("~p", [AppearOps])),
+    ?assertNotEqual([], AppearOps),
+    ?assertNotEqual(nomatch, binary:match(AppearStr, <<"login-error">>)),
+    ?assertNotEqual(nomatch, binary:match(AppearStr, <<"boom">>)),
+    %% message -> undefined: a clearing op is emitted, the old content is gone
+    {ClearOps, _Snap2} = arizona_diff:diff(Mod:render(#{error => undefined}), Snap1),
+    ClearStr = iolist_to_binary(io_lib:format("~p", [ClearOps])),
+    ?assertNotEqual([], ClearOps),
+    ?assertEqual(nomatch, binary:match(ClearStr, <<"login-error">>)).
+
+%% A pure element-list tail is compiled as a fragment (every item an element).
+cond_case_element_list_tail(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_cond_list). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:html({'ul', [], ["
+        "        case arizona_template:get(show, Bindings) of "
+        "            true -> [{'li', [], [<<\"a\">>]}, {'li', [], [<<\"b\">>]}]; "
+        "            false -> <<\"\">> "
+        "        end "
+        "    ]}). "
+    ),
+    {HTML, _} = arizona_render:render(Mod:render(#{show => true})),
+    Bin = iolist_to_binary(HTML),
+    ?assertNotEqual(nomatch, binary:match(Bin, <<"<li>a</li>">>)),
+    ?assertNotEqual(nomatch, binary:match(Bin, <<"<li>b</li>">>)).
+
+%% A mixed-fragment tail (static text interleaved with an element) is compiled
+%% as a fragment -- matching what an explicit ?html([...]) there would do.
+cond_case_mixed_fragment_tail(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_cond_mixed). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:html({'div', [], ["
+        "        case arizona_template:get(show, Bindings) of "
+        "            true -> [<<\"label: \">>, {'b', [], [arizona_template:get(v, Bindings)]}]; "
+        "            false -> <<\"\">> "
+        "        end "
+        "    ]}). "
+    ),
+    {HTML, _} = arizona_render:render(Mod:render(#{show => true, v => <<"x">>})),
+    Bin = iolist_to_binary(HTML),
+    ?assertNotEqual(nomatch, binary:match(Bin, <<"label: ">>)),
+    ?assertNotEqual(nomatch, binary:match(Bin, <<"<b ">>)),
+    ?assertNotEqual(nomatch, binary:match(Bin, <<"x">>)).
+
+%% A `begin ... end` block whose last expression is a bare element.
+cond_begin_block_tail(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_cond_begin). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:html({'div', [], ["
+        "        begin "
+        "            Msg = arizona_template:get(msg, Bindings), "
+        "            {'p', [], [Msg]} "
+        "        end "
+        "    ]}). "
+    ),
+    {HTML, _} = arizona_render:render(Mod:render(#{msg => <<"hi">>})),
+    Bin = iolist_to_binary(HTML),
+    ?assertNotEqual(nomatch, binary:match(Bin, <<"<p ">>)),
+    ?assertNotEqual(nomatch, binary:match(Bin, <<"hi">>)),
+    ?assertNotEqual(nomatch, binary:match(Bin, <<"</p>">>)).
 
 %% Test 14: Two dynamic attributes -- both share az, statics split between both.
 two_dynamic_attrs(Config) when is_list(Config) ->


### PR DESCRIPTION
# Description

A control-flow expression in a content slot -- `case`, `if`, `begin`, `receive`, `try`, or `maybe` -- can now return a bare element tuple, element list, or mixed fragment directly from a tail position. The parse transform compiles each tail into a nested template, just as an explicit `?html`/`?native`/`?terminal` there would, inheriting the enclosing render target. This removes the `?html` wrap users previously needed (and which `?each` bodies never required), bringing conditionals in line with loops.

The set of forms and tail positions is defined once in a shared `map_tail_exprs/3` walker, reused by the existing live-render-root transform (`transform_live_render_last/3`) so both paths stay consistent and the existing live-render tests exercise it. The compiled output is byte-identical to the explicit `?html` form, so diffing, dependency tracking, az-scoping, and escaping are unchanged; `?html` keeps working everywhere.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
