### PR TITLE
Add opaque-cursor pagination to the MCP list methods

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1104,6 +1104,17 @@ replayed. Two ways to push a `notifications/*` message:
 
 Both are no-ops for a session with no attached SSE channel.
 
+### Pagination
+
+The `*/list` methods paginate with opaque cursors, framework-side: the `tools/1` / `resources/1` /
+`prompts/1` callbacks keep returning their full list, and the transport slices it by an offset cursor
+(base64 of the offset), emitting `nextCursor` when more remain. The page size is the route's
+`page_size` opt (default 50), so a list that fits returns in one page with no cursor. A malformed
+cursor is a `-32602`; an offset past the end returns an empty final page. The callbacks never see a
+cursor. Because the cursor is an offset, it assumes a stable list across pages -- a list mutated
+mid-pagination can skip or repeat an item (acceptable for the near-static MCP lists, and a
+`list_changed` notification has the client re-list anyway).
+
 ### Capability gating and security
 
 `init/1` returns an atom-keyed capability map; the transport serves `resources/*` and `prompts/*`

--- a/src/arizona_mcp.erl
+++ b/src/arizona_mcp.erl
@@ -19,7 +19,7 @@ calls back into this module to negotiate the connection and run tools.
   tool callbacks. Called once on `initialize`, and again to source the
   state for `tools/list` / `tools/call`.
 - `tools/1` -- returns the tool metadata advertised by `tools/list`.
-- `handle_tool/3` -- runs one `tools/call`, dispatched by name (the MCP
+- `handle_tool/4` -- runs one `tools/call`, dispatched by name (the MCP
   analogue of how `arizona_stateful` dispatches an event by name).
 - `resources/1` + `read_resource/2` -- optional; list and read resources.
 - `prompts/1` + `get_prompt/3` -- optional; list and render prompts.
@@ -32,6 +32,22 @@ transport routes `resources/*` / `prompts/*` only when `init/1` advertised
 the matching `resources` / `prompts` capability, returning `method not
 found` otherwise. A server advertising a capability must implement its
 callbacks. Tools are always available (their callbacks are required).
+
+## Pagination
+
+`tools/1` / `resources/1` / `prompts/1` always return their **full** list;
+the transport paginates the `*/list` results with opaque cursors. A list at or
+under the route's `page_size` opt (default 50) returns in one page with no
+cursor; a larger one returns a page plus a `nextCursor` the client echoes to
+fetch the next. The callbacks never see a cursor -- pagination is entirely the
+transport's concern.
+
+The cursor is an offset into the list the callback returns, so it assumes the
+list is **stable across pages**: if the callback returns a different list
+mid-pagination (an item added or removed between page requests), the client may
+skip or repeat an item. This is fine for the near-static lists tools/resources/
+prompts usually are -- and a client that receives a `list_changed` notification
+re-lists from the start anyway.
 
 ## Tool results vs protocol errors
 

--- a/src/arizona_mcp_handler.erl
+++ b/src/arizona_mcp_handler.erl
@@ -49,13 +49,15 @@ protocol contract holds even when a tool raises.
 %% Types definitions
 %% --------------------------------------------------------------------
 
-%% The dispatch context: the handler module, its state, and the capabilities
-%% negotiated at initialize. `arizona_mcp_session` holds one across a
-%% stateful connection; `dispatch/3` builds an ephemeral one per request.
+%% The dispatch context: the handler module, its state, the capabilities
+%% negotiated at initialize, and the list page size. `arizona_mcp_session` holds
+%% one across a stateful connection; `dispatch/3` builds an ephemeral one per
+%% request.
 -type session() :: #{
     mod := module(),
     state := arizona_mcp:state(),
-    caps := arizona_mcp:capabilities()
+    caps := arizona_mcp:capabilities(),
+    page_size := pos_integer()
 }.
 
 %% An optional per-route auth hook, run after the Origin check and before any
@@ -79,6 +81,10 @@ protocol contract holds even when a tool raises.
 %% Resumability buffer depth per session, overridable via the route's
 %% `session_buffer_max` opt.
 -define(DEFAULT_BUFFER_MAX, 256).
+
+%% Page size for the `*/list` methods, overridable via the route's `page_size`
+%% opt. A list at or under this size returns no cursor; a larger one paginates.
+-define(DEFAULT_PAGE_SIZE, 50).
 
 %% --------------------------------------------------------------------
 %% API Functions
@@ -200,36 +206,39 @@ Exported for unit testing; `handle/1` calls it inside a crash guard.
     Mod :: module(),
     Request :: arizona_jsonrpc:request(),
     Ctx :: map().
-dispatch(Mod, #{method := Method, params := Params, id := Id}, _Ctx) ->
+dispatch(Mod, #{method := Method, params := Params, id := Id}, Ctx) ->
+    PageSize = maps:get(page_size, Ctx, ?DEFAULT_PAGE_SIZE),
     case Id of
         %% A JSON-RPC notification (no id) is accepted and never answered,
         %% whatever its method -- `notifications/initialized` included.
         undefined ->
             notification;
         _ when Method =:= ~"initialize" ->
-            {ServerInfo, #{caps := Caps}} = open_session(Mod, Params),
+            {ServerInfo, #{caps := Caps}} = open_session(Mod, Params, PageSize),
             {reply, arizona_jsonrpc:result(Id, initialize_result(ServerInfo, Caps, Params))};
         _ ->
             %% Stateless: a fresh per-request session sourced from `init/1`.
             %% Nothing outlives the request, so the threaded-back session is
             %% discarded -- the next request rebuilds from `init/1`.
-            {_ServerInfo, Session} = open_session(Mod, #{}),
+            {_ServerInfo, Session} = open_session(Mod, #{}, PageSize),
             {Outcome, _Session1} = handle_method(Method, Params, Id, Session),
             Outcome
     end.
 
 %% Build a session from the handler's `init/1`: the server identity plus the
-%% state and negotiated capabilities the methods run against. The session map
-%% is what `arizona_mcp_session` holds for a stateful (`Mcp-Session-Id`)
-%% connection; `dispatch/3` builds an ephemeral one per request.
--spec open_session(Mod, InitParams) -> {ServerInfo, Session} when
+%% state, negotiated capabilities, and list page size the methods run against.
+%% The session map is what `arizona_mcp_session` holds for a stateful
+%% (`Mcp-Session-Id`) connection; `dispatch/3` builds an ephemeral one per
+%% request.
+-spec open_session(Mod, InitParams, PageSize) -> {ServerInfo, Session} when
     Mod :: module(),
     InitParams :: arizona_mcp:init_params(),
+    PageSize :: pos_integer(),
     ServerInfo :: arizona_mcp:server_info(),
     Session :: session().
-open_session(Mod, InitParams) ->
+open_session(Mod, InitParams, PageSize) ->
     {ok, ServerInfo, Caps, State} = Mod:init(InitParams),
-    {ServerInfo, #{mod => Mod, state => State, caps => Caps}}.
+    {ServerInfo, #{mod => Mod, state => State, caps => Caps, page_size => PageSize}}.
 
 %% Build the `initialize` result: negotiated protocol version, advertised
 %% capabilities, and the server identity.
@@ -325,8 +334,18 @@ check_origin(Req, Opts) ->
 
 %% Stateless mode: every request is self-contained -- dispatch against a fresh
 %% per-request session, encode. No `Mcp-Session-Id`.
-reply_stateless(Request, #{handler := Mod}) ->
-    reply_dispatch(Mod, Request).
+reply_stateless(Request, #{handler := Mod} = Opts) ->
+    reply_dispatch(Mod, Request, page_size(Opts)).
+
+%% The configured list page size, defaulting when the route does not set it. A
+%% `page_size` of zero/negative would make the cursor never advance (an empty
+%% page that always re-issues the same cursor -- an infinite client loop), so a
+%% misconfigured route fails loudly (a `function_clause`) rather than looping.
+page_size(Opts) ->
+    valid_page_size(maps:get(page_size, Opts, ?DEFAULT_PAGE_SIZE)).
+
+valid_page_size(N) when is_integer(N), N >= 1 ->
+    N.
 
 %% Session mode: `initialize` opens a session and returns its id; every
 %% other request is routed to the session named by `Mcp-Session-Id`.
@@ -346,7 +365,7 @@ session_initialize(Params, Id, #{handler := Mod} = Opts) ->
         %% session later via `arizona_mcp:notify/3`. An atom key can't collide
         %% with the client's binary-keyed JSON params.
         InitParams = Params#{mcp_session_id => SessionId},
-        {ServerInfo, #{caps := Caps} = Session} = open_session(Mod, InitParams),
+        {ServerInfo, #{caps := Caps} = Session} = open_session(Mod, InitParams, page_size(Opts)),
         SessionOpts = #{
             ttl_ms => maps:get(session_ttl_ms, Opts, ?DEFAULT_TTL_MS),
             buffer_max => maps:get(session_buffer_max, Opts, ?DEFAULT_BUFFER_MAX)
@@ -455,7 +474,8 @@ serve_streaming(#{name := Name, args := Args, token := Token, id := Id}, Req, Op
             #{handler := Mod} = Opts,
             %% Stateless: a fresh per-request session; its threaded-back state
             %% is per-request and discarded. The worker frees the loop to push.
-            {_ServerInfo, Session} = open_session(Mod, #{}),
+            %% page_size is irrelevant to a tools/call -- the default suffices.
+            {_ServerInfo, Session} = open_session(Mod, #{}, ?DEFAULT_PAGE_SIZE),
             Ctx = #{token => Token, to => ConnPid},
             _Worker = spawn(fun() ->
                 _Session1 = run_streaming_tool(Session, Name, Args, Id, Ctx, ConnPid)
@@ -534,8 +554,8 @@ stream_tool_outcome({error, ToolError, NewState}, Id) ->
 generate_session_id() ->
     binary:encode_hex(crypto:strong_rand_bytes(16), lowercase).
 
-reply_dispatch(Mod, Request) ->
-    try dispatch(Mod, Request, #{}) of
+reply_dispatch(Mod, Request, PageSize) ->
+    try dispatch(Mod, Request, #{page_size => PageSize}) of
         {reply, Object} -> json(Object);
         {error, Object} -> json(Object);
         notification -> roadrunner_resp:status(202)
@@ -577,27 +597,85 @@ method) return the session unchanged.
     Outcome :: {reply, map()} | {error, map()}.
 handle_method(~"ping", _Params, Id, Session) ->
     {{reply, arizona_jsonrpc:result(Id, #{})}, Session};
-handle_method(~"tools/list", _Params, Id, #{mod := Mod, state := State} = Session) ->
-    Tools = [tool_json(Tool) || Tool <- Mod:tools(State)],
-    {{reply, arizona_jsonrpc:result(Id, #{~"tools" => Tools})}, Session};
+handle_method(~"tools/list", Params, Id, #{mod := Mod, state := State} = Session) ->
+    list_reply(Mod:tools(State), fun tool_json/1, ~"tools", Params, Id, Session);
 handle_method(~"tools/call", Params, Id, Session) ->
     call_tool(Params, Id, Session);
-handle_method(~"resources/list", _Params, Id, Session) ->
+handle_method(~"resources/list", Params, Id, Session) ->
     capability(resources, Id, Session, fun(#{mod := Mod, state := State} = S) ->
-        Resources = [resource_json(Resource) || Resource <- Mod:resources(State)],
-        {{reply, arizona_jsonrpc:result(Id, #{~"resources" => Resources})}, S}
+        list_reply(Mod:resources(State), fun resource_json/1, ~"resources", Params, Id, S)
     end);
 handle_method(~"resources/read", Params, Id, Session) ->
     capability(resources, Id, Session, fun(S) -> read_resource(Params, Id, S) end);
-handle_method(~"prompts/list", _Params, Id, Session) ->
+handle_method(~"prompts/list", Params, Id, Session) ->
     capability(prompts, Id, Session, fun(#{mod := Mod, state := State} = S) ->
-        Prompts = [prompt_json(Prompt) || Prompt <- Mod:prompts(State)],
-        {{reply, arizona_jsonrpc:result(Id, #{~"prompts" => Prompts})}, S}
+        list_reply(Mod:prompts(State), fun prompt_json/1, ~"prompts", Params, Id, S)
     end);
 handle_method(~"prompts/get", Params, Id, Session) ->
     capability(prompts, Id, Session, fun(S) -> get_prompt(Params, Id, S) end);
 handle_method(_Method, _Params, Id, Session) ->
     method_not_found(Id, Session).
+
+%% Paginate a full list by the request's opaque `cursor`, map the page to wire
+%% JSON under `Key`, and add `nextCursor` when more remain. A malformed cursor
+%% is a -32602. The app's list callback is unchanged -- it returns the full
+%% list and the transport owns the slicing.
+list_reply(Full, ItemFun, Key, Params, Id, #{page_size := PageSize} = Session) ->
+    case paginate(Full, Params, PageSize) of
+        {ok, Page, Next} ->
+            Items = [ItemFun(Item) || Item <- Page],
+            Result = maybe_next_cursor(Next, #{Key => Items}),
+            {{reply, arizona_jsonrpc:result(Id, Result)}, Session};
+        error ->
+            {{error, arizona_jsonrpc:error(Id, -32602, ~"Invalid cursor")}, Session}
+    end.
+
+%% Slice `Full` at the cursor's offset for `PageSize` items, returning the page
+%% and the next cursor (`undefined` once exhausted). A bad cursor -> `error`. An
+%% offset past the end (a stale or tampered cursor) yields an empty final page
+%% rather than crashing `lists:sublist/3`.
+paginate(Full, Params, PageSize) ->
+    case cursor_offset(Params) of
+        {ok, Offset} ->
+            Len = length(Full),
+            Page =
+                case Offset < Len of
+                    true -> lists:sublist(Full, Offset + 1, PageSize);
+                    false -> []
+                end,
+            Next =
+                case Offset + PageSize < Len of
+                    true -> encode_cursor(Offset + PageSize);
+                    false -> undefined
+                end,
+            {ok, Page, Next};
+        error ->
+            error
+    end.
+
+%% Absent cursor -> page from the start; present -> decode it (a non-binary or
+%% malformed cursor is rejected).
+cursor_offset(#{~"cursor" := Cursor}) when is_binary(Cursor) ->
+    decode_cursor(Cursor);
+cursor_offset(#{~"cursor" := _}) ->
+    error;
+cursor_offset(_Params) ->
+    {ok, 0}.
+
+maybe_next_cursor(undefined, Result) -> Result;
+maybe_next_cursor(Next, Result) -> Result#{~"nextCursor" => Next}.
+
+%% Cursors are opaque to the client: a base64 of the integer offset.
+encode_cursor(Offset) ->
+    base64:encode(integer_to_binary(Offset)).
+
+decode_cursor(Cursor) ->
+    try binary_to_integer(base64:decode(Cursor)) of
+        Offset when Offset >= 0 -> {ok, Offset};
+        _ -> error
+    catch
+        _:_ -> error
+    end.
 
 %% An optional capability (resources/prompts) is served only when the server
 %% advertised it at initialize; otherwise the method does not exist. The gated

--- a/test/arizona_mcp_SUITE.erl
+++ b/test/arizona_mcp_SUITE.erl
@@ -35,6 +35,12 @@
     dispatch_prompts_get_unknown/1,
     dispatch_prompts_get_missing_name/1,
     dispatch_prompts_unsupported/1,
+    pagination_tools_walk/1,
+    pagination_resources_walk/1,
+    pagination_no_cursor_when_list_fits/1,
+    pagination_past_end_cursor/1,
+    pagination_invalid_cursor/1,
+    pagination_non_binary_cursor/1,
     handle_get_405/1,
     handle_origin_absent_ok/1,
     handle_origin_allowed_ok/1,
@@ -85,6 +91,12 @@ all() ->
         dispatch_prompts_get_unknown,
         dispatch_prompts_get_missing_name,
         dispatch_prompts_unsupported,
+        pagination_tools_walk,
+        pagination_resources_walk,
+        pagination_no_cursor_when_list_fits,
+        pagination_past_end_cursor,
+        pagination_invalid_cursor,
+        pagination_non_binary_cursor,
         handle_get_405,
         handle_origin_absent_ok,
         handle_origin_allowed_ok,
@@ -327,6 +339,50 @@ dispatch_prompts_unsupported(_Config) ->
     ?assertEqual(-32601, Code).
 
 %% --------------------------------------------------------------------
+%% Pagination (framework-side opaque cursors over the */list methods)
+%% --------------------------------------------------------------------
+
+pagination_tools_walk(_Config) ->
+    %% 6 tools at page size 2 -> 3 pages; following the cursor chain yields all
+    %% 6 names in order. The page count proves it actually paginated.
+    {Names, Pages} = walk(~"tools/list", ~"tools", 2),
+    ?assertEqual([~"add", ~"boom", ~"crash", ~"echo", ~"count", ~"progress"], Names),
+    ?assertEqual(3, Pages).
+
+pagination_resources_walk(_Config) ->
+    %% The capability-gated list path paginates identically.
+    {Names, Pages} = walk(~"resources/list", ~"resources", 2),
+    ?assertEqual([~"greeting", ~"locked", ~"structured", ~"counter"], Names),
+    ?assertEqual(2, Pages).
+
+pagination_no_cursor_when_list_fits(_Config) ->
+    %% A page larger than the list returns everything and omits nextCursor.
+    {reply, #{~"result" := Result}} = dispatch_paged(~"tools/list", #{}, 1, 100),
+    ?assertEqual(6, length(maps:get(~"tools", Result))),
+    ?assertNot(maps:is_key(~"nextCursor", Result)).
+
+pagination_past_end_cursor(_Config) ->
+    %% A valid cursor whose offset is past the end (stale/tampered) returns an
+    %% empty final page with no cursor -- not a -32603 crash.
+    PastEnd = base64:encode(integer_to_binary(1000)),
+    {reply, #{~"result" := Result}} = dispatch_paged(~"tools/list", #{~"cursor" => PastEnd}, 1, 2),
+    ?assertEqual([], maps:get(~"tools", Result)),
+    ?assertNot(maps:is_key(~"nextCursor", Result)).
+
+pagination_invalid_cursor(_Config) ->
+    %% A cursor that does not decode to a non-negative integer is a -32602.
+    Garbage = base64:encode(~"not-a-number"),
+    {error, #{~"error" := #{~"code" := Code}}} =
+        dispatch_paged(~"tools/list", #{~"cursor" => Garbage}, 1, 2),
+    ?assertEqual(-32602, Code).
+
+pagination_non_binary_cursor(_Config) ->
+    %% A non-binary cursor (a misbehaving client) is rejected, not crashed.
+    {error, #{~"error" := #{~"code" := Code}}} =
+        dispatch_paged(~"tools/list", #{~"cursor" => 7}, 1, 2),
+    ?assertEqual(-32602, Code).
+
+%% --------------------------------------------------------------------
 %% handle/1 (transport: method gate + origin + crash mapping)
 %% --------------------------------------------------------------------
 
@@ -399,6 +455,30 @@ handle_tool_crash_internal_error(_Config) ->
 dispatch(Method, Params, Id) ->
     dispatch_on(?SERVER, Method, Params, Id).
 
+%% Dispatch statelessly with a configured list page size (via the dispatch Ctx).
+dispatch_paged(Method, Params, Id, PageSize) ->
+    Request = #{method => Method, params => Params, id => Id},
+    arizona_mcp_handler:dispatch(?SERVER, Request, #{page_size => PageSize}).
+
+%% Follow the cursor chain of a `*/list` method to exhaustion, returning all
+%% item names (every item -- tool/resource/prompt -- carries `name`) and the
+%% number of pages it took.
+walk(Method, Key, PageSize) ->
+    walk(Method, Key, PageSize, undefined, [], 0).
+
+walk(Method, Key, PageSize, Cursor, Acc, Pages) ->
+    Params =
+        case Cursor of
+            undefined -> #{};
+            _ -> #{~"cursor" => Cursor}
+        end,
+    {reply, #{~"result" := Result}} = dispatch_paged(Method, Params, 1, PageSize),
+    Names = Acc ++ [maps:get(~"name", Item) || Item <- maps:get(Key, Result)],
+    case Result of
+        #{~"nextCursor" := Next} -> walk(Method, Key, PageSize, Next, Names, Pages + 1);
+        _ -> {Names, Pages + 1}
+    end.
+
 %% Dispatch a `tools/call` statelessly and return the reply's counter text.
 stateless_count(Params, Id) ->
     {reply, #{~"result" := #{~"content" := [#{~"text" := Text}]}}} =
@@ -407,7 +487,12 @@ stateless_count(Params, Id) ->
 
 %% A session map for the test server, as the transport builds at initialize.
 session() ->
-    #{mod => ?SERVER, state => #{}, caps => #{tools => #{}, resources => #{}, prompts => #{}}}.
+    #{
+        mod => ?SERVER,
+        state => #{},
+        caps => #{tools => #{}, resources => #{}, prompts => #{}},
+        page_size => 50
+    }.
 
 %% Receive one relayed progress notification, returning its `progress` amount.
 recv_progress() ->

--- a/test/arizona_mcp_conformance_SUITE.erl
+++ b/test/arizona_mcp_conformance_SUITE.erl
@@ -28,7 +28,11 @@ init_per_suite(Config) ->
             {ok, _} = application:ensure_all_started(roadrunner),
             %% 15050+ is well clear of the WHATWG "bad ports" the SDK refuses.
             Port = 15050 + erlang:unique_integer([positive, monotonic]) rem 1000,
-            Routes = [{mcp, ~"/mcp", arizona_mcp_test_server, #{sessions => true}}],
+            %% page_size 2 forces multi-page lists, so the SDK driver exercises
+            %% the cursor protocol end-to-end.
+            Routes = [
+                {mcp, ~"/mcp", arizona_mcp_test_server, #{sessions => true, page_size => 2}}
+            ],
             {ok, _} = arizona_roadrunner_server:start(?LISTENER, #{
                 transport_opts => [{port, Port}],
                 routes => Routes

--- a/test/arizona_mcp_e2e_SUITE.erl
+++ b/test/arizona_mcp_e2e_SUITE.erl
@@ -9,6 +9,7 @@
     post_tools_call/1,
     post_streaming_progress/1,
     post_progress_without_accept_buffered/1,
+    post_tools_list_paginates/1,
     post_resources_read/1,
     post_prompts_get/1,
     get_returns_405/1,
@@ -41,6 +42,7 @@ all() ->
         post_tools_call,
         post_streaming_progress,
         post_progress_without_accept_buffered,
+        post_tools_list_paginates,
         post_resources_read,
         post_prompts_get,
         get_returns_405,
@@ -86,6 +88,10 @@ init_per_suite(Config) ->
         {mcp, ~"/mcp-session-crash", arizona_mcp_crashing_server, #{
             origins => [?ALLOWED_ORIGIN],
             sessions => true
+        }},
+        {mcp, ~"/mcp-paged", arizona_mcp_test_server, #{
+            origins => [?ALLOWED_ORIGIN],
+            page_size => 2
         }}
     ],
     {ok, _} = arizona_roadrunner_server:start(?LISTENER, #{
@@ -184,6 +190,32 @@ post_progress_without_accept_buffered(Config) ->
         #{~"content" => [#{~"type" => ~"text", ~"text" => ~"done"}], ~"isError" => false},
         Result
     ).
+
+post_tools_list_paginates(Config) ->
+    %% On the page_size=2 route, the first tools/list page carries 2 tools and a
+    %% nextCursor; following the cursor returns the next, different, page.
+    Page1 =
+        ~"""
+    {"jsonrpc":"2.0","id":11,"method":"tools/list","params":{}}
+    """,
+    Resp1 = post(Config, "/mcp-paged", [], Page1),
+    ?assertEqual(200, status_code(Resp1)),
+    #{~"result" := #{~"tools" := Tools1, ~"nextCursor" := Cursor}} = body_json(Resp1),
+    ?assertEqual(2, length(Tools1)),
+    %% Follow the cursor for page 2.
+    Page2 = json:encode(#{
+        jsonrpc => ~"2.0",
+        id => 12,
+        method => ~"tools/list",
+        params => #{cursor => Cursor}
+    }),
+    Resp2 = post(Config, "/mcp-paged", [], iolist_to_binary(Page2)),
+    ?assertEqual(200, status_code(Resp2)),
+    #{~"result" := #{~"tools" := Tools2}} = body_json(Resp2),
+    ?assertEqual(2, length(Tools2)),
+    Names1 = [maps:get(~"name", T) || T <- Tools1],
+    Names2 = [maps:get(~"name", T) || T <- Tools2],
+    ?assertNotEqual(Names1, Names2).
 
 post_resources_read(Config) ->
     Body =

--- a/test/arizona_mcp_session_SUITE.erl
+++ b/test/arizona_mcp_session_SUITE.erl
@@ -262,7 +262,8 @@ terminate_calls_app(_Config) ->
     Session = #{
         mod => arizona_mcp_test_server,
         state => #{terminate_pid => self()},
-        caps => #{tools => #{}}
+        caps => #{tools => #{}},
+        page_size => 50
     },
     {ok, Pid} = arizona_mcp_sup:start_session(Id, Session, #{ttl_ms => 60000, buffer_max => 256}),
     ok = arizona_mcp_session:stop(Pid),
@@ -321,5 +322,6 @@ session() ->
     #{
         mod => arizona_mcp_test_server,
         state => #{},
-        caps => #{tools => #{}, resources => #{}, prompts => #{}}
+        caps => #{tools => #{}, resources => #{}, prompts => #{}},
+        page_size => 50
     }.

--- a/test/conformance/mcp_client.mjs
+++ b/test/conformance/mcp_client.mjs
@@ -32,6 +32,19 @@ const check = (label, ok) => {
   if (!ok) failures.push(label);
 };
 
+// Follow nextCursor to aggregate every page of a list method. Exercises the
+// cursor protocol and makes the list assertions independent of page order.
+const listAll = async (listFn, key) => {
+  const all = [];
+  let cursor;
+  do {
+    const page = await listFn(cursor ? { cursor } : {});
+    all.push(...page[key]);
+    cursor = page.nextCursor;
+  } while (cursor);
+  return all;
+};
+
 const client = new Client({ name: 'arizona-conformance', version: '1.0.0' });
 const transport = new StreamableHTTPClientTransport(new URL(url));
 
@@ -40,8 +53,12 @@ try {
   check('session id assigned', Boolean(transport.sessionId));
   check('advertises tools capability', 'tools' in (client.getServerCapabilities() ?? {}));
 
-  const tools = await client.listTools();
-  check("tools/list has 'add'", tools.tools.some((t) => t.name === 'add'));
+  // The server uses a small page_size, so each list spans several pages.
+  // Aggregating across pages keeps these checks order-independent and proves
+  // the cursor protocol round-trips (reaching the last-page tool, 'progress').
+  const tools = await listAll((p) => client.listTools(p), 'tools');
+  check("tools/list has 'add'", tools.some((t) => t.name === 'add'));
+  check('tools/list pagination reaches last page', tools.some((t) => t.name === 'progress'));
 
   const call = await client.callTool({ name: 'add', arguments: { a: 2, b: 3 } });
   check("tools/call add => '5'", call.content?.[0]?.text === '5');
@@ -59,17 +76,14 @@ try {
   check('tools/call progress streamed', seen.length >= 1);
   check("tools/call streamed result => 'done'", streamed.content?.[0]?.text === 'done');
 
-  const resources = await client.listResources();
-  check(
-    'resources/list has mem://greeting',
-    resources.resources.some((r) => r.uri === 'mem://greeting'),
-  );
+  const resources = await listAll((p) => client.listResources(p), 'resources');
+  check('resources/list has mem://greeting', resources.some((r) => r.uri === 'mem://greeting'));
 
   const read = await client.readResource({ uri: 'mem://greeting' });
   check("resources/read => 'hello'", read.contents?.[0]?.text === 'hello');
 
-  const prompts = await client.listPrompts();
-  check("prompts/list has 'greet'", prompts.prompts.some((p) => p.name === 'greet'));
+  const prompts = await listAll((p) => client.listPrompts(p), 'prompts');
+  check("prompts/list has 'greet'", prompts.some((p) => p.name === 'greet'));
 
   const prompt = await client.getPrompt({ name: 'greet', arguments: { who: 'Ada' } });
   check("prompts/get => 'Hello, Ada'", JSON.stringify(prompt).includes('Hello, Ada'));


### PR DESCRIPTION
# Description

Adds cursor pagination to the MCP `tools/list` / `resources/list` / `prompts/list` methods, the third chunk of the server completion work (progress streaming landed in #543).

Pagination is framework-side, so the `tools/1` / `resources/1` / `prompts/1` callbacks are unchanged: they keep returning their full list, and the transport slices it by an opaque offset cursor, emitting `nextCursor` when more remain. The page size is a new `page_size` route opt (default 50), so a list that fits returns in one page with no cursor. A malformed cursor is a `-32602`, and an offset past the end returns an empty final page.

Because the cursor is an offset, it assumes a stable list across pages; a list mutated mid-pagination can skip or repeat an item, which is acceptable for the near-static MCP lists and self-corrects once the client re-lists after a `list_changed`.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
