### PR TITLE
Add MCP resource subscriptions and templates

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1104,6 +1104,16 @@ replayed. Two ways to push a `notifications/*` message:
 
 Both are no-ops for a session with no attached SSE channel.
 
+### Resource subscriptions and templates
+
+`resources/subscribe` joins the session to a per-uri `arizona_pubsub` channel
+(`{mcp_resource, Uri}`); `arizona_mcp:resource_updated/1` broadcasts to it, so every subscribed
+session forwards `notifications/resources/updated`. `resources/unsubscribe` leaves the channel, and
+`pg` auto-removes a session on exit, so there is no per-session subscription bookkeeping. It is the
+same fan-out path as `broadcast/3` + `channels/1`, just keyed per uri and joined at runtime. The
+optional `resource_templates/1` callback backs `resources/templates/list` (URI templates like
+`mem://user/{id}`), paginated through the same `list_reply`.
+
 ### Pagination
 
 The `*/list` methods paginate with opaque cursors, framework-side: the `tools/1` / `resources/1` /

--- a/src/arizona_mcp.erl
+++ b/src/arizona_mcp.erl
@@ -114,6 +114,20 @@ session has no channel attached:
   key of the init params, so a handler can keep it and address its own
   session later.
 
+## Resource subscriptions and templates
+
+A client subscribes to a resource with `resources/subscribe` (advertise
+`resources => #{subscribe => true}` from `init/1`); the server announces a
+change with `resource_updated/1`, which fans `notifications/resources/updated`
+out to every subscribed session. It is built on the same pubsub path as
+`broadcast/3`: subscribe joins a per-uri channel, `resource_updated/1`
+broadcasts to it, and `resources/unsubscribe` (or session exit) leaves. Like
+the other pushes it needs a session with an attached SSE channel.
+
+The optional `resource_templates/1` callback advertises URI templates
+(`mem://user/{id}`) through `resources/templates/list`. Omit it for a server
+with no parameterized resources.
+
 ## Operational notes
 
 Session mode starts one process per `initialize`, and the count is
@@ -139,6 +153,7 @@ the official MCP SDK client.
 
 -export([broadcast/3]).
 -export([notify/3]).
+-export([resource_updated/1]).
 -export([progress/2]).
 -export([progress/3]).
 
@@ -149,6 +164,7 @@ the official MCP SDK client.
 %% The server-push and progress APIs are called by applications, not from
 %% within arizona.
 -ignore_xref([broadcast/3, notify/3]).
+-ignore_xref([resource_updated/1]).
 -ignore_xref([progress/2, progress/3]).
 
 %% --------------------------------------------------------------------
@@ -167,6 +183,7 @@ the official MCP SDK client.
 -export_type([tool_result/0]).
 -export_type([tool_error/0]).
 -export_type([resource/0]).
+-export_type([resource_template/0]).
 -export_type([resource_contents/0]).
 -export_type([resource_error/0]).
 -export_type([prompt/0]).
@@ -227,6 +244,13 @@ the official MCP SDK client.
 
 -nominal resource() :: #{
     uri := binary(),
+    name := binary(),
+    description => binary(),
+    mime_type => binary()
+}.
+
+-nominal resource_template() :: #{
+    uri_template := binary(),
     name := binary(),
     description => binary(),
     mime_type => binary()
@@ -314,6 +338,13 @@ resource-level failure (surfaced as a `-32002` error).
     | {error, resource_error(), state()}.
 
 -doc """
+Return the URI-template metadata advertised by `resources/templates/list`.
+Optional; a server with no parameterized resources omits it (the transport
+then returns an empty template list).
+""".
+-callback resource_templates(State :: state()) -> [resource_template()].
+
+-doc """
 Return the prompt metadata advertised by `prompts/list`. Optional;
 implement it (with `get_prompt/3`) when advertising the `prompts`
 capability.
@@ -342,6 +373,7 @@ is forwarded to the session's SSE channel. Optional; defaults to none.
 -optional_callbacks([
     resources/1,
     read_resource/2,
+    resource_templates/1,
     prompts/1,
     get_prompt/3,
     channels/1,
@@ -380,6 +412,18 @@ notify(SessionId, Method, Params) ->
         {ok, Pid} -> arizona_mcp_session:notify(Pid, Method, Params);
         error -> ok
     end.
+
+-doc """
+Announce that a resource changed to every session subscribed to its `Uri` (via
+`resources/subscribe`). Each subscribed session forwards
+`notifications/resources/updated` to its client; sessions that did not subscribe
+(or have no SSE channel) ignore it. Decoupled -- the caller holds no session
+reference.
+""".
+-spec resource_updated(Uri) -> ok when
+    Uri :: binary().
+resource_updated(Uri) ->
+    broadcast({mcp_resource, Uri}, ~"notifications/resources/updated", #{~"uri" => Uri}).
 
 -doc """
 Emit a `notifications/progress` update from a running `tools/call`, using the

--- a/src/arizona_mcp_handler.erl
+++ b/src/arizona_mcp_handler.erl
@@ -607,6 +607,15 @@ handle_method(~"resources/list", Params, Id, Session) ->
     end);
 handle_method(~"resources/read", Params, Id, Session) ->
     capability(resources, Id, Session, fun(S) -> read_resource(Params, Id, S) end);
+handle_method(~"resources/templates/list", Params, Id, Session) ->
+    capability(resources, Id, Session, fun(#{mod := Mod, state := State} = S) ->
+        Templates = resource_templates(Mod, State),
+        list_reply(Templates, fun resource_template_json/1, ~"resourceTemplates", Params, Id, S)
+    end);
+handle_method(~"resources/subscribe", Params, Id, Session) ->
+    capability(resources, Id, Session, fun(S) -> subscribe_resource(Params, Id, S) end);
+handle_method(~"resources/unsubscribe", Params, Id, Session) ->
+    capability(resources, Id, Session, fun(S) -> unsubscribe_resource(Params, Id, S) end);
 handle_method(~"prompts/list", Params, Id, Session) ->
     capability(prompts, Id, Session, fun(#{mod := Mod, state := State} = S) ->
         list_reply(Mod:prompts(State), fun prompt_json/1, ~"prompts", Params, Id, S)
@@ -739,6 +748,44 @@ read_resource(Params, Id, #{mod := Mod, state := State} = Session) ->
         fun(Uri) -> resource_contents(Mod:read_resource(Uri, State), Uri, Id, Session) end
     ).
 
+%% The optional `resource_templates/1` callback; absent means no parameterized
+%% resources, so the transport advertises an empty template list.
+resource_templates(Mod, State) ->
+    case erlang:function_exported(Mod, resource_templates, 1) of
+        true -> Mod:resource_templates(State);
+        false -> []
+    end.
+
+%% `resources/subscribe` / `unsubscribe` join/leave the per-uri pubsub channel as
+%% the calling process. In session mode that is the session process, so the
+%% subscription persists and `arizona_mcp:resource_updated/1` broadcasts reach it
+%% (forwarded as `notifications/resources/updated`); in stateless mode the request
+%% process dies after the reply -- a harmless no-op, since stateless has no SSE
+%% channel to deliver on. Both answer the MCP empty result.
+subscribe_resource(Params, Id, Session) ->
+    resource_subscription(Params, Id, Session, fun join_resource/1).
+
+unsubscribe_resource(Params, Id, Session) ->
+    resource_subscription(Params, Id, Session, fun leave_resource/1).
+
+resource_subscription(#{~"uri" := Uri}, Id, Session, Fun) when is_binary(Uri) ->
+    ok = Fun({mcp_resource, Uri}),
+    {{reply, arizona_jsonrpc:result(Id, #{})}, Session};
+resource_subscription(_Params, Id, Session, _Fun) ->
+    {{error, arizona_jsonrpc:error(Id, -32602, ~"Invalid params: missing resource uri")}, Session}.
+
+join_resource(Channel) ->
+    case arizona_pubsub:subscribe(Channel, self()) of
+        ok -> ok;
+        {error, already_joined} -> ok
+    end.
+
+leave_resource(Channel) ->
+    case arizona_pubsub:unsubscribe(Channel, self()) of
+        ok -> ok;
+        {error, not_joined} -> ok
+    end.
+
 get_prompt(Params, Id, #{mod := Mod, state := State} = Session) ->
     with_member(
         Params,
@@ -808,6 +855,11 @@ resource_json(#{uri := Uri, name := Name} = Resource) ->
     Base = #{~"uri" => Uri, ~"name" => Name},
     WithDescription = maybe_put(~"description", description, Resource, Base),
     maybe_put(~"mimeType", mime_type, Resource, WithDescription).
+
+resource_template_json(#{uri_template := UriTemplate, name := Name} = Template) ->
+    Base = #{~"uriTemplate" => UriTemplate, ~"name" => Name},
+    WithDescription = maybe_put(~"description", description, Template, Base),
+    maybe_put(~"mimeType", mime_type, Template, WithDescription).
 
 %% A bare binary becomes one text entry keyed by the requested uri; a map
 %% supplies its content entries verbatim. An `{error, _}` is a -32002. Either

--- a/test/arizona_mcp_SUITE.erl
+++ b/test/arizona_mcp_SUITE.erl
@@ -29,6 +29,9 @@
     dispatch_resources_read_unknown/1,
     dispatch_resources_read_missing_uri/1,
     dispatch_resources_unsupported/1,
+    dispatch_resources_templates_list/1,
+    dispatch_resources_templates_unsupported/1,
+    dispatch_resources_subscribe_missing_uri/1,
     dispatch_prompts_list/1,
     dispatch_prompts_get/1,
     dispatch_prompts_get_error/1,
@@ -85,6 +88,9 @@ all() ->
         dispatch_resources_read_unknown,
         dispatch_resources_read_missing_uri,
         dispatch_resources_unsupported,
+        dispatch_resources_templates_list,
+        dispatch_resources_templates_unsupported,
+        dispatch_resources_subscribe_missing_uri,
         dispatch_prompts_list,
         dispatch_prompts_get,
         dispatch_prompts_get_error,
@@ -117,7 +123,7 @@ dispatch_initialize(_Config) ->
     {reply, #{~"result" := Result}} = dispatch(~"initialize", Params, 1),
     ?assertEqual(~"2025-06-18", maps:get(~"protocolVersion", Result)),
     ?assertEqual(
-        #{tools => #{}, resources => #{}, prompts => #{}},
+        #{tools => #{}, resources => #{subscribe => true}, prompts => #{}},
         maps:get(~"capabilities", Result)
     ),
     ?assertEqual(
@@ -301,6 +307,26 @@ dispatch_resources_unsupported(_Config) ->
     {error, #{~"error" := #{~"code" := Code}}} =
         dispatch_on(arizona_mcp_minimal_server, ~"resources/list", #{}, 25),
     ?assertEqual(-32601, Code).
+
+dispatch_resources_templates_list(_Config) ->
+    {reply, #{~"result" := #{~"resourceTemplates" := [Template]}}} =
+        dispatch(~"resources/templates/list", #{}, 26),
+    ?assertEqual(~"mem://user/{id}", maps:get(~"uriTemplate", Template)),
+    ?assertEqual(~"user", maps:get(~"name", Template)),
+    %% uri_template is renamed to the wire's uriTemplate.
+    ?assertNot(maps:is_key(~"uri_template", Template)).
+
+dispatch_resources_templates_unsupported(_Config) ->
+    %% A server without the resources capability has no templates endpoint.
+    {error, #{~"error" := #{~"code" := Code}}} =
+        dispatch_on(arizona_mcp_minimal_server, ~"resources/templates/list", #{}, 27),
+    ?assertEqual(-32601, Code).
+
+dispatch_resources_subscribe_missing_uri(_Config) ->
+    %% The missing-uri rejection happens before any pubsub join (no app needed).
+    {error, #{~"error" := #{~"code" := Code}}} =
+        dispatch(~"resources/subscribe", #{}, 28),
+    ?assertEqual(-32602, Code).
 
 dispatch_prompts_list(_Config) ->
     {reply, #{~"result" := #{~"prompts" := Prompts}}} = dispatch(~"prompts/list", #{}, 30),

--- a/test/arizona_mcp_e2e_SUITE.erl
+++ b/test/arizona_mcp_e2e_SUITE.erl
@@ -11,6 +11,7 @@
     post_progress_without_accept_buffered/1,
     post_tools_list_paginates/1,
     post_resources_read/1,
+    post_resources_templates_list/1,
     post_prompts_get/1,
     get_returns_405/1,
     post_disallowed_origin_403/1,
@@ -23,6 +24,7 @@
     session_tool_crash_survives/1,
     session_get_without_id_400/1,
     session_channel_receives_push/1,
+    session_resource_subscribe_pushes_update/1,
     session_second_channel_409/1,
     session_survives_channel_disconnect/1,
     session_resumes_with_last_event_id/1,
@@ -44,6 +46,7 @@ all() ->
         post_progress_without_accept_buffered,
         post_tools_list_paginates,
         post_resources_read,
+        post_resources_templates_list,
         post_prompts_get,
         get_returns_405,
         post_disallowed_origin_403,
@@ -56,6 +59,7 @@ all() ->
         session_tool_crash_survives,
         session_get_without_id_400,
         session_channel_receives_push,
+        session_resource_subscribe_pushes_update,
         session_second_channel_409,
         session_survives_channel_disconnect,
         session_resumes_with_last_event_id,
@@ -229,6 +233,17 @@ post_resources_read(Config) ->
     ?assertEqual(~"mem://greeting", maps:get(~"uri", Content)),
     ?assertEqual(~"hello", maps:get(~"text", Content)).
 
+post_resources_templates_list(Config) ->
+    Body =
+        ~"""
+    {"jsonrpc":"2.0","id":13,"method":"resources/templates/list","params":{}}
+    """,
+    Resp = post(Config, "/mcp", [], Body),
+    ?assertEqual(200, status_code(Resp)),
+    #{~"result" := #{~"resourceTemplates" := [Template]}} = body_json(Resp),
+    ?assertEqual(~"mem://user/{id}", maps:get(~"uriTemplate", Template)),
+    ?assertEqual(~"user", maps:get(~"name", Template)).
+
 post_prompts_get(Config) ->
     Body =
         ~"""
@@ -340,6 +355,24 @@ session_channel_receives_push(Config) ->
     gen_tcp:close(Sock),
     ?assertNotEqual(nomatch, binary:match(Data, ~"notifications/message")),
     ?assertNotEqual(nomatch, binary:match(Data, ~"hello-sse")).
+
+session_resource_subscribe_pushes_update(Config) ->
+    SessionId = open_session(Config),
+    {ok, Sock} = open_channel(Config, SessionId),
+    %% Subscribe (the POST is served by the session process, which joins the
+    %% per-uri channel), then announce the change server-side (in-node).
+    SubBody =
+        ~"""
+    {"jsonrpc":"2.0","id":14,"method":"resources/subscribe",
+     "params":{"uri":"mem://greeting"}}
+    """,
+    SubResp = post(Config, "/mcp-session", session_header(SessionId), SubBody),
+    ?assertEqual(200, status_code(SubResp)),
+    ok = arizona_mcp:resource_updated(~"mem://greeting"),
+    Data = recv_until(Sock, ~"resources/updated", 5000),
+    gen_tcp:close(Sock),
+    ?assertNotEqual(nomatch, binary:match(Data, ~"notifications/resources/updated")),
+    ?assertNotEqual(nomatch, binary:match(Data, ~"mem://greeting")).
 
 session_second_channel_409(Config) ->
     SessionId = open_session(Config),

--- a/test/arizona_mcp_session_SUITE.erl
+++ b/test/arizona_mcp_session_SUITE.erl
@@ -17,6 +17,10 @@
     ignores_unknown_messages/1,
     notify_pushes_to_channel/1,
     broadcast_reaches_subscribed_session/1,
+    resource_subscribe_receives_update/1,
+    resource_unsubscribe_stops_updates/1,
+    resource_subscribe_idempotent/1,
+    resource_unsubscribe_without_subscribe/1,
     notify_without_channel_is_noop/1,
     notify_unknown_session_is_noop/1,
     detach_re_enables_attach/1,
@@ -44,6 +48,10 @@ all() ->
         ignores_unknown_messages,
         notify_pushes_to_channel,
         broadcast_reaches_subscribed_session,
+        resource_subscribe_receives_update,
+        resource_unsubscribe_stops_updates,
+        resource_subscribe_idempotent,
+        resource_unsubscribe_without_subscribe,
         notify_without_channel_is_noop,
         notify_unknown_session_is_noop,
         detach_re_enables_attach,
@@ -181,6 +189,56 @@ broadcast_reaches_subscribed_session(_Config) ->
             ?assertNotEqual(nomatch, binary:match(iolist_to_binary(Frame), ~"list_changed"))
     after 5000 -> ct:fail(no_broadcast)
     end.
+
+resource_subscribe_receives_update(_Config) ->
+    {_Id, Pid} = start(60000),
+    ok = arizona_mcp_session:attach_channel(Pid, self(), undefined),
+    Uri = ~"mem://greeting",
+    %% Dispatched in the session process, so the session joins the per-uri
+    %% channel; a resource_updated/1 broadcast then reaches it. subscribe answers
+    %% the MCP empty result.
+    {reply, #{~"result" := #{}}} =
+        arizona_mcp_session:dispatch(Pid, ~"resources/subscribe", #{~"uri" => Uri}, 1),
+    ok = arizona_mcp:resource_updated(Uri),
+    receive
+        {mcp_event, Frame} ->
+            Bin = iolist_to_binary(Frame),
+            ?assertNotEqual(nomatch, binary:match(Bin, ~"notifications/resources/updated")),
+            ?assertNotEqual(nomatch, binary:match(Bin, Uri))
+    after 5000 -> ct:fail(no_update)
+    end.
+
+resource_unsubscribe_stops_updates(_Config) ->
+    {_Id, Pid} = start(60000),
+    ok = arizona_mcp_session:attach_channel(Pid, self(), undefined),
+    Uri = ~"mem://greeting",
+    {reply, _} = arizona_mcp_session:dispatch(Pid, ~"resources/subscribe", #{~"uri" => Uri}, 1),
+    {reply, _} = arizona_mcp_session:dispatch(Pid, ~"resources/unsubscribe", #{~"uri" => Uri}, 2),
+    %% The synchronous unsubscribe has left the channel before we publish.
+    ok = arizona_mcp:resource_updated(Uri),
+    receive
+        {mcp_event, _} -> ct:fail(unexpected_update)
+    after 200 -> ok
+    end.
+
+resource_subscribe_idempotent(_Config) ->
+    {_Id, Pid} = start(60000),
+    Uri = ~"mem://greeting",
+    %% A second subscribe to the same uri is idempotent (already_joined -> ok).
+    {reply, #{~"result" := #{}}} =
+        arizona_mcp_session:dispatch(Pid, ~"resources/subscribe", #{~"uri" => Uri}, 1),
+    ?assertMatch(
+        {reply, #{~"result" := #{}}},
+        arizona_mcp_session:dispatch(Pid, ~"resources/subscribe", #{~"uri" => Uri}, 2)
+    ).
+
+resource_unsubscribe_without_subscribe(_Config) ->
+    {_Id, Pid} = start(60000),
+    %% Unsubscribing a uri that was never subscribed is a no-op (not_joined -> ok).
+    ?assertMatch(
+        {reply, #{~"result" := #{}}},
+        arizona_mcp_session:dispatch(Pid, ~"resources/unsubscribe", #{~"uri" => ~"mem://never"}, 1)
+    ).
 
 notify_without_channel_is_noop(_Config) ->
     {_Id, Pid} = start(60000),

--- a/test/conformance/mcp_client.mjs
+++ b/test/conformance/mcp_client.mjs
@@ -82,6 +82,18 @@ try {
   const read = await client.readResource({ uri: 'mem://greeting' });
   check("resources/read => 'hello'", read.contents?.[0]?.text === 'hello');
 
+  const templates = await client.listResourceTemplates();
+  check(
+    'resources/templates/list has user',
+    templates.resourceTemplates?.some((t) => t.uriTemplate === 'mem://user/{id}'),
+  );
+
+  // subscribe/unsubscribe round-trip (delivery itself is covered by the Erlang
+  // suites, where the server can publish an update mid-test); a throw here fails.
+  await client.subscribeResource({ uri: 'mem://greeting' });
+  await client.unsubscribeResource({ uri: 'mem://greeting' });
+  check('resources subscribe/unsubscribe round-trip', true);
+
   const prompts = await listAll((p) => client.listPrompts(p), 'prompts');
   check("prompts/list has 'greet'", prompts.some((p) => p.name === 'greet'));
 

--- a/test/support/arizona_mcp_test_server.erl
+++ b/test/support/arizona_mcp_test_server.erl
@@ -7,6 +7,7 @@
 -export([handle_tool/4]).
 -export([resources/1]).
 -export([read_resource/2]).
+-export([resource_templates/1]).
 -export([prompts/1]).
 -export([get_prompt/3]).
 -export([channels/1]).
@@ -14,7 +15,7 @@
 
 init(_InitParams) ->
     {ok, #{name => ~"arizona_test", version => ~"0.1.0"},
-        #{tools => #{}, resources => #{}, prompts => #{}}, #{}}.
+        #{tools => #{}, resources => #{subscribe => true}, prompts => #{}}, #{}}.
 
 tools(_State) ->
     [
@@ -115,6 +116,16 @@ read_resource(~"mem://counter", State) ->
     %% resource read threads its returned state back too.
     Count = maps:get(count, State, 0) + 1,
     {reply, integer_to_binary(Count), State#{count => Count}}.
+
+resource_templates(_State) ->
+    [
+        #{
+            uri_template => ~"mem://user/{id}",
+            name => ~"user",
+            description => ~"A user by id",
+            mime_type => ~"application/json"
+        }
+    ].
 
 prompts(_State) ->
     [


### PR DESCRIPTION
# Description

Adds MCP resource subscriptions and resource templates, the fourth chunk of the server completion work (pagination landed in #552).

A client subscribes to a resource with `resources/subscribe`; the app announces a change with `arizona_mcp:resource_updated(Uri)`, which fans `notifications/resources/updated` out to every subscribed session. It reuses the existing pubsub fan-out: subscribe joins a per-uri `arizona_pubsub` channel, `resource_updated/1` broadcasts to it, and `resources/unsubscribe` (or session exit) leaves, so there is no per-session subscription bookkeeping. A server advertises support with `resources => #{subscribe => true}` from `init/1`.

The optional `resource_templates/1` callback backs `resources/templates/list` (URI templates like `mem://user/{id}`), paginated through the same path as the other list methods. Omit it for a server with no parameterized resources.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
