### PR TITLE
Add MCP logging and argument completion

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1114,6 +1114,15 @@ same fan-out path as `broadcast/3` + `channels/1`, just keyed per uri and joined
 optional `resource_templates/1` callback backs `resources/templates/list` (URI templates like
 `mem://user/{id}`), paginated through the same `list_reply`.
 
+### Logging and completion
+
+`logging/setLevel` stores a minimum severity in the session map (`log_min_severity`, default `info`),
+threaded back like any other state; `arizona_mcp:log/3` resolves the level severity caller-side and
+casts to the session, which emits a `notifications/message` only when the message is at or above the
+stored minimum. `completion/complete` decodes the ref (`{prompt, Name}` | `{resource, Uri}`) and the
+partial argument, calls the optional `complete/3` callback, and caps the returned values at 100,
+setting `hasMore`. Both are capability-gated (`logging` / `completions`).
+
 ### Pagination
 
 The `*/list` methods paginate with opaque cursors, framework-side: the `tools/1` / `resources/1` /

--- a/src/arizona_mcp.erl
+++ b/src/arizona_mcp.erl
@@ -128,6 +128,16 @@ The optional `resource_templates/1` callback advertises URI templates
 (`mem://user/{id}`) through `resources/templates/list`. Omit it for a server
 with no parameterized resources.
 
+## Logging and completion
+
+With `logging => #{}` advertised, the client sets a minimum severity via
+`logging/setLevel` and the server pushes logs with `log/3` (a
+`notifications/message`); a message below the session's level is dropped (the
+default is `info`). With `completions => #{}` advertised, the optional
+`complete/3` callback autocompletes a prompt or resource argument from
+`completion/complete` -- it returns the matching strings and the transport caps
+them at 100.
+
 ## Operational notes
 
 Session mode starts one process per `initialize`, and the count is
@@ -154,6 +164,9 @@ the official MCP SDK client.
 -export([broadcast/3]).
 -export([notify/3]).
 -export([resource_updated/1]).
+-export([log/3]).
+-export([level_severity/1]).
+-export([parse_level/1]).
 -export([progress/2]).
 -export([progress/3]).
 
@@ -165,6 +178,7 @@ the official MCP SDK client.
 %% within arizona.
 -ignore_xref([broadcast/3, notify/3]).
 -ignore_xref([resource_updated/1]).
+-ignore_xref([log/3]).
 -ignore_xref([progress/2, progress/3]).
 
 %% --------------------------------------------------------------------
@@ -191,6 +205,9 @@ the official MCP SDK client.
 -export_type([prompt_message/0]).
 -export_type([prompt_result/0]).
 -export_type([prompt_error/0]).
+-export_type([log_level/0]).
+-export_type([complete_ref/0]).
+-export_type([complete_argument/0]).
 
 %% --------------------------------------------------------------------
 %% Types definitions
@@ -285,6 +302,24 @@ the official MCP SDK client.
 
 -nominal prompt_error() :: binary().
 
+%% The RFC 5424 / syslog severities MCP uses, ascending. `logging/setLevel` sets
+%% the minimum; a message at or above it is delivered.
+-nominal log_level() ::
+    debug
+    | info
+    | notice
+    | warning
+    | error
+    | critical
+    | alert
+    | emergency.
+
+%% What `completion/complete` is completing: a prompt or a resource argument.
+-nominal complete_ref() :: {prompt, binary()} | {resource, binary()}.
+
+%% The argument being completed: its name and the partial value typed so far.
+-nominal complete_argument() :: {binary(), binary()}.
+
 %% --------------------------------------------------------------------
 %% Behaviour callbacks
 %% --------------------------------------------------------------------
@@ -361,6 +396,16 @@ decoded `arguments` object. Return `{reply, Result, State}` on success or
     | {error, prompt_error(), state()}.
 
 -doc """
+Autocomplete a prompt or resource argument, dispatched from
+`completion/complete`. `Ref` is `{prompt, Name}` or `{resource, Uri}`; `Arg` is
+`{ArgName, PartialValue}`. Return `{reply, Values, State}` with the matching
+completion strings (the transport caps them at 100 and sets `hasMore`).
+Optional; implement it when advertising the `completions` capability.
+""".
+-callback complete(Ref :: complete_ref(), Arg :: complete_argument(), State :: state()) ->
+    {reply, [binary()], state()}.
+
+-doc """
 Return the pubsub channels this session subscribes to for server-initiated
 notifications. Anything published to one of these channels via `broadcast/3`
 is forwarded to the session's SSE channel. Optional; defaults to none.
@@ -376,6 +421,7 @@ is forwarded to the session's SSE channel. Optional; defaults to none.
     resource_templates/1,
     prompts/1,
     get_prompt/3,
+    complete/3,
     channels/1,
     terminate/2
 ]).
@@ -424,6 +470,54 @@ reference.
     Uri :: binary().
 resource_updated(Uri) ->
     broadcast({mcp_resource, Uri}, ~"notifications/resources/updated", #{~"uri" => Uri}).
+
+-doc """
+Send a log message (a `notifications/message`) to one session by its
+`Mcp-Session-Id`. Dropped if `Level` is below the level the client set via
+`logging/setLevel` (default `info`), or if the session is unknown/expired or has
+no SSE channel. `Data` is any JSON-encodable term. Like `notify/3`, the id comes
+from the handler's `initialize` params.
+""".
+-spec log(SessionId, Level, Data) -> ok when
+    SessionId :: binary(),
+    Level :: log_level(),
+    Data :: term().
+log(SessionId, Level, Data) ->
+    %% Severity is resolved caller-side, so a bad level crashes the caller
+    %% rather than the session.
+    Severity = level_severity(Level),
+    case arizona_mcp_session_registry:lookup(SessionId) of
+        {ok, Pid} -> arizona_mcp_session:log(Pid, Severity, Level, Data);
+        error -> ok
+    end.
+
+-doc false.
+%% The numeric severity of a level, ascending (debug lowest). The transport
+%% delivers a message only when its severity is at or above the session's set
+%% minimum. Framework-internal; shared by the handler and `log/3`.
+-spec level_severity(log_level()) -> 0..7.
+level_severity(debug) -> 0;
+level_severity(info) -> 1;
+level_severity(notice) -> 2;
+level_severity(warning) -> 3;
+level_severity(error) -> 4;
+level_severity(critical) -> 5;
+level_severity(alert) -> 6;
+level_severity(emergency) -> 7.
+
+-doc false.
+%% Parse a wire log level string into its atom, or `error` for an unknown one
+%% (`logging/setLevel` answers a -32602). Framework-internal.
+-spec parse_level(binary()) -> {ok, log_level()} | error.
+parse_level(~"debug") -> {ok, debug};
+parse_level(~"info") -> {ok, info};
+parse_level(~"notice") -> {ok, notice};
+parse_level(~"warning") -> {ok, warning};
+parse_level(~"error") -> {ok, error};
+parse_level(~"critical") -> {ok, critical};
+parse_level(~"alert") -> {ok, alert};
+parse_level(~"emergency") -> {ok, emergency};
+parse_level(_Other) -> error.
 
 -doc """
 Emit a `notifications/progress` update from a running `tools/call`, using the

--- a/src/arizona_mcp_handler.erl
+++ b/src/arizona_mcp_handler.erl
@@ -50,14 +50,16 @@ protocol contract holds even when a tool raises.
 %% --------------------------------------------------------------------
 
 %% The dispatch context: the handler module, its state, the capabilities
-%% negotiated at initialize, and the list page size. `arizona_mcp_session` holds
-%% one across a stateful connection; `dispatch/3` builds an ephemeral one per
+%% negotiated at initialize, the list page size, and the minimum log severity
+%% the client set (via `logging/setLevel`). `arizona_mcp_session` holds one
+%% across a stateful connection; `dispatch/3` builds an ephemeral one per
 %% request.
 -type session() :: #{
     mod := module(),
     state := arizona_mcp:state(),
     caps := arizona_mcp:capabilities(),
-    page_size := pos_integer()
+    page_size := pos_integer(),
+    log_min_severity := 0..7
 }.
 
 %% An optional per-route auth hook, run after the Origin check and before any
@@ -85,6 +87,10 @@ protocol contract holds even when a tool raises.
 %% Page size for the `*/list` methods, overridable via the route's `page_size`
 %% opt. A list at or under this size returns no cursor; a larger one paginates.
 -define(DEFAULT_PAGE_SIZE, 50).
+
+%% The minimum log level before the client sends `logging/setLevel`: `info`, so
+%% operational logs flow but `debug` is suppressed until requested.
+-define(DEFAULT_LOG_LEVEL, info).
 
 %% --------------------------------------------------------------------
 %% API Functions
@@ -238,7 +244,14 @@ dispatch(Mod, #{method := Method, params := Params, id := Id}, Ctx) ->
     Session :: session().
 open_session(Mod, InitParams, PageSize) ->
     {ok, ServerInfo, Caps, State} = Mod:init(InitParams),
-    {ServerInfo, #{mod => Mod, state => State, caps => Caps, page_size => PageSize}}.
+    Session = #{
+        mod => Mod,
+        state => State,
+        caps => Caps,
+        page_size => PageSize,
+        log_min_severity => arizona_mcp:level_severity(?DEFAULT_LOG_LEVEL)
+    },
+    {ServerInfo, Session}.
 
 %% Build the `initialize` result: negotiated protocol version, advertised
 %% capabilities, and the server identity.
@@ -622,6 +635,10 @@ handle_method(~"prompts/list", Params, Id, Session) ->
     end);
 handle_method(~"prompts/get", Params, Id, Session) ->
     capability(prompts, Id, Session, fun(S) -> get_prompt(Params, Id, S) end);
+handle_method(~"logging/setLevel", Params, Id, Session) ->
+    capability(logging, Id, Session, fun(S) -> set_level(Params, Id, S) end);
+handle_method(~"completion/complete", Params, Id, Session) ->
+    capability(completions, Id, Session, fun(S) -> complete(Params, Id, S) end);
 handle_method(_Method, _Params, Id, Session) ->
     method_not_found(Id, Session).
 
@@ -799,6 +816,60 @@ get_prompt(Params, Id, #{mod := Mod, state := State} = Session) ->
             prompt_messages(Mod:get_prompt(Name, Args, State), Id, Session)
         end
     ).
+
+%% `logging/setLevel` stores the client's minimum severity in the session, so a
+%% later `log/3` below it is dropped. A bad or missing level is a -32602.
+set_level(#{~"level" := LevelBin}, Id, Session) when is_binary(LevelBin) ->
+    case arizona_mcp:parse_level(LevelBin) of
+        {ok, Level} ->
+            Session1 = Session#{log_min_severity := arizona_mcp:level_severity(Level)},
+            {{reply, arizona_jsonrpc:result(Id, #{})}, Session1};
+        error ->
+            {
+                {error,
+                    arizona_jsonrpc:error(Id, -32602, <<"Invalid log level: ", LevelBin/binary>>)},
+                Session
+            }
+    end;
+set_level(_Params, Id, Session) ->
+    {{error, arizona_jsonrpc:error(Id, -32602, ~"Invalid params: missing level")}, Session}.
+
+%% `completion/complete` decodes the ref + argument, runs the app's `complete/3`,
+%% caps the values at the MCP limit of 100, and reports `hasMore`. A malformed
+%% ref or argument is a -32602.
+complete(#{~"ref" := Ref, ~"argument" := Arg}, Id, #{mod := Mod, state := State} = Session) ->
+    case {decode_ref(Ref), decode_arg(Arg)} of
+        {{ok, DecRef}, {ok, DecArg}} ->
+            {reply, Values, NewState} = Mod:complete(DecRef, DecArg, State),
+            Result = completion_result(Values),
+            {{reply, arizona_jsonrpc:result(Id, Result)}, Session#{state := NewState}};
+        _ ->
+            {
+                {error, arizona_jsonrpc:error(Id, -32602, ~"Invalid completion ref or argument")},
+                Session
+            }
+    end;
+complete(_Params, Id, Session) ->
+    {
+        {error, arizona_jsonrpc:error(Id, -32602, ~"Invalid params: missing ref or argument")},
+        Session
+    }.
+
+decode_ref(#{~"type" := ~"ref/prompt", ~"name" := Name}) when is_binary(Name) ->
+    {ok, {prompt, Name}};
+decode_ref(#{~"type" := ~"ref/resource", ~"uri" := Uri}) when is_binary(Uri) ->
+    {ok, {resource, Uri}};
+decode_ref(_Ref) ->
+    error.
+
+decode_arg(#{~"name" := Name, ~"value" := Value}) when is_binary(Name), is_binary(Value) ->
+    {ok, {Name, Value}};
+decode_arg(_Arg) ->
+    error.
+
+completion_result(Values) ->
+    Capped = lists:sublist(Values, 100),
+    #{~"completion" => #{~"values" => Capped, ~"hasMore" => length(Values) > 100}}.
 
 %% The callback ran -- thread its returned state back into the session whether
 %% it succeeded or failed in-band, since a failed-but-ran tool may have

--- a/src/arizona_mcp_session.erl
+++ b/src/arizona_mcp_session.erl
@@ -28,6 +28,7 @@ sends `DELETE`) does not leak; every served request resets it.
 -export([attach_channel/3]).
 -export([detach_channel/2]).
 -export([notify/3]).
+-export([log/4]).
 -export([stop/1]).
 
 %% --------------------------------------------------------------------
@@ -155,6 +156,19 @@ session's SSE channel. A no-op if no channel is attached. Fire-and-forget.
 notify(Pid, Method, Params) ->
     gen_server:cast(Pid, {notify, Method, Params}).
 
+-doc """
+Send a `notifications/message` log to the session, dropped if `Severity` is
+below the session's set minimum (`logging/setLevel`). `Level` is the wire level
+atom and `Data` the message body. Fire-and-forget.
+""".
+-spec log(Pid, Severity, Level, Data) -> ok when
+    Pid :: pid(),
+    Severity :: 0..7,
+    Level :: arizona_mcp:log_level(),
+    Data :: term().
+log(Pid, Severity, Level, Data) ->
+    gen_server:cast(Pid, {log, Severity, Level, Data}).
+
 -doc "Terminate the session (the `DELETE` teardown).".
 -spec stop(Pid) -> ok when
     Pid :: pid().
@@ -215,6 +229,15 @@ handle_cast({detach_channel, ChannelPid}, #state{channel = ChannelPid} = State) 
     {noreply, do_detach(State)};
 handle_cast({notify, Method, Params}, State) ->
     {noreply, emit(Method, Params, State)};
+handle_cast({log, Severity, Level, Data}, #state{session = Session} = State) ->
+    %% Deliver only when at or above the level the client set via setLevel.
+    case Severity >= maps:get(log_min_severity, Session) of
+        true ->
+            Params = #{~"level" => atom_to_binary(Level), ~"data" => Data},
+            {noreply, emit(~"notifications/message", Params, State)};
+        false ->
+            {noreply, State}
+    end;
 handle_cast(
     {run_streaming_tool, Name, Args, Id, Token, ConnPid}, #state{session = Session} = State
 ) ->

--- a/test/arizona_mcp_SUITE.erl
+++ b/test/arizona_mcp_SUITE.erl
@@ -38,6 +38,15 @@
     dispatch_prompts_get_unknown/1,
     dispatch_prompts_get_missing_name/1,
     dispatch_prompts_unsupported/1,
+    dispatch_set_level/1,
+    dispatch_set_level_invalid/1,
+    dispatch_set_level_missing/1,
+    dispatch_logging_unsupported/1,
+    dispatch_complete/1,
+    dispatch_complete_invalid_ref/1,
+    dispatch_complete_unsupported/1,
+    log_level_severities/1,
+    parse_log_levels/1,
     pagination_tools_walk/1,
     pagination_resources_walk/1,
     pagination_no_cursor_when_list_fits/1,
@@ -97,6 +106,15 @@ all() ->
         dispatch_prompts_get_unknown,
         dispatch_prompts_get_missing_name,
         dispatch_prompts_unsupported,
+        dispatch_set_level,
+        dispatch_set_level_invalid,
+        dispatch_set_level_missing,
+        dispatch_logging_unsupported,
+        dispatch_complete,
+        dispatch_complete_invalid_ref,
+        dispatch_complete_unsupported,
+        log_level_severities,
+        parse_log_levels,
         pagination_tools_walk,
         pagination_resources_walk,
         pagination_no_cursor_when_list_fits,
@@ -123,7 +141,13 @@ dispatch_initialize(_Config) ->
     {reply, #{~"result" := Result}} = dispatch(~"initialize", Params, 1),
     ?assertEqual(~"2025-06-18", maps:get(~"protocolVersion", Result)),
     ?assertEqual(
-        #{tools => #{}, resources => #{subscribe => true}, prompts => #{}},
+        #{
+            tools => #{},
+            resources => #{subscribe => true},
+            prompts => #{},
+            logging => #{},
+            completions => #{}
+        },
         maps:get(~"capabilities", Result)
     ),
     ?assertEqual(
@@ -365,6 +389,70 @@ dispatch_prompts_unsupported(_Config) ->
     ?assertEqual(-32601, Code).
 
 %% --------------------------------------------------------------------
+%% Logging (logging/setLevel) and completion (completion/complete)
+%% --------------------------------------------------------------------
+
+dispatch_set_level(_Config) ->
+    %% setLevel answers the MCP empty result.
+    {reply, #{~"result" := Result}} = dispatch(~"logging/setLevel", #{~"level" => ~"warning"}, 40),
+    ?assertEqual(#{}, Result).
+
+dispatch_set_level_invalid(_Config) ->
+    {error, #{~"error" := #{~"code" := Code}}} =
+        dispatch(~"logging/setLevel", #{~"level" => ~"loud"}, 41),
+    ?assertEqual(-32602, Code).
+
+dispatch_set_level_missing(_Config) ->
+    {error, #{~"error" := #{~"code" := Code}}} = dispatch(~"logging/setLevel", #{}, 42),
+    ?assertEqual(-32602, Code).
+
+dispatch_logging_unsupported(_Config) ->
+    {error, #{~"error" := #{~"code" := Code}}} =
+        dispatch_on(arizona_mcp_minimal_server, ~"logging/setLevel", #{~"level" => ~"info"}, 43),
+    ?assertEqual(-32601, Code).
+
+dispatch_complete(_Config) ->
+    Params = #{
+        ~"ref" => #{~"type" => ~"ref/prompt", ~"name" => ~"greet"},
+        ~"argument" => #{~"name" => ~"who", ~"value" => ~"Ad"}
+    },
+    {reply, #{~"result" := #{~"completion" := Completion}}} =
+        dispatch(~"completion/complete", Params, 44),
+    ?assertEqual([~"Ada", ~"Adam"], maps:get(~"values", Completion)),
+    ?assertEqual(false, maps:get(~"hasMore", Completion)).
+
+dispatch_complete_invalid_ref(_Config) ->
+    Params = #{
+        ~"ref" => #{~"type" => ~"ref/bogus"},
+        ~"argument" => #{~"name" => ~"who", ~"value" => ~"Ad"}
+    },
+    {error, #{~"error" := #{~"code" := Code}}} = dispatch(~"completion/complete", Params, 45),
+    ?assertEqual(-32602, Code).
+
+dispatch_complete_unsupported(_Config) ->
+    Params = #{
+        ~"ref" => #{~"type" => ~"ref/prompt", ~"name" => ~"greet"},
+        ~"argument" => #{~"name" => ~"who", ~"value" => ~"Ad"}
+    },
+    {error, #{~"error" := #{~"code" := Code}}} =
+        dispatch_on(arizona_mcp_minimal_server, ~"completion/complete", Params, 46),
+    ?assertEqual(-32601, Code).
+
+log_level_severities(_Config) ->
+    %% Every level maps to a strictly ascending severity.
+    Levels = [debug, info, notice, warning, error, critical, alert, emergency],
+    ?assertEqual([0, 1, 2, 3, 4, 5, 6, 7], [arizona_mcp:level_severity(L) || L <- Levels]).
+
+parse_log_levels(_Config) ->
+    %% Every level round-trips from its wire string; an unknown one is `error`.
+    Levels = [debug, info, notice, warning, error, critical, alert, emergency],
+    lists:foreach(
+        fun(L) -> ?assertEqual({ok, L}, arizona_mcp:parse_level(atom_to_binary(L))) end,
+        Levels
+    ),
+    ?assertEqual(error, arizona_mcp:parse_level(~"nope")).
+
+%% --------------------------------------------------------------------
 %% Pagination (framework-side opaque cursors over the */list methods)
 %% --------------------------------------------------------------------
 
@@ -517,7 +605,8 @@ session() ->
         mod => ?SERVER,
         state => #{},
         caps => #{tools => #{}, resources => #{}, prompts => #{}},
-        page_size => 50
+        page_size => 50,
+        log_min_severity => 1
     }.
 
 %% Receive one relayed progress notification, returning its `progress` amount.

--- a/test/arizona_mcp_e2e_SUITE.erl
+++ b/test/arizona_mcp_e2e_SUITE.erl
@@ -12,6 +12,7 @@
     post_tools_list_paginates/1,
     post_resources_read/1,
     post_resources_templates_list/1,
+    post_completion_complete/1,
     post_prompts_get/1,
     get_returns_405/1,
     post_disallowed_origin_403/1,
@@ -25,6 +26,7 @@
     session_get_without_id_400/1,
     session_channel_receives_push/1,
     session_resource_subscribe_pushes_update/1,
+    session_set_level_filters_log/1,
     session_second_channel_409/1,
     session_survives_channel_disconnect/1,
     session_resumes_with_last_event_id/1,
@@ -47,6 +49,7 @@ all() ->
         post_tools_list_paginates,
         post_resources_read,
         post_resources_templates_list,
+        post_completion_complete,
         post_prompts_get,
         get_returns_405,
         post_disallowed_origin_403,
@@ -60,6 +63,7 @@ all() ->
         session_get_without_id_400,
         session_channel_receives_push,
         session_resource_subscribe_pushes_update,
+        session_set_level_filters_log,
         session_second_channel_409,
         session_survives_channel_disconnect,
         session_resumes_with_last_event_id,
@@ -244,6 +248,18 @@ post_resources_templates_list(Config) ->
     ?assertEqual(~"mem://user/{id}", maps:get(~"uriTemplate", Template)),
     ?assertEqual(~"user", maps:get(~"name", Template)).
 
+post_completion_complete(Config) ->
+    Body =
+        ~"""
+    {"jsonrpc":"2.0","id":16,"method":"completion/complete",
+     "params":{"ref":{"type":"ref/prompt","name":"greet"},
+               "argument":{"name":"who","value":"Ad"}}}
+    """,
+    Resp = post(Config, "/mcp", [], Body),
+    ?assertEqual(200, status_code(Resp)),
+    #{~"result" := #{~"completion" := #{~"values" := Values}}} = body_json(Resp),
+    ?assertEqual([~"Ada", ~"Adam"], Values).
+
 post_prompts_get(Config) ->
     Body =
         ~"""
@@ -373,6 +389,25 @@ session_resource_subscribe_pushes_update(Config) ->
     gen_tcp:close(Sock),
     ?assertNotEqual(nomatch, binary:match(Data, ~"notifications/resources/updated")),
     ?assertNotEqual(nomatch, binary:match(Data, ~"mem://greeting")).
+
+session_set_level_filters_log(Config) ->
+    SessionId = open_session(Config),
+    {ok, Sock} = open_channel(Config, SessionId),
+    %% Raise the threshold to warning via the wire, then log info (dropped) and
+    %% error (delivered) in-node.
+    SetBody =
+        ~"""
+    {"jsonrpc":"2.0","id":17,"method":"logging/setLevel","params":{"level":"warning"}}
+    """,
+    SetResp = post(Config, "/mcp-session", session_header(SessionId), SetBody),
+    ?assertEqual(200, status_code(SetResp)),
+    ok = arizona_mcp:log(SessionId, info, ~"info-drop"),
+    ok = arizona_mcp:log(SessionId, error, ~"error-send"),
+    Data = recv_until(Sock, ~"error-send", 5000),
+    gen_tcp:close(Sock),
+    ?assertNotEqual(nomatch, binary:match(Data, ~"notifications/message")),
+    ?assertNotEqual(nomatch, binary:match(Data, ~"error-send")),
+    ?assertEqual(nomatch, binary:match(Data, ~"info-drop")).
 
 session_second_channel_409(Config) ->
     SessionId = open_session(Config),

--- a/test/arizona_mcp_session_SUITE.erl
+++ b/test/arizona_mcp_session_SUITE.erl
@@ -21,8 +21,11 @@
     resource_unsubscribe_stops_updates/1,
     resource_subscribe_idempotent/1,
     resource_unsubscribe_without_subscribe/1,
+    log_filtered_by_default_level/1,
+    log_respects_set_level/1,
     notify_without_channel_is_noop/1,
     notify_unknown_session_is_noop/1,
+    log_unknown_session_is_noop/1,
     detach_re_enables_attach/1,
     channel_cancels_idle_ttl/1,
     detach_re_arms_ttl/1,
@@ -52,8 +55,11 @@ all() ->
         resource_unsubscribe_stops_updates,
         resource_subscribe_idempotent,
         resource_unsubscribe_without_subscribe,
+        log_filtered_by_default_level,
+        log_respects_set_level,
         notify_without_channel_is_noop,
         notify_unknown_session_is_noop,
+        log_unknown_session_is_noop,
         detach_re_enables_attach,
         channel_cancels_idle_ttl,
         detach_re_arms_ttl,
@@ -240,6 +246,39 @@ resource_unsubscribe_without_subscribe(_Config) ->
         arizona_mcp_session:dispatch(Pid, ~"resources/unsubscribe", #{~"uri" => ~"mem://never"}, 1)
     ).
 
+log_filtered_by_default_level(_Config) ->
+    {Id, Pid} = start(60000),
+    ok = arizona_mcp_session:attach_channel(Pid, self(), undefined),
+    %% Default level is info: debug drops, info delivers. Casts are ordered, so
+    %% the only event that arrives is the info one.
+    ok = arizona_mcp:log(Id, debug, ~"should-drop"),
+    ok = arizona_mcp:log(Id, info, ~"should-send"),
+    receive
+        {mcp_event, Frame} ->
+            Bin = iolist_to_binary(Frame),
+            ?assertNotEqual(nomatch, binary:match(Bin, ~"notifications/message")),
+            ?assertNotEqual(nomatch, binary:match(Bin, ~"should-send")),
+            ?assertEqual(nomatch, binary:match(Bin, ~"should-drop"))
+    after 5000 -> ct:fail(no_log)
+    end,
+    no_more_events().
+
+log_respects_set_level(_Config) ->
+    {Id, Pid} = start(60000),
+    ok = arizona_mcp_session:attach_channel(Pid, self(), undefined),
+    %% Raise the threshold to warning: info now drops, error delivers.
+    {reply, #{~"result" := #{}}} =
+        arizona_mcp_session:dispatch(Pid, ~"logging/setLevel", #{~"level" => ~"warning"}, 1),
+    ok = arizona_mcp:log(Id, info, ~"info-drop"),
+    ok = arizona_mcp:log(Id, error, ~"error-send"),
+    receive
+        {mcp_event, Frame} ->
+            Bin = iolist_to_binary(Frame),
+            ?assertNotEqual(nomatch, binary:match(Bin, ~"error-send")),
+            ?assertEqual(nomatch, binary:match(Bin, ~"info-drop"))
+    after 5000 -> ct:fail(no_log)
+    end.
+
 notify_without_channel_is_noop(_Config) ->
     {_Id, Pid} = start(60000),
     ok = arizona_mcp_session:notify(Pid, ~"notifications/message", #{}),
@@ -252,6 +291,10 @@ notify_without_channel_is_noop(_Config) ->
 notify_unknown_session_is_noop(_Config) ->
     %% arizona_mcp:notify/3 to an unknown session id is a silent no-op.
     ?assertEqual(ok, arizona_mcp:notify(~"no-such-session", ~"notifications/message", #{})).
+
+log_unknown_session_is_noop(_Config) ->
+    %% arizona_mcp:log/3 to an unknown session id is a silent no-op.
+    ?assertEqual(ok, arizona_mcp:log(~"no-such-session", info, ~"x")).
 
 detach_re_enables_attach(_Config) ->
     {_Id, Pid} = start(60000),
@@ -321,7 +364,8 @@ terminate_calls_app(_Config) ->
         mod => arizona_mcp_test_server,
         state => #{terminate_pid => self()},
         caps => #{tools => #{}},
-        page_size => 50
+        page_size => 50,
+        log_min_severity => 1
     },
     {ok, Pid} = arizona_mcp_sup:start_session(Id, Session, #{ttl_ms => 60000, buffer_max => 256}),
     ok = arizona_mcp_session:stop(Pid),
@@ -380,6 +424,9 @@ session() ->
     #{
         mod => arizona_mcp_test_server,
         state => #{},
-        caps => #{tools => #{}, resources => #{}, prompts => #{}},
-        page_size => 50
+        caps => #{
+            tools => #{}, resources => #{}, prompts => #{}, logging => #{}, completions => #{}
+        },
+        page_size => 50,
+        log_min_severity => 1
     }.

--- a/test/conformance/mcp_client.mjs
+++ b/test/conformance/mcp_client.mjs
@@ -100,6 +100,17 @@ try {
   const prompt = await client.getPrompt({ name: 'greet', arguments: { who: 'Ada' } });
   check("prompts/get => 'Hello, Ada'", JSON.stringify(prompt).includes('Hello, Ada'));
 
+  // logging/setLevel round-trips (delivery + filtering is covered by the Erlang
+  // suites, where the server can emit a log mid-test); a throw here fails.
+  await client.setLoggingLevel('warning');
+  check('logging/setLevel round-trip', true);
+
+  const completion = await client.complete({
+    ref: { type: 'ref/prompt', name: 'greet' },
+    argument: { name: 'who', value: 'Ad' },
+  });
+  check('completion/complete has Ada', completion.completion?.values?.includes('Ada'));
+
   await client.close();
 } catch (e) {
   console.log(`  ERROR  ${e?.message ?? e}`);

--- a/test/support/arizona_mcp_test_server.erl
+++ b/test/support/arizona_mcp_test_server.erl
@@ -10,12 +10,20 @@
 -export([resource_templates/1]).
 -export([prompts/1]).
 -export([get_prompt/3]).
+-export([complete/3]).
 -export([channels/1]).
 -export([terminate/2]).
 
 init(_InitParams) ->
     {ok, #{name => ~"arizona_test", version => ~"0.1.0"},
-        #{tools => #{}, resources => #{subscribe => true}, prompts => #{}}, #{}}.
+        #{
+            tools => #{},
+            resources => #{subscribe => true},
+            prompts => #{},
+            logging => #{},
+            completions => #{}
+        },
+        #{}}.
 
 tools(_State) ->
     [
@@ -156,6 +164,20 @@ get_prompt(~"count", _Args, State) ->
     Count = maps:get(count, State, 0) + 1,
     Message = #{role => ~"user", content => #{type => ~"text", text => integer_to_binary(Count)}},
     {reply, #{messages => [Message]}, State#{count => Count}}.
+
+complete({prompt, ~"greet"}, {~"who", Value}, State) ->
+    %% Prefix-complete the `who` argument of the greet prompt.
+    Candidates = [~"Ada", ~"Adam", ~"Alan"],
+    {reply, [Name || Name <- Candidates, is_prefix(Value, Name)], State};
+complete(_Ref, _Arg, State) ->
+    {reply, [], State}.
+
+is_prefix(Prefix, Bin) ->
+    Size = byte_size(Prefix),
+    case Bin of
+        <<Prefix:Size/binary, _/binary>> -> true;
+        _ -> false
+    end.
 
 channels(_State) ->
     [mcp_test_channel].


### PR DESCRIPTION
# Description

Adds MCP logging and argument completion, the fifth chunk of the server completion work (resource subscriptions landed in #553).

Logging: with `logging => #{}` advertised, the client sets a minimum severity via `logging/setLevel` and the app pushes logs with `arizona_mcp:log(SessionId, Level, Data)`, which the session delivers as a `notifications/message` only when the level is at or above that minimum (default `info`). The level is stored in the session and threaded back like any other state, so it survives across requests; targeting works exactly like `notify/3`.

Completion: with `completions => #{}` advertised, the optional `complete/3` callback autocompletes a prompt or resource argument from `completion/complete`. The callback receives `{prompt, Name}` or `{resource, Uri}` plus the `{ArgName, PartialValue}` being typed, and returns the matching strings; the transport caps them at the MCP limit of 100 and sets `hasMore`.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
