### PR TITLE
Cancel in-flight MCP streaming tools and bound buffered requests

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1072,13 +1072,28 @@ frame to the wire with no coalescing, so a `notifications/*` message reaches the
 
 ### Progress streaming
 
-When a token-bearing `tools/call` streams (the client accepted SSE), the tool runs off the connection
-process so the loop is free to push its progress as it arrives. In **stateless** mode a worker
-process runs the tool; in **session** mode the session process runs it (state still threads back).
-Either way the tool emits via the `Ctx`
-handed to `handle_tool/4` -- `arizona_mcp:progress/2,3` relays each `notifications/progress` to the
-POST's loop, which frames and pushes it; the final result is the last frame, then the loop stops.
-The context is inert (a no-op) for a non-streaming call, so a tool can always call `progress/2,3`.
+When a token-bearing `tools/call` streams (the client accepted SSE), the tool runs in a worker
+process so the connection loop is free to push its progress as it arrives. In **stateless** mode the
+loop spawns the worker; in **session** mode the session spawns it (so the session stays responsive to
+a cancel) and the worker reports its threaded-back state on completion. Either way the tool emits via
+the `Ctx` handed to `handle_tool/4` -- `arizona_mcp:progress/2,3` relays each `notifications/progress`
+to the POST's loop, which frames and pushes it; the final result is the last frame, then the loop
+stops. The context is inert (a no-op) for a non-streaming call, so a tool can always call
+`progress/2,3`.
+
+### Cancellation and timeouts
+
+A buffered request waits on its session for `request_timeout_ms` (default 60s); past it the client
+gets a -32603 (the session may still be finishing the call). A streaming `tools/call` is cancellable
+because it runs in a tracked worker: a `notifications/cancelled {requestId}` (routed to the session,
+which kills the worker and tells the POST loop to stop) or a client disconnect (the loop kills the
+stateless worker, or asks the session to cancel) stops it. The session monitors each worker, so an
+unexpected worker death answers the loop with -32603 rather than hanging it.
+
+An in-flight streaming request holds its session alive the way an attached channel does -- the idle
+TTL is suspended while any worker runs, so a long stream is never reaped mid-run, and re-arms once
+the last one finishes or is cancelled. Conversely, tearing the session down (DELETE, idle TTL, or
+shutdown) kills any still-running worker, so a blocking tool cannot orphan and run forever.
 
 ### Stateless vs session mode
 

--- a/src/arizona_mcp.erl
+++ b/src/arizona_mcp.erl
@@ -143,11 +143,15 @@ them at 100.
 Session mode starts one process per `initialize`, and the count is
 unbounded -- a public deployment should gate the endpoint with the `auth`
 hook and a reverse-proxy rate limit. An abandoned session is reaped after
-its idle TTL (`session_ttl_ms`, default 5 minutes). A tool that never
-returns holds its session and its connection until it does (a request waits
-on the tool indefinitely). The optional `terminate/2` callback runs when a
-session ends (DELETE, idle TTL, or shutdown); it does **not** run in
-stateless mode, which has no session to end.
+its idle TTL (`session_ttl_ms`, default 5 minutes). A **buffered** request is
+bounded by `request_timeout_ms` (default 60s): a slower tool frees the client
+with a -32603, though the session keeps running it. A **streaming** `tools/call`
+runs in a worker, so it is cancellable: a `notifications/cancelled {requestId}`
+or a client disconnect kills the tool. An in-flight streaming worker holds its
+session alive (it is not idle-reaped mid-run) and is killed if the session is
+torn down. The optional `terminate/2` callback runs when a session ends (DELETE,
+idle TTL, or shutdown); it does **not** run in stateless mode, which has no
+session to end.
 
 Clients that use `fetch` (browsers and the official MCP SDK) refuse to
 connect to ports on the WHATWG Fetch "bad ports" blocklist, so mount the

--- a/src/arizona_mcp_handler.erl
+++ b/src/arizona_mcp_handler.erl
@@ -92,6 +92,11 @@ protocol contract holds even when a tool raises.
 %% operational logs flow but `debug` is suppressed until requested.
 -define(DEFAULT_LOG_LEVEL, info).
 
+%% How long a buffered (non-streaming) request waits on its session before the
+%% client is freed with a timeout, overridable via the route's
+%% `request_timeout_ms` opt. Generous, since a tool may legitimately run a while.
+-define(DEFAULT_REQUEST_TIMEOUT_MS, 60000).
+
 %% --------------------------------------------------------------------
 %% API Functions
 %% --------------------------------------------------------------------
@@ -174,7 +179,7 @@ Roadrunner loop `handle_info/3` callback for the two SSE loops:
 -spec handle_info(Info, Push, State) -> {ok, State} | {stop, State} when
     Info :: term(),
     Push :: roadrunner_handler:push_fun(),
-    State :: #{session := pid()} | #{mcp_post_stream := true}.
+    State :: #{session := pid()} | #{mcp_post_stream := true, _ => term()}.
 handle_info({mcp_event, Frame}, Push, State) ->
     _ = Push(Frame),
     {ok, State};
@@ -184,13 +189,29 @@ handle_info({mcp_progress, Notification}, Push, State) ->
 handle_info({mcp_result, Object}, Push, State) ->
     _ = Push(message_frame(Object)),
     {stop, State};
+handle_info(mcp_cancelled, _Push, State) ->
+    %% The session cancelled this streaming request; close the stream, no result.
+    {stop, State};
+%% The streaming-POST disconnect is checked first: its state may also carry
+%% `session`, which would otherwise match the GET-channel clause below.
+handle_info({roadrunner_disconnect, _Reason}, _Push, #{mcp_post_stream := true} = State) ->
+    cancel_stream(State),
+    {stop, State};
 handle_info({roadrunner_disconnect, _Reason}, _Push, #{session := SessionPid} = State) ->
     ok = arizona_mcp_session:detach_channel(SessionPid, self()),
     {stop, State};
-handle_info({roadrunner_disconnect, _Reason}, _Push, #{mcp_post_stream := true} = State) ->
-    {stop, State};
 handle_info(_Info, _Push, State) ->
     {ok, State}.
+
+%% On client disconnect, stop the running streaming tool: kill the stateless
+%% worker, or ask the session to cancel the request it tracks.
+cancel_stream(#{worker := Worker}) ->
+    true = exit(Worker, kill),
+    ok;
+cancel_stream(#{session := SessionPid, id := Id}) ->
+    arizona_mcp_session:cancel(SessionPid, Id);
+cancel_stream(_State) ->
+    ok.
 
 %% A JSON-RPC message (a progress notification or the final result) framed as a
 %% single SSE `message` event. The streaming POST is request-scoped, so -- unlike
@@ -364,10 +385,34 @@ valid_page_size(N) when is_integer(N), N >= 1 ->
 %% other request is routed to the session named by `Mcp-Session-Id`.
 reply_session(#{method := Method, params := Params, id := Id} = Request, Req, Opts) ->
     case Id of
-        undefined -> roadrunner_resp:status(202);
-        _ when Method =:= ~"initialize" -> session_initialize(Params, Id, Opts);
-        _ -> session_request(Method, Params, Id, Request, Req)
+        undefined ->
+            session_notification(Method, Params, Req),
+            roadrunner_resp:status(202);
+        _ when Method =:= ~"initialize" ->
+            session_initialize(Params, Id, Opts);
+        _ ->
+            session_request(Method, Params, Id, Request, Req, request_timeout(Opts))
     end.
+
+%% A `notifications/cancelled {requestId}` cancels the in-flight streaming
+%% request on the addressed session; any other notification is accepted with no
+%% action. (Stateless mode has no session to route a cancel to.)
+session_notification(~"notifications/cancelled", #{~"requestId" := RequestId}, Req) ->
+    case roadrunner_req:header(~"mcp-session-id", Req) of
+        undefined ->
+            ok;
+        SessionId ->
+            case arizona_mcp_session_registry:lookup(SessionId) of
+                {ok, Pid} -> arizona_mcp_session:cancel(Pid, RequestId);
+                error -> ok
+            end
+    end;
+session_notification(_Method, _Params, _Req) ->
+    ok.
+
+%% The configured buffered-request timeout.
+request_timeout(Opts) ->
+    maps:get(request_timeout_ms, Opts, ?DEFAULT_REQUEST_TIMEOUT_MS).
 
 session_initialize(Params, Id, #{handler := Mod} = Opts) ->
     SessionId = generate_session_id(),
@@ -392,7 +437,7 @@ session_initialize(Params, Id, #{handler := Mod} = Opts) ->
             json(arizona_jsonrpc:error(Id, -32603, ~"Internal error"))
     end.
 
-session_request(Method, Params, Id, Request, Req) ->
+session_request(Method, Params, Id, Request, Req, Timeout) ->
     case roadrunner_req:header(~"mcp-session-id", Req) of
         undefined ->
             json(arizona_jsonrpc:error(reply_id(Request), -32600, ~"Missing Mcp-Session-Id"));
@@ -400,7 +445,7 @@ session_request(Method, Params, Id, Request, Req) ->
             with_session(
                 SessionId,
                 fun(Pid) ->
-                    {_Tag, Object} = arizona_mcp_session:dispatch(Pid, Method, Params, Id),
+                    {_Tag, Object} = arizona_mcp_session:dispatch(Pid, Method, Params, Id, Timeout),
                     json(Object)
                 end,
                 fun() -> unknown_session(Id) end
@@ -490,10 +535,11 @@ serve_streaming(#{name := Name, args := Args, token := Token, id := Id}, Req, Op
             %% page_size is irrelevant to a tools/call -- the default suffices.
             {_ServerInfo, Session} = open_session(Mod, #{}, ?DEFAULT_PAGE_SIZE),
             Ctx = #{token => Token, to => ConnPid},
-            _Worker = spawn(fun() ->
+            Worker = spawn(fun() ->
                 _Session1 = run_streaming_tool(Session, Name, Args, Id, Ctx, ConnPid)
             end),
-            stream_loop();
+            %% Track the worker so a client disconnect kills it.
+            stream_loop(#{mcp_post_stream => true, worker => Worker});
         true ->
             case roadrunner_req:header(~"mcp-session-id", Req) of
                 undefined ->
@@ -502,10 +548,13 @@ serve_streaming(#{name := Name, args := Args, token := Token, id := Id}, Req, Op
                     with_session(
                         SessionId,
                         fun(Pid) ->
-                            ok = arizona_mcp_session:run_streaming_tool(
+                            ok = arizona_mcp_session:start_streaming_tool(
                                 Pid, Name, Args, Id, Token, ConnPid
                             ),
-                            stream_loop()
+                            %% Track the session + request id so a disconnect
+                            %% cancels it (a `notifications/cancelled` arrives on
+                            %% its own POST instead).
+                            stream_loop(#{mcp_post_stream => true, session => Pid, id => Id})
                         end,
                         fun() -> unknown_session(Id) end
                     )
@@ -513,9 +562,10 @@ serve_streaming(#{name := Name, args := Args, token := Token, id := Id}, Req, Op
     end.
 
 %% The streaming-POST loop: a request-scoped stream (no resumability), tagged so
-%% `handle_info/3` distinguishes it from the GET channel.
-stream_loop() ->
-    {loop, 200, sse_headers(), #{mcp_post_stream => true}}.
+%% `handle_info/3` distinguishes it from the GET channel. The state also carries
+%% what to cancel on disconnect.
+stream_loop(LoopState) ->
+    {loop, 200, sse_headers(), LoopState}.
 
 -doc """
 Run a streaming `tools/call` against `Session`, relaying the result (and, via

--- a/src/arizona_mcp_session.erl
+++ b/src/arizona_mcp_session.erl
@@ -24,7 +24,9 @@ sends `DELETE`) does not leak; every served request resets it.
 
 -export([start_link/3]).
 -export([dispatch/4]).
--export([run_streaming_tool/6]).
+-export([dispatch/5]).
+-export([start_streaming_tool/6]).
+-export([cancel/2]).
 -export([attach_channel/3]).
 -export([detach_channel/2]).
 -export([notify/3]).
@@ -37,6 +39,9 @@ sends `DELETE`) does not leak; every served request resets it.
 
 %% Referenced only by `arizona_mcp_sup`'s child spec (an MFA tuple, not a call).
 -ignore_xref([start_link/3]).
+
+%% A test-only convenience wrapper (the release dispatches via `dispatch/5`).
+-ignore_xref([dispatch/4]).
 
 %% --------------------------------------------------------------------
 %% gen_server callback exports
@@ -68,7 +73,10 @@ sends `DELETE`) does not leak; every served request resets it.
     next_event_id :: pos_integer(),
     buffer :: queue:queue({pos_integer(), iodata()}),
     buffer_len :: non_neg_integer(),
-    buffer_max :: pos_integer()
+    buffer_max :: pos_integer(),
+    %% In-flight streaming `tools/call` workers, by their request id, so a
+    %% `notifications/cancelled` (or a client disconnect) can kill one.
+    streams :: #{arizona_jsonrpc:id() => {pid(), reference(), pid()}}
 }).
 
 -type state() :: #state{}.
@@ -103,26 +111,51 @@ through the session process and resets the idle timer.
     Params :: map(),
     Id :: arizona_jsonrpc:id().
 dispatch(Pid, Method, Params, Id) ->
-    %% `infinity`: a tool may legitimately run long, and the calling roadrunner
-    %% connection is already dedicated to this one request. (Bounding this and
-    %% cancelling on client disconnect is a later-phase hardening.)
-    gen_server:call(Pid, {dispatch, Method, Params, Id}, infinity).
+    dispatch(Pid, Method, Params, Id, infinity).
+
+-spec dispatch(Pid, Method, Params, Id, Timeout) -> {reply, map()} | {error, map()} when
+    Pid :: pid(),
+    Method :: binary(),
+    Params :: map(),
+    Id :: arizona_jsonrpc:id(),
+    Timeout :: timeout().
+dispatch(Pid, Method, Params, Id, Timeout) ->
+    %% Bounded by the route's `request_timeout_ms`: a buffered tool that runs
+    %% past it frees the client with a -32603 (the session may still be finishing
+    %% the call -- a tool that never returns still holds its session).
+    try
+        gen_server:call(Pid, {dispatch, Method, Params, Id}, Timeout)
+    catch
+        exit:{timeout, _} ->
+            {error, arizona_jsonrpc:error(Id, -32603, ~"Request timed out")}
+    end.
 
 -doc """
-Run a streaming `tools/call` against the session's state, relaying the result
-and any `notifications/progress` to `ConnPid` (the POST's loop process). Async
-(a cast) so `ConnPid` is free to push the relayed frames while the tool runs;
-the tool's returned state threads back into the session.
+Start a streaming `tools/call` in a worker process tracked by `Id`, relaying the
+result and any `notifications/progress` to `ConnPid` (the POST's loop process).
+The worker frees the session to handle a `cancel/2` for the same `Id`; the
+tool's returned state threads back when it completes.
 """.
--spec run_streaming_tool(Pid, Name, Args, Id, Token, ConnPid) -> ok when
+-spec start_streaming_tool(Pid, Name, Args, Id, Token, ConnPid) -> ok when
     Pid :: pid(),
     Name :: binary(),
     Args :: map(),
     Id :: arizona_jsonrpc:id(),
     Token :: binary() | integer(),
     ConnPid :: pid().
-run_streaming_tool(Pid, Name, Args, Id, Token, ConnPid) ->
-    gen_server:cast(Pid, {run_streaming_tool, Name, Args, Id, Token, ConnPid}).
+start_streaming_tool(Pid, Name, Args, Id, Token, ConnPid) ->
+    gen_server:cast(Pid, {start_streaming_tool, Name, Args, Id, Token, ConnPid}).
+
+-doc """
+Cancel an in-flight streaming `tools/call` by its request `Id` (a
+`notifications/cancelled`, or a client disconnect): kills the worker and tells
+its POST loop to stop. A no-op for an unknown or already-finished id.
+""".
+-spec cancel(Pid, Id) -> ok when
+    Pid :: pid(),
+    Id :: arizona_jsonrpc:id().
+cancel(Pid, Id) ->
+    gen_server:cast(Pid, {cancel, Id}).
 
 -doc """
 Attach a server-to-client SSE channel (a roadrunner loop process) to the
@@ -195,7 +228,8 @@ init({SessionId, Session, #{ttl_ms := TtlMs, buffer_max := BufferMax}}) ->
         next_event_id = 1,
         buffer = queue:new(),
         buffer_len = 0,
-        buffer_max = BufferMax
+        buffer_max = BufferMax,
+        streams = #{}
     },
     {ok, refresh_ttl(State)}.
 
@@ -239,15 +273,35 @@ handle_cast({log, Severity, Level, Data}, #state{session = Session} = State) ->
             {noreply, State}
     end;
 handle_cast(
-    {run_streaming_tool, Name, Args, Id, Token, ConnPid}, #state{session = Session} = State
+    {start_streaming_tool, Name, Args, Id, Token, ConnPid},
+    #state{session = Session, streams = Streams} = State
 ) ->
-    %% Run the tool here (serialized, state threads back) while `ConnPid` pushes
-    %% the relayed progress + result. The context's `to` is the POST loop, so
-    %% `arizona_mcp:progress/2,3` reaches the client's stream, not this session's
-    %% channel.
+    %% Run the tool in a monitored worker so the session stays free to handle a
+    %% cancel. The worker relays progress + result to `ConnPid` directly and
+    %% reports its threaded-back session to us on completion.
+    SessionPid = self(),
     Ctx = #{token => Token, to => ConnPid},
-    Session1 = arizona_mcp_handler:run_streaming_tool(Session, Name, Args, Id, Ctx, ConnPid),
-    {noreply, refresh_ttl(State#state{session = Session1})};
+    WorkerPid = spawn(fun() ->
+        Session1 = arizona_mcp_handler:run_streaming_tool(Session, Name, Args, Id, Ctx, ConnPid),
+        SessionPid ! {streaming_done, Id, Session1}
+    end),
+    MonRef = erlang:monitor(process, WorkerPid),
+    Streams1 = Streams#{Id => {WorkerPid, MonRef, ConnPid}},
+    {noreply, refresh_ttl(State#state{streams = Streams1})};
+handle_cast({cancel, Id}, #state{streams = Streams} = State) ->
+    case Streams of
+        #{Id := {WorkerPid, MonRef, ConnPid}} ->
+            true = erlang:demonitor(MonRef, [flush]),
+            true = exit(WorkerPid, kill),
+            %% Tell the POST loop to stop -- the spec says a cancelled request
+            %% gets no response.
+            ConnPid ! mcp_cancelled,
+            %% Dropping the last stream re-arms the idle timer (the stream was
+            %% holding the session alive).
+            {noreply, refresh_ttl(State#state{streams = maps:remove(Id, Streams)})};
+        _ ->
+            {noreply, State}
+    end;
 handle_cast(_Msg, State) ->
     {noreply, State}.
 
@@ -260,13 +314,41 @@ handle_info(
 ) ->
     %% The channel's connection died without a clean detach.
     {noreply, do_detach(State)};
+handle_info({streaming_done, Id, Session1}, #state{streams = Streams} = State) ->
+    %% The worker finished (it already sent the result to the POST loop). Store
+    %% its threaded-back session and drop the tracking. Ignored if the request
+    %% was cancelled just before completion.
+    case Streams of
+        #{Id := {_WorkerPid, MonRef, _ConnPid}} ->
+            true = erlang:demonitor(MonRef, [flush]),
+            State1 = State#state{session = Session1, streams = maps:remove(Id, Streams)},
+            {noreply, refresh_ttl(State1)};
+        _ ->
+            {noreply, State}
+    end;
+handle_info({'DOWN', MonRef, process, _WorkerPid, _Reason}, #state{streams = Streams} = State) ->
+    %% A streaming worker died without reporting done -- a crash. Answer the POST
+    %% loop with -32603 and drop the tracking.
+    case stream_by_mon(MonRef, Streams) of
+        {Id, ConnPid} ->
+            ConnPid ! {mcp_result, arizona_jsonrpc:error(Id, -32603, ~"Internal error")},
+            {noreply, refresh_ttl(State#state{streams = maps:remove(Id, Streams)})};
+        error ->
+            {noreply, State}
+    end;
 handle_info(session_ttl_expired, State) ->
     {stop, normal, State};
 handle_info(_Info, State) ->
     {noreply, State}.
 
 -spec terminate(term(), state()) -> ok.
-terminate(Reason, #state{id = SessionId, session = #{mod := Mod, state := HandlerState}}) ->
+terminate(
+    Reason,
+    #state{id = SessionId, session = #{mod := Mod, state := HandlerState}, streams = Streams}
+) ->
+    %% Kill any in-flight streaming workers so none outlive the session (a
+    %% blocking tool would otherwise run forever, orphaned).
+    maps:foreach(fun(_Id, {WorkerPid, _MonRef, _ConnPid}) -> exit(WorkerPid, kill) end, Streams),
     %% Run the app's optional cleanup hook, then drop the registry row. (pg
     %% auto-removes the session from its subscribed channels on exit.)
     erlang:function_exported(Mod, terminate, 2) andalso Mod:terminate(Reason, HandlerState),
@@ -288,6 +370,13 @@ safe_handle_method(Method, Params, Id, Session) ->
         Class:Reason:Stacktrace ->
             logger:error("MCP session dispatch crashed: ~ts:~tp~n~tp", [Class, Reason, Stacktrace]),
             {{error, arizona_jsonrpc:error(Id, -32603, ~"Internal error")}, Session}
+    end.
+
+%% Find the streaming request (its id and POST loop) whose worker monitor died.
+stream_by_mon(MonRef, Streams) ->
+    case [{Id, Conn} || {Id, {_W, Mon, Conn}} <:- maps:to_list(Streams), Mon =:= MonRef] of
+        [{Id, Conn} | _] -> {Id, Conn};
+        [] -> error
     end.
 
 %% Subscribe to the handler's declared pubsub channels (if it exports
@@ -378,18 +467,23 @@ demonitor_channel(Mon) ->
     true = erlang:demonitor(Mon, [flush]),
     ok.
 
-%% A session with a live SSE channel is kept alive by it; a connectionless
-%% session counts down to teardown. Cancel any pending timer, then arm a
-%% fresh one only when no channel is attached.
-refresh_ttl(#state{ttl_timer = Old, ttl_ms = TtlMs, channel = Channel} = State) ->
+%% A session with a live SSE channel or an in-flight streaming request is kept
+%% alive by it; an otherwise connectionless session counts down to teardown.
+%% Cancel any pending timer, then arm a fresh one only when nothing holds it
+%% (so a streaming tool is never idle-reaped mid-run).
+refresh_ttl(#state{ttl_timer = Old, ttl_ms = TtlMs} = State) ->
     cancel_ttl(Old),
-    case Channel of
-        undefined ->
+    case held_open(State) of
+        true ->
+            State#state{ttl_timer = undefined};
+        false ->
             Ref = erlang:send_after(TtlMs, self(), session_ttl_expired),
-            State#state{ttl_timer = Ref};
-        _ ->
-            State#state{ttl_timer = undefined}
+            State#state{ttl_timer = Ref}
     end.
+
+%% An attached channel or any in-flight streaming worker holds the session open.
+held_open(#state{channel = Channel, streams = Streams}) ->
+    Channel =/= undefined orelse Streams =/= #{}.
 
 cancel_ttl(undefined) ->
     ok;

--- a/test/arizona_mcp_SUITE.erl
+++ b/test/arizona_mcp_SUITE.erl
@@ -169,7 +169,17 @@ dispatch_ping(_Config) ->
 dispatch_tools_list(_Config) ->
     {reply, #{~"result" := #{~"tools" := Tools}}} = dispatch(~"tools/list", #{}, 3),
     ?assertEqual(
-        [~"add", ~"boom", ~"crash", ~"echo", ~"count", ~"progress"],
+        [
+            ~"add",
+            ~"boom",
+            ~"crash",
+            ~"echo",
+            ~"count",
+            ~"progress",
+            ~"block",
+            ~"sleep",
+            ~"selfkill"
+        ],
         [maps:get(~"name", T) || T <- Tools]
     ),
     [Add | _] = Tools,
@@ -457,11 +467,24 @@ parse_log_levels(_Config) ->
 %% --------------------------------------------------------------------
 
 pagination_tools_walk(_Config) ->
-    %% 6 tools at page size 2 -> 3 pages; following the cursor chain yields all
-    %% 6 names in order. The page count proves it actually paginated.
+    %% 9 tools at page size 2 -> 5 pages; following the cursor chain yields all
+    %% 9 names in order. The page count proves it actually paginated.
     {Names, Pages} = walk(~"tools/list", ~"tools", 2),
-    ?assertEqual([~"add", ~"boom", ~"crash", ~"echo", ~"count", ~"progress"], Names),
-    ?assertEqual(3, Pages).
+    ?assertEqual(
+        [
+            ~"add",
+            ~"boom",
+            ~"crash",
+            ~"echo",
+            ~"count",
+            ~"progress",
+            ~"block",
+            ~"sleep",
+            ~"selfkill"
+        ],
+        Names
+    ),
+    ?assertEqual(5, Pages).
 
 pagination_resources_walk(_Config) ->
     %% The capability-gated list path paginates identically.
@@ -472,7 +495,7 @@ pagination_resources_walk(_Config) ->
 pagination_no_cursor_when_list_fits(_Config) ->
     %% A page larger than the list returns everything and omits nextCursor.
     {reply, #{~"result" := Result}} = dispatch_paged(~"tools/list", #{}, 1, 100),
-    ?assertEqual(6, length(maps:get(~"tools", Result))),
+    ?assertEqual(9, length(maps:get(~"tools", Result))),
     ?assertNot(maps:is_key(~"nextCursor", Result)).
 
 pagination_past_end_cursor(_Config) ->

--- a/test/arizona_mcp_e2e_SUITE.erl
+++ b/test/arizona_mcp_e2e_SUITE.erl
@@ -9,6 +9,7 @@
     post_tools_call/1,
     post_streaming_progress/1,
     post_progress_without_accept_buffered/1,
+    stateless_disconnect_kills_worker/1,
     post_tools_list_paginates/1,
     post_resources_read/1,
     post_resources_templates_list/1,
@@ -31,6 +32,8 @@
     session_survives_channel_disconnect/1,
     session_resumes_with_last_event_id/1,
     session_streaming_progress/1,
+    session_cancel_stops_stream/1,
+    session_disconnect_cancels_stream/1,
     auth_missing_token_401/1,
     auth_valid_token_ok/1,
     session_init_crash_internal_error/1
@@ -46,6 +49,7 @@ all() ->
         post_tools_call,
         post_streaming_progress,
         post_progress_without_accept_buffered,
+        stateless_disconnect_kills_worker,
         post_tools_list_paginates,
         post_resources_read,
         post_resources_templates_list,
@@ -68,6 +72,8 @@ all() ->
         session_survives_channel_disconnect,
         session_resumes_with_last_event_id,
         session_streaming_progress,
+        session_cancel_stops_stream,
+        session_disconnect_cancels_stream,
         auth_missing_token_401,
         auth_valid_token_ok,
         session_init_crash_internal_error
@@ -198,6 +204,26 @@ post_progress_without_accept_buffered(Config) ->
         #{~"content" => [#{~"type" => ~"text", ~"text" => ~"done"}], ~"isError" => false},
         Result
     ).
+
+stateless_disconnect_kills_worker(Config) ->
+    %% A stateless streaming tool that blocks; dropping the connection kills its
+    %% worker. The server stays up to serve the next request.
+    Body =
+        ~"""
+    {"jsonrpc":"2.0","id":20,"method":"tools/call",
+     "params":{"name":"block","arguments":{},"_meta":{"progressToken":"t"}}}
+    """,
+    Sock = stream_post(Config, "/mcp", [], Body),
+    _Head = recv_until(Sock, ~"\r\n\r\n", 5000),
+    gen_tcp:close(Sock),
+    %% The server survived; a fresh request still works.
+    Ping =
+        ~"""
+    {"jsonrpc":"2.0","id":21,"method":"ping"}
+    """,
+    Resp = post(Config, "/mcp", [], Ping),
+    ?assertEqual(200, status_code(Resp)),
+    ?assertMatch(#{~"result" := #{}}, body_json(Resp)).
 
 post_tools_list_paginates(Config) ->
     %% On the page_size=2 route, the first tools/list page carries 2 tools and a
@@ -457,6 +483,47 @@ session_streaming_progress(Config) ->
     ?assertNotEqual(nomatch, binary:match(Data, ~"\"progressToken\":42")),
     ?assertNotEqual(nomatch, binary:match(Data, ~"\"done\"")).
 
+session_cancel_stops_stream(Config) ->
+    SessionId = open_session(Config),
+    %% Open a blocking streaming tool, then cancel it by request id on another
+    %% connection. The streaming connection then closes (the loop stopped).
+    Body =
+        ~"""
+    {"jsonrpc":"2.0","id":18,"method":"tools/call",
+     "params":{"name":"block","arguments":{},"_meta":{"progressToken":"t"}}}
+    """,
+    Sock = stream_post(Config, "/mcp-session", session_header(SessionId), Body),
+    Head = recv_until(Sock, ~"\r\n\r\n", 5000),
+    ?assertNotEqual(nomatch, binary:match(Head, ~"200 OK")),
+    Cancel =
+        ~"""
+    {"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":18}}
+    """,
+    CancelResp = post(Config, "/mcp-session", session_header(SessionId), Cancel),
+    ?assertEqual(202, status_code(CancelResp)),
+    ?assertEqual(closed, wait_closed(Sock, 5000)),
+    gen_tcp:close(Sock).
+
+session_disconnect_cancels_stream(Config) ->
+    SessionId = open_session(Config),
+    %% Dropping a session's streaming connection cancels the worker; the session
+    %% itself survives and keeps serving.
+    Body =
+        ~"""
+    {"jsonrpc":"2.0","id":19,"method":"tools/call",
+     "params":{"name":"block","arguments":{},"_meta":{"progressToken":"t"}}}
+    """,
+    Sock = stream_post(Config, "/mcp-session", session_header(SessionId), Body),
+    _Head = recv_until(Sock, ~"\r\n\r\n", 5000),
+    gen_tcp:close(Sock),
+    Ping =
+        ~"""
+    {"jsonrpc":"2.0","id":22,"method":"ping"}
+    """,
+    Resp = post(Config, "/mcp-session", session_header(SessionId), Ping),
+    ?assertEqual(200, status_code(Resp)),
+    ?assertMatch(#{~"result" := #{}}, body_json(Resp)).
+
 %% --------------------------------------------------------------------
 %% Auth-gated tests (/mcp-auth, auth => bearer hook)
 %% --------------------------------------------------------------------
@@ -520,7 +587,8 @@ send_channel_get(Config, SessionId, ExtraHeaders) ->
 %% Send a POST and read its streamed (SSE) response until `Needle` appears. The
 %% response has no Content-Length (it is chunked), so the buffered `recv_response`
 %% does not apply.
-post_stream_until(Config, Path, ExtraHeaders, Body, Needle) ->
+%% Send a streaming POST (with the SSE Accept header) and return the open socket.
+stream_post(Config, Path, ExtraHeaders, Body) ->
     Port = ?config(port, Config),
     {ok, Sock} = gen_tcp:connect("localhost", Port, [binary, {active, false}]),
     Req = [
@@ -541,6 +609,18 @@ post_stream_until(Config, Path, ExtraHeaders, Body, Needle) ->
         Body
     ],
     ok = gen_tcp:send(Sock, Req),
+    Sock.
+
+%% Read until the peer closes the connection (or `open` if it stays up).
+wait_closed(Sock, Timeout) ->
+    case gen_tcp:recv(Sock, 0, Timeout) of
+        {error, closed} -> closed;
+        {error, timeout} -> open;
+        {ok, _Chunk} -> wait_closed(Sock, Timeout)
+    end.
+
+post_stream_until(Config, Path, ExtraHeaders, Body, Needle) ->
+    Sock = stream_post(Config, Path, ExtraHeaders, Body),
     Data = recv_until(Sock, Needle, 5000),
     gen_tcp:close(Sock),
     Data.

--- a/test/arizona_mcp_session_SUITE.erl
+++ b/test/arizona_mcp_session_SUITE.erl
@@ -23,6 +23,12 @@
     resource_unsubscribe_without_subscribe/1,
     log_filtered_by_default_level/1,
     log_respects_set_level/1,
+    cancel_stops_streaming_tool/1,
+    cancel_unknown_id_is_noop/1,
+    streaming_worker_crash_errors_conn/1,
+    dispatch_bounded_timeout/1,
+    streaming_tool_holds_session/1,
+    terminate_kills_streaming_worker/1,
     notify_without_channel_is_noop/1,
     notify_unknown_session_is_noop/1,
     log_unknown_session_is_noop/1,
@@ -57,6 +63,12 @@ all() ->
         resource_unsubscribe_without_subscribe,
         log_filtered_by_default_level,
         log_respects_set_level,
+        cancel_stops_streaming_tool,
+        cancel_unknown_id_is_noop,
+        streaming_worker_crash_errors_conn,
+        dispatch_bounded_timeout,
+        streaming_tool_holds_session,
+        terminate_kills_streaming_worker,
         notify_without_channel_is_noop,
         notify_unknown_session_is_noop,
         log_unknown_session_is_noop,
@@ -279,6 +291,83 @@ log_respects_set_level(_Config) ->
     after 5000 -> ct:fail(no_log)
     end.
 
+cancel_stops_streaming_tool(_Config) ->
+    {_Id, Pid} = start(60000),
+    ConnPid = self(),
+    %% Start a blocking streaming tool in a worker, then cancel it by id. The
+    %% casts are ordered, so the worker is registered before the cancel.
+    ok = arizona_mcp_session:start_streaming_tool(Pid, ~"block", #{}, 7, ~"tok", ConnPid),
+    ok = arizona_mcp_session:cancel(Pid, 7),
+    %% The POST loop (us) is told to stop and gets no result.
+    receive
+        mcp_cancelled -> ok
+    after 5000 -> ct:fail(no_cancel)
+    end,
+    no_result(),
+    %% The session survived the cancel and still serves.
+    ?assertMatch({reply, _}, arizona_mcp_session:dispatch(Pid, ~"ping", #{}, 8)).
+
+cancel_unknown_id_is_noop(_Config) ->
+    {_Id, Pid} = start(60000),
+    %% A cancel that races past a request's completion (no in-flight stream for
+    %% that id) is a silent no-op; the session keeps serving.
+    ok = arizona_mcp_session:cancel(Pid, 999),
+    ?assertMatch({reply, _}, arizona_mcp_session:dispatch(Pid, ~"ping", #{}, 1)).
+
+streaming_worker_crash_errors_conn(_Config) ->
+    {_Id, Pid} = start(60000),
+    ConnPid = self(),
+    %% A streaming worker that dies without reporting done makes the session
+    %% answer the POST loop with -32603, rather than leaving it hanging.
+    ok = arizona_mcp_session:start_streaming_tool(Pid, ~"selfkill", #{}, 7, ~"tok", ConnPid),
+    receive
+        {mcp_result, Object} ->
+            ?assertMatch(#{~"error" := #{~"code" := -32603}}, Object)
+    after 5000 -> ct:fail(no_error_result)
+    end.
+
+dispatch_bounded_timeout(_Config) ->
+    {_Id, Pid} = start(60000),
+    %% A buffered tool slower than the timeout frees the client with -32603 (the
+    %% session keeps running it; the sleep tool finishes, so nothing leaks).
+    Result = arizona_mcp_session:dispatch(Pid, ~"tools/call", #{~"name" => ~"sleep"}, 9, 50),
+    ?assertMatch({error, #{~"error" := #{~"code" := -32603}}}, Result).
+
+streaming_tool_holds_session(_Config) ->
+    {_Id, Pid} = start(100),
+    ConnPid = self(),
+    %% A blocking streaming tool holds the session up past what the 100ms idle
+    %% TTL would otherwise allow -- an in-flight stream is not idle-reaped.
+    ok = arizona_mcp_session:start_streaming_tool(Pid, ~"block", #{}, 7, ~"tok", ConnPid),
+    timer:sleep(250),
+    ?assertMatch({reply, _}, arizona_mcp_session:dispatch(Pid, ~"ping", #{}, 8)),
+    %% Cancelling the last stream re-arms the idle timer, so the session is reaped.
+    Ref = erlang:monitor(process, Pid),
+    ok = arizona_mcp_session:cancel(Pid, 7),
+    receive
+        {'DOWN', Ref, process, Pid, normal} -> ok
+    after 5000 -> ct:fail(ttl_did_not_rearm)
+    end.
+
+terminate_kills_streaming_worker(_Config) ->
+    {_Id, Pid} = start(60000),
+    %% Stopping a session with an in-flight streaming worker kills the worker, so
+    %% a blocking tool does not orphan and run forever.
+    ok = arizona_mcp_session:start_streaming_tool(
+        Pid, ~"block", #{watch => self()}, 7, ~"tok", self()
+    ),
+    Worker =
+        receive
+            {block_started, W} -> W
+        after 5000 -> ct:fail(worker_did_not_start)
+        end,
+    WRef = erlang:monitor(process, Worker),
+    ok = arizona_mcp_session:stop(Pid),
+    receive
+        {'DOWN', WRef, process, Worker, killed} -> ok
+    after 5000 -> ct:fail(worker_not_killed)
+    end.
+
 notify_without_channel_is_noop(_Config) ->
     {_Id, Pid} = start(60000),
     ok = arizona_mcp_session:notify(Pid, ~"notifications/message", #{}),
@@ -381,6 +470,13 @@ terminate_calls_app(_Config) ->
 no_more_events() ->
     receive
         {mcp_event, _} -> ct:fail(unexpected_event)
+    after 100 -> ok
+    end.
+
+%% Assert no streaming result frame follows (a cancelled request gets none).
+no_result() ->
+    receive
+        {mcp_result, _} -> ct:fail(unexpected_result)
     after 100 -> ok
     end.
 

--- a/test/support/arizona_mcp_test_server.erl
+++ b/test/support/arizona_mcp_test_server.erl
@@ -64,6 +64,21 @@ tools(_State) ->
             name => ~"progress",
             description => ~"Emits two progress notifications then returns",
             input_schema => #{type => ~"object", properties => #{}}
+        },
+        #{
+            name => ~"block",
+            description => ~"Blocks forever (exercises cancellation)",
+            input_schema => #{type => ~"object", properties => #{}}
+        },
+        #{
+            name => ~"sleep",
+            description => ~"Sleeps a while (exercises the bounded timeout)",
+            input_schema => #{type => ~"object", properties => #{}}
+        },
+        #{
+            name => ~"selfkill",
+            description => ~"Kills its own process (exercises worker-death cleanup)",
+            input_schema => #{type => ~"object", properties => #{}}
         }
     ].
 
@@ -96,7 +111,28 @@ handle_tool(~"progress", _Args, Ctx, State) ->
     %% inert for a non-streaming (no progressToken) call, so these are no-ops.
     ok = arizona_mcp:progress(Ctx, 1, #{total => 2, message => ~"step 1"}),
     ok = arizona_mcp:progress(Ctx, 2, #{total => 2, message => ~"step 2"}),
-    {reply, ~"done", State}.
+    {reply, ~"done", State};
+handle_tool(~"block", Args, _Ctx, State) ->
+    %% Never returns: a streaming `block` holds its worker until cancelled. When
+    %% Args carries a `watch` pid (tests pass one directly), report the worker
+    %% pid first so the test can assert it is killed on teardown.
+    ok =
+        case Args of
+            #{watch := Watcher} ->
+                Watcher ! {block_started, self()},
+                ok;
+            _ ->
+                ok
+        end,
+    receive
+    after infinity -> {reply, ~"unreachable", State}
+    end;
+handle_tool(~"sleep", _Args, _Ctx, State) ->
+    timer:sleep(300),
+    {reply, ~"slept", State};
+handle_tool(~"selfkill", _Args, _Ctx, _State) ->
+    %% Kill the worker untrappably, so the session's worker-death cleanup runs.
+    exit(self(), kill).
 
 resources(_State) ->
     [


### PR DESCRIPTION
# Description

Streaming MCP `tools/call` requests now run in a tracked worker, so they can be cancelled by a `notifications/cancelled {requestId}` or by a client disconnect, and the session stays responsive while one runs. Buffered requests are bounded by a configurable `request_timeout_ms` (default 60s), so a slow tool frees the client with an error instead of hanging it. An in-flight streaming worker holds its session alive (it is not idle-reaped mid-run) and is killed when the session is torn down, so a blocking tool cannot orphan and run forever.

A buffered (non-streaming) tool still runs inline, so a slow one blocks its session until it finishes; making that path non-blocking is a planned follow-up.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
