### PR TITLE
Run MCP session requests in workers so a slow tool can't block the session

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1081,19 +1081,29 @@ to the POST's loop, which frames and pushes it; the final result is the last fra
 stops. The context is inert (a no-op) for a non-streaming call, so a tool can always call
 `progress/2,3`.
 
-### Cancellation and timeouts
+### Dispatch, cancellation, and timeouts
 
-A buffered request waits on its session for `request_timeout_ms` (default 60s); past it the client
-gets a -32603 (the session may still be finishing the call). A streaming `tools/call` is cancellable
-because it runs in a tracked worker: a `notifications/cancelled {requestId}` (routed to the session,
-which kills the worker and tells the POST loop to stop) or a client disconnect (the loop kills the
-stateless worker, or asks the session to cancel) stops it. The session monitors each worker, so an
-unexpected worker death answers the loop with -32603 rather than hanging it.
+Requests run in a worker process (the only exceptions are `resources/subscribe`/`unsubscribe`, which
+own a session-keyed pubsub subscription and run no app code), so the session process never blocks on
+app code -- it stays responsive to cancels, idle-reap, and server pushes even while a tool runs.
+**Buffered** (non-streaming) requests are served through a one-at-a-time queue (so their state
+threading stays serialized) and replied to asynchronously; a request that outlives
+`request_timeout_ms` (default 60s) frees the client with a -32603 while the session keeps running it.
+A **streaming** `tools/call` runs concurrently in its own worker, reading a state snapshot and
+threading nothing back -- so the serialized buffered queue is the only path that mutates session
+state, and nothing races on it.
+
+Any in-flight request is cancellable: a `notifications/cancelled {requestId}` (routed to the
+session) or a client disconnect kills the worker and frees the caller -- a buffered caller with a
+-32603, a streaming POST loop told to stop. The session monitors each worker, so an unexpected
+worker death frees the caller with a -32603 rather than hanging it.
 
 An in-flight streaming request holds its session alive the way an attached channel does -- the idle
-TTL is suspended while any worker runs, so a long stream is never reaped mid-run, and re-arms once
-the last one finishes or is cancelled. Conversely, tearing the session down (DELETE, idle TTL, or
-shutdown) kills any still-running worker, so a blocking tool cannot orphan and run forever.
+TTL is suspended while a stream runs, so a long stream is never reaped mid-run, and re-arms once it
+finishes or is cancelled. A buffered worker deliberately does *not* hold the session: the idle TTL
+stays the safety net that reaps, and so kills, a stuck buffered tool. Tearing the session down
+(DELETE, idle TTL, or shutdown) kills any still-running worker, so a blocking tool cannot orphan and
+run forever.
 
 ### Stateless vs session mode
 
@@ -1101,10 +1111,11 @@ Without `sessions => true` every request is self-contained: the handler runs `in
 dispatches, and discards the state. With `sessions => true`, `initialize` mints an `Mcp-Session-Id`
 and starts an `arizona_mcp_session` process (owned by `arizona_mcp_sup`, not linked to the
 connection, so it outlives any single request); later requests carrying that id route to the
-process via `arizona_mcp_session_registry`, which runs them one at a time against its held state. A
-stateful callback's returned state threads back into the session, so the session is genuinely
-stateful across requests; a crash answers `-32603` and leaves the prior state intact. An idle
-session is reaped after `session_ttl_ms` (default 5 minutes).
+process via `arizona_mcp_session_registry`, which runs them one at a time (each in a worker, so a
+slow tool never blocks the session) against its held state. A stateful callback's returned state
+threads back into the session, so the session is genuinely stateful across requests; a crash answers
+`-32603` and leaves the prior state intact. An idle session is reaped after `session_ttl_ms` (default
+5 minutes).
 
 ### Resumability and server push
 

--- a/src/arizona_mcp.erl
+++ b/src/arizona_mcp.erl
@@ -93,6 +93,11 @@ succeeded (`{reply, ...}`) or failed in-band (`{error, ...}`), since a
 ran-but-failed callback may have mutated state legitimately; only a *crash*
 (a `-32603`) discards it, leaving the prior state intact.
 
+One exception: a **streaming** `tools/call` (one carrying a progress
+token) runs on a state *snapshot* and does **not** thread state back, so
+concurrent streams never race on the session's state. Persist anything it
+computes via a follow-up buffered call.
+
 In **stateless** mode the transport calls `init/1` per request and discards
 the returned state, so the threaded-back state does not persist across
 requests -- every request starts from a fresh `init/1`.
@@ -143,12 +148,15 @@ them at 100.
 Session mode starts one process per `initialize`, and the count is
 unbounded -- a public deployment should gate the endpoint with the `auth`
 hook and a reverse-proxy rate limit. An abandoned session is reaped after
-its idle TTL (`session_ttl_ms`, default 5 minutes). A **buffered** request is
-bounded by `request_timeout_ms` (default 60s): a slower tool frees the client
-with a -32603, though the session keeps running it. A **streaming** `tools/call`
-runs in a worker, so it is cancellable: a `notifications/cancelled {requestId}`
-or a client disconnect kills the tool. An in-flight streaming worker holds its
-session alive (it is not idle-reaped mid-run) and is killed if the session is
+its idle TTL (`session_ttl_ms`, default 5 minutes). Every request runs in a
+worker, so app code never blocks the session process: it stays responsive to
+cancels, idle-reap, and server pushes even while a tool runs. Buffered requests
+are served one at a time (so their state threading stays serialized) and bounded
+by `request_timeout_ms` (default 60s): a slower tool frees the client with a
+-32603 while the session keeps running it. Any request is cancellable by a
+`notifications/cancelled {requestId}` or a client disconnect, which frees the
+caller and kills the worker. An in-flight streaming worker holds its session
+alive (it is not idle-reaped mid-run); every worker is killed if the session is
 torn down. The optional `terminate/2` callback runs when a session ends (DELETE,
 idle TTL, or shutdown); it does **not** run in stateless mode, which has no
 session to end.

--- a/src/arizona_mcp_handler.erl
+++ b/src/arizona_mcp_handler.erl
@@ -530,13 +530,13 @@ serve_streaming(#{name := Name, args := Args, token := Token, id := Id}, Req, Op
     case sessions_enabled(Opts) of
         false ->
             #{handler := Mod} = Opts,
-            %% Stateless: a fresh per-request session; its threaded-back state
-            %% is per-request and discarded. The worker frees the loop to push.
+            %% Stateless: a fresh per-request session; the worker frees the loop
+            %% to push, and any state it mutates is per-request and discarded.
             %% page_size is irrelevant to a tools/call -- the default suffices.
             {_ServerInfo, Session} = open_session(Mod, #{}, ?DEFAULT_PAGE_SIZE),
             Ctx = #{token => Token, to => ConnPid},
             Worker = spawn(fun() ->
-                _Session1 = run_streaming_tool(Session, Name, Args, Id, Ctx, ConnPid)
+                ok = run_streaming_tool(Session, Name, Args, Id, Ctx, ConnPid)
             end),
             %% Track the worker so a client disconnect kills it.
             stream_loop(#{mcp_post_stream => true, worker => Worker});
@@ -568,38 +568,40 @@ stream_loop(LoopState) ->
     {loop, 200, sse_headers(), LoopState}.
 
 -doc """
-Run a streaming `tools/call` against `Session`, relaying the result (and, via
-`Ctx`, any `notifications/progress`) to `ConnPid`, and return the session
-carrying the tool's threaded-back state. Shared by the stateless worker and the
-session process; exported for the latter's cross-module call.
+Run a streaming `tools/call` against a snapshot of `Session`, relaying the
+result (and, via `Ctx`, any `notifications/progress`) to `ConnPid`. Threads no
+state back -- streaming runs on a snapshot, and only the serialized buffered
+queue mutates session state. Shared by the stateless worker and the session
+process; exported for the latter's cross-module call.
 """.
--spec run_streaming_tool(Session, Name, Args, Id, Ctx, ConnPid) -> Session when
+-spec run_streaming_tool(Session, Name, Args, Id, Ctx, ConnPid) -> ok when
     Session :: session(),
     Name :: binary(),
     Args :: map(),
     Id :: arizona_jsonrpc:id(),
     Ctx :: arizona_mcp:progress_ctx(),
     ConnPid :: pid().
-run_streaming_tool(#{state := State} = Session, Name, Args, Id, Ctx, ConnPid) ->
-    %% Guard the whole run (the `tools/1` read included), since the session
-    %% process calls this in `handle_cast`: a crash must answer -32603 and leave
-    %% the prior state intact, never kill the session.
-    {Object, NewState} =
+run_streaming_tool(Session, Name, Args, Id, Ctx, ConnPid) ->
+    %% Guard the whole run (the `tools/1` read included): a crash must answer
+    %% -32603 rather than leave the POST loop hanging. The tool's returned state
+    %% is discarded (snapshot semantics).
+    Object =
         try
-            run_tool(Session, Name, Args, Id, Ctx)
+            {Obj, _NewState} = run_tool(Session, Name, Args, Id, Ctx),
+            Obj
         catch
             Class:Reason:Stacktrace ->
                 logger:error(
                     "MCP streaming tool crashed: ~ts:~tp~n~tp", [Class, Reason, Stacktrace]
                 ),
-                {arizona_jsonrpc:error(Id, -32603, ~"Internal error"), State}
+                arizona_jsonrpc:error(Id, -32603, ~"Internal error")
         end,
     ConnPid ! {mcp_result, Object},
-    Session#{state := NewState}.
+    ok.
 
 %% Validate the tool name, run it, and shape the outcome into a
-%% `{ResultObject, NewState}` pair. Unknown name -> a -32602 result with the
-%% prior state; a declared tool -> its result and threaded-back state.
+%% `{ResultObject, NewState}` pair (the streaming caller keeps only the result
+%% -- it runs on a snapshot). Unknown name -> a -32602 result.
 run_tool(#{mod := Mod, state := State}, Name, Args, Id, Ctx) ->
     case lists:member(Name, [N || #{name := N} <- Mod:tools(State)]) of
         false ->

--- a/src/arizona_mcp_session.erl
+++ b/src/arizona_mcp_session.erl
@@ -6,9 +6,9 @@ Started by `arizona_mcp_sup` when an `initialize` request opens a session,
 and **not** linked to the connection process that created it -- it is owned
 by the supervisor so it outlives any single HTTP request, which is the
 point of an MCP session. It holds the session record `arizona_mcp_handler` builds at initialize (the
-handler module, its state, and the negotiated capabilities) and serves one
-method at a time via `dispatch/4`, so a session's requests never race on its
-state.
+handler module, its state, and the negotiated capabilities) and serves its
+requests one at a time in a worker, so app code never blocks the session
+process and a session's requests never race on its state.
 
 The session registers itself in `arizona_mcp_session_registry` on start and
 removes itself on terminate. An idle timer tears the session down after a
@@ -76,11 +76,21 @@ sends `DELETE`) does not leak; every served request resets it.
     buffer_max :: pos_integer(),
     %% In-flight streaming `tools/call` workers, by their request id, so a
     %% `notifications/cancelled` (or a client disconnect) can kill one.
-    streams :: #{arizona_jsonrpc:id() => {pid(), reference(), pid()}}
+    streams :: #{arizona_jsonrpc:id() => {pid(), reference(), pid()}},
+    %% Buffered (non-streaming) dispatch runs in a worker so the session process
+    %% never blocks on app code. One worker at a time keeps the state threading
+    %% serialized; the rest wait their turn in `dispatch_q`.
+    dispatch_active :: active_dispatch() | undefined,
+    dispatch_q :: queue:queue(pending_dispatch())
 }).
 
 -type state() :: #state{}.
 -type session_opts() :: #{ttl_ms := pos_integer(), buffer_max := pos_integer()}.
+%% A queued buffered request awaiting its turn: the caller to reply to, its
+%% request id, and the method/params to run.
+-type pending_dispatch() :: {gen_server:from(), arizona_jsonrpc:id(), binary(), map()}.
+%% The running buffered worker: its pid, monitor, caller to reply, request id.
+-type active_dispatch() :: {pid(), reference(), gen_server:from(), arizona_jsonrpc:id()}.
 
 -export_type([session_opts/0]).
 
@@ -102,8 +112,10 @@ start_link(SessionId, Session, SessionOpts) ->
 
 -doc """
 Run one non-initialize MCP method against the session, returning the
-JSON-RPC outcome (`{reply, Object}` | `{error, Object}`). Serialized
-through the session process and resets the idle timer.
+JSON-RPC outcome (`{reply, Object}` | `{error, Object}`). The method runs
+in a worker (replied to asynchronously), so a slow tool never blocks the
+session process; requests are still served one at a time, so they never
+race on the session's state. Resets the idle timer.
 """.
 -spec dispatch(Pid, Method, Params, Id) -> {reply, map()} | {error, map()} when
     Pid :: pid(),
@@ -121,20 +133,24 @@ dispatch(Pid, Method, Params, Id) ->
     Timeout :: timeout().
 dispatch(Pid, Method, Params, Id, Timeout) ->
     %% Bounded by the route's `request_timeout_ms`: a buffered tool that runs
-    %% past it frees the client with a -32603 (the session may still be finishing
-    %% the call -- a tool that never returns still holds its session).
+    %% past it frees the client with a -32603 (the session stays responsive and
+    %% keeps running the call in its worker). A session that ends mid-wait (idle
+    %% reap / DELETE) frees the caller the same way rather than crashing it.
     try
         gen_server:call(Pid, {dispatch, Method, Params, Id}, Timeout)
     catch
         exit:{timeout, _} ->
-            {error, arizona_jsonrpc:error(Id, -32603, ~"Request timed out")}
+            {error, arizona_jsonrpc:error(Id, -32603, ~"Request timed out")};
+        exit:_ ->
+            {error, arizona_jsonrpc:error(Id, -32603, ~"Session ended")}
     end.
 
 -doc """
 Start a streaming `tools/call` in a worker process tracked by `Id`, relaying the
 result and any `notifications/progress` to `ConnPid` (the POST's loop process).
-The worker frees the session to handle a `cancel/2` for the same `Id`; the
-tool's returned state threads back when it completes.
+The worker reads a snapshot of the session state and does **not** thread state
+back -- only the serialized buffered queue mutates session state, so nothing
+races on it. It frees the session to handle a `cancel/2` for the same `Id`.
 """.
 -spec start_streaming_tool(Pid, Name, Args, Id, Token, ConnPid) -> ok when
     Pid :: pid(),
@@ -147,9 +163,11 @@ start_streaming_tool(Pid, Name, Args, Id, Token, ConnPid) ->
     gen_server:cast(Pid, {start_streaming_tool, Name, Args, Id, Token, ConnPid}).
 
 -doc """
-Cancel an in-flight streaming `tools/call` by its request `Id` (a
-`notifications/cancelled`, or a client disconnect): kills the worker and tells
-its POST loop to stop. A no-op for an unknown or already-finished id.
+Cancel an in-flight request by its `Id` (a `notifications/cancelled`, or a
+client disconnect). A streaming `tools/call` has its worker killed and its POST
+loop told to stop; a buffered request has its worker killed (or is dropped from
+the queue) and its caller freed with a -32603. A no-op for an unknown or
+already-finished id.
 """.
 -spec cancel(Pid, Id) -> ok when
     Pid :: pid(),
@@ -229,20 +247,36 @@ init({SessionId, Session, #{ttl_ms := TtlMs, buffer_max := BufferMax}}) ->
         buffer = queue:new(),
         buffer_len = 0,
         buffer_max = BufferMax,
-        streams = #{}
+        streams = #{},
+        dispatch_active = undefined,
+        dispatch_q = queue:new()
     },
     {ok, refresh_ttl(State)}.
 
--spec handle_call(Request, gen_server:from(), state()) -> {reply, Reply, state()} when
+-spec handle_call(Request, gen_server:from(), state()) -> Return when
     Request ::
         {dispatch, binary(), map(), arizona_jsonrpc:id()}
         | {attach_channel, pid(), binary() | undefined},
+    Return :: {noreply, state()} | {reply, Reply, state()},
     Reply :: {reply, map()} | {error, map()} | ok | {error, already_attached}.
-handle_call({dispatch, Method, Params, Id}, _From, #state{session = Session} = State) ->
-    %% A stateful callback's returned state threads back here: store the
-    %% updated session so this session's later requests see it.
-    {Outcome, Session1} = safe_handle_method(Method, Params, Id, Session),
-    {reply, Outcome, refresh_ttl(State#state{session = Session1})};
+handle_call({dispatch, Method, Params, Id}, From, State) ->
+    case session_coupled(Method) of
+        true ->
+            %% `resources/subscribe`/`unsubscribe` own a pubsub subscription
+            %% keyed to THIS process, so they must run in the session process,
+            %% not a worker. They run no app code (a pg join/leave), so running
+            %% them inline never blocks.
+            #state{session = Session} = State,
+            {Outcome, Session1} = safe_handle_method(Method, Params, Id, Session),
+            {reply, Outcome, refresh_ttl(State#state{session = Session1})};
+        false ->
+            %% Everything else runs in a worker, replied to asynchronously, so a
+            %% slow tool never blocks the session process (it stays responsive to
+            %% cancels, idle-reap, and channel pushes). One worker at a time keeps
+            %% the state threading serialized; the rest wait in the queue.
+            Q1 = queue:in({From, Id, Method, Params}, State#state.dispatch_q),
+            {noreply, refresh_ttl(start_next_dispatch(State#state{dispatch_q = Q1}))}
+    end;
 handle_call({attach_channel, ChannelPid, LastEventId}, _From, State) ->
     case channel_alive(State) of
         true ->
@@ -277,31 +311,20 @@ handle_cast(
     #state{session = Session, streams = Streams} = State
 ) ->
     %% Run the tool in a monitored worker so the session stays free to handle a
-    %% cancel. The worker relays progress + result to `ConnPid` directly and
-    %% reports its threaded-back session to us on completion.
+    %% cancel. The worker reads a snapshot of `Session`, relays progress + result
+    %% to `ConnPid`, and threads no state back (only the buffered queue mutates
+    %% session state). It signals completion so we can drop the tracking.
     SessionPid = self(),
     Ctx = #{token => Token, to => ConnPid},
     WorkerPid = spawn(fun() ->
-        Session1 = arizona_mcp_handler:run_streaming_tool(Session, Name, Args, Id, Ctx, ConnPid),
-        SessionPid ! {streaming_done, Id, Session1}
+        ok = arizona_mcp_handler:run_streaming_tool(Session, Name, Args, Id, Ctx, ConnPid),
+        SessionPid ! {streaming_done, Id}
     end),
     MonRef = erlang:monitor(process, WorkerPid),
     Streams1 = Streams#{Id => {WorkerPid, MonRef, ConnPid}},
     {noreply, refresh_ttl(State#state{streams = Streams1})};
-handle_cast({cancel, Id}, #state{streams = Streams} = State) ->
-    case Streams of
-        #{Id := {WorkerPid, MonRef, ConnPid}} ->
-            true = erlang:demonitor(MonRef, [flush]),
-            true = exit(WorkerPid, kill),
-            %% Tell the POST loop to stop -- the spec says a cancelled request
-            %% gets no response.
-            ConnPid ! mcp_cancelled,
-            %% Dropping the last stream re-arms the idle timer (the stream was
-            %% holding the session alive).
-            {noreply, refresh_ttl(State#state{streams = maps:remove(Id, Streams)})};
-        _ ->
-            {noreply, State}
-    end;
+handle_cast({cancel, Id}, State) ->
+    {noreply, cancel_request(Id, State)};
 handle_cast(_Msg, State) ->
     {noreply, State}.
 
@@ -309,20 +332,41 @@ handle_cast(_Msg, State) ->
 handle_info({arizona_mcp_notification, Method, Params}, State) ->
     {noreply, emit(Method, Params, State)};
 handle_info(
+    {dispatch_done, WorkerPid, Outcome, Session1}, #state{dispatch_active = Active} = State
+) ->
+    %% The active buffered worker finished: reply to its caller, store the
+    %% threaded-back session, and start the next queued request. A stale message
+    %% (the worker was cancelled just before completion) is ignored.
+    case Active of
+        {WorkerPid, MonRef, From, _Id} ->
+            true = erlang:demonitor(MonRef, [flush]),
+            gen_server:reply(From, Outcome),
+            State1 = State#state{session = Session1, dispatch_active = undefined},
+            {noreply, refresh_ttl(start_next_dispatch(State1))};
+        _ ->
+            {noreply, State}
+    end;
+handle_info(
     {'DOWN', Mon, process, ChannelPid, _Reason},
     #state{channel_mon = Mon, channel = ChannelPid} = State
 ) ->
     %% The channel's connection died without a clean detach.
     {noreply, do_detach(State)};
-handle_info({streaming_done, Id, Session1}, #state{streams = Streams} = State) ->
-    %% The worker finished (it already sent the result to the POST loop). Store
-    %% its threaded-back session and drop the tracking. Ignored if the request
-    %% was cancelled just before completion.
+handle_info(
+    {'DOWN', Mon, process, _Pid, _Reason}, #state{dispatch_active = {_W, Mon, From, Id}} = State
+) ->
+    %% The active buffered worker died without reporting done (an untrappable
+    %% kill -- safe_handle_method catches everything else). Free its caller.
+    gen_server:reply(From, {error, arizona_jsonrpc:error(Id, -32603, ~"Internal error")}),
+    {noreply, refresh_ttl(start_next_dispatch(State#state{dispatch_active = undefined}))};
+handle_info({streaming_done, Id}, #state{streams = Streams} = State) ->
+    %% The streaming worker finished (it already sent the result to the POST
+    %% loop). Drop the tracking; its state snapshot is discarded. Ignored if the
+    %% request was cancelled just before completion.
     case Streams of
         #{Id := {_WorkerPid, MonRef, _ConnPid}} ->
             true = erlang:demonitor(MonRef, [flush]),
-            State1 = State#state{session = Session1, streams = maps:remove(Id, Streams)},
-            {noreply, refresh_ttl(State1)};
+            {noreply, refresh_ttl(State#state{streams = maps:remove(Id, Streams)})};
         _ ->
             {noreply, State}
     end;
@@ -344,11 +388,17 @@ handle_info(_Info, State) ->
 -spec terminate(term(), state()) -> ok.
 terminate(
     Reason,
-    #state{id = SessionId, session = #{mod := Mod, state := HandlerState}, streams = Streams}
+    #state{
+        id = SessionId,
+        session = #{mod := Mod, state := HandlerState},
+        streams = Streams,
+        dispatch_active = Active
+    }
 ) ->
-    %% Kill any in-flight streaming workers so none outlive the session (a
-    %% blocking tool would otherwise run forever, orphaned).
+    %% Kill any in-flight workers (streaming + the active buffered one) so none
+    %% outlive the session (a blocking tool would otherwise run forever, orphaned).
     maps:foreach(fun(_Id, {WorkerPid, _MonRef, _ConnPid}) -> exit(WorkerPid, kill) end, Streams),
+    kill_active_dispatch(Active),
     %% Run the app's optional cleanup hook, then drop the registry row. (pg
     %% auto-removes the session from its subscribed channels on exit.)
     erlang:function_exported(Mod, terminate, 2) andalso Mod:terminate(Reason, HandlerState),
@@ -378,6 +428,82 @@ stream_by_mon(MonRef, Streams) ->
         [{Id, Conn} | _] -> {Id, Conn};
         [] -> error
     end.
+
+%% Methods that own a pubsub subscription keyed to the session process, so they
+%% must run there rather than in a worker (they run no app code, so they don't
+%% block). Everything else is offloaded.
+session_coupled(~"resources/subscribe") -> true;
+session_coupled(~"resources/unsubscribe") -> true;
+session_coupled(_Method) -> false.
+
+%% Spawn a monitored worker for the head of the dispatch queue if none is
+%% active. The worker runs the method against the current session snapshot and
+%% reports `{dispatch_done, ...}`; one-at-a-time keeps the state threading
+%% serialized (the next starts only once this one completes or is cancelled).
+start_next_dispatch(#state{dispatch_active = Active} = State) when Active =/= undefined ->
+    State;
+start_next_dispatch(#state{dispatch_q = Q, session = Session} = State) ->
+    case queue:out(Q) of
+        {empty, _} ->
+            State;
+        {{value, {From, Id, Method, Params}}, Q1} ->
+            SessionPid = self(),
+            WorkerPid = spawn(fun() ->
+                {Outcome, Session1} = safe_handle_method(Method, Params, Id, Session),
+                SessionPid ! {dispatch_done, self(), Outcome, Session1}
+            end),
+            MonRef = erlang:monitor(process, WorkerPid),
+            State#state{dispatch_active = {WorkerPid, MonRef, From, Id}, dispatch_q = Q1}
+    end.
+
+%% Cancel by request id: a streaming worker, the active buffered worker, or a
+%% still-queued buffered request -- whichever holds the id (at most one). A no-op
+%% if none does.
+cancel_request(Id, #state{streams = Streams} = State) ->
+    case Streams of
+        #{Id := {WorkerPid, MonRef, ConnPid}} ->
+            true = erlang:demonitor(MonRef, [flush]),
+            true = exit(WorkerPid, kill),
+            %% Tell the POST loop to stop -- the spec says a cancelled request
+            %% gets no response. Dropping the last stream re-arms the idle timer.
+            ConnPid ! mcp_cancelled,
+            refresh_ttl(State#state{streams = maps:remove(Id, Streams)});
+        _ ->
+            cancel_buffered(Id, State)
+    end.
+
+%% Cancel a buffered request: kill the active worker (replying a -32603 to its
+%% caller so the held HTTP POST closes), or drop a still-queued one.
+cancel_buffered(Id, #state{dispatch_active = {WorkerPid, MonRef, From, Id}} = State) ->
+    true = erlang:demonitor(MonRef, [flush]),
+    true = exit(WorkerPid, kill),
+    gen_server:reply(From, dispatch_cancelled(Id)),
+    refresh_ttl(start_next_dispatch(State#state{dispatch_active = undefined}));
+cancel_buffered(Id, #state{dispatch_q = Q} = State) ->
+    case drop_queued(Id, Q) of
+        {From, Q1} ->
+            gen_server:reply(From, dispatch_cancelled(Id)),
+            refresh_ttl(State#state{dispatch_q = Q1});
+        error ->
+            State
+    end.
+
+%% Remove the queued request with the given id, returning its caller. Queues are
+%% short, so a list round-trip is fine.
+drop_queued(Id, Q) ->
+    case lists:partition(fun({_From, QId, _M, _P}) -> QId =:= Id end, queue:to_list(Q)) of
+        {[], _} -> error;
+        {[{From, _, _, _} | _], Rest} -> {From, queue:from_list(Rest)}
+    end.
+
+dispatch_cancelled(Id) ->
+    {error, arizona_jsonrpc:error(Id, -32603, ~"Request cancelled")}.
+
+kill_active_dispatch({WorkerPid, _MonRef, _From, _Id}) ->
+    true = exit(WorkerPid, kill),
+    ok;
+kill_active_dispatch(undefined) ->
+    ok.
 
 %% Subscribe to the handler's declared pubsub channels (if it exports
 %% channels/1) so broadcasts reach this session. pg auto-removes the session

--- a/test/arizona_mcp_e2e_SUITE.erl
+++ b/test/arizona_mcp_e2e_SUITE.erl
@@ -34,6 +34,7 @@
     session_streaming_progress/1,
     session_cancel_stops_stream/1,
     session_disconnect_cancels_stream/1,
+    session_buffered_cancel_frees_request/1,
     auth_missing_token_401/1,
     auth_valid_token_ok/1,
     session_init_crash_internal_error/1
@@ -74,6 +75,7 @@ all() ->
         session_streaming_progress,
         session_cancel_stops_stream,
         session_disconnect_cancels_stream,
+        session_buffered_cancel_frees_request,
         auth_missing_token_401,
         auth_valid_token_ok,
         session_init_crash_internal_error
@@ -523,6 +525,27 @@ session_disconnect_cancels_stream(Config) ->
     Resp = post(Config, "/mcp-session", session_header(SessionId), Ping),
     ?assertEqual(200, status_code(Resp)),
     ?assertMatch(#{~"result" := #{}}, body_json(Resp)).
+
+session_buffered_cancel_frees_request(Config) ->
+    SessionId = open_session(Config),
+    %% A buffered (no progressToken) blocking tool holds its HTTP POST open. The
+    %% session stays responsive: a notifications/cancelled on another connection
+    %% frees the held request with a -32603 (proving it wasn't blocking the
+    %% session process).
+    Body =
+        ~"""
+    {"jsonrpc":"2.0","id":31,"method":"tools/call","params":{"name":"block","arguments":{}}}
+    """,
+    Sock = stream_post(Config, "/mcp-session", session_header(SessionId), Body),
+    Cancel =
+        ~"""
+    {"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":31}}
+    """,
+    CancelResp = post(Config, "/mcp-session", session_header(SessionId), Cancel),
+    ?assertEqual(202, status_code(CancelResp)),
+    Data = recv_until(Sock, ~"-32603", 5000),
+    ?assertNotEqual(nomatch, binary:match(Data, ~"-32603")),
+    gen_tcp:close(Sock).
 
 %% --------------------------------------------------------------------
 %% Auth-gated tests (/mcp-auth, auth => bearer hook)

--- a/test/arizona_mcp_session_SUITE.erl
+++ b/test/arizona_mcp_session_SUITE.erl
@@ -29,6 +29,12 @@
     dispatch_bounded_timeout/1,
     streaming_tool_holds_session/1,
     terminate_kills_streaming_worker/1,
+    buffered_dispatch_runs_in_worker/1,
+    buffered_cancel_frees_caller/1,
+    buffered_worker_crash_frees_caller/1,
+    buffered_block_does_not_wedge_session/1,
+    buffered_requests_serialize/1,
+    cancel_queued_buffered_request/1,
     notify_without_channel_is_noop/1,
     notify_unknown_session_is_noop/1,
     log_unknown_session_is_noop/1,
@@ -69,6 +75,12 @@ all() ->
         dispatch_bounded_timeout,
         streaming_tool_holds_session,
         terminate_kills_streaming_worker,
+        buffered_dispatch_runs_in_worker,
+        buffered_cancel_frees_caller,
+        buffered_worker_crash_frees_caller,
+        buffered_block_does_not_wedge_session,
+        buffered_requests_serialize,
+        cancel_queued_buffered_request,
         notify_without_channel_is_noop,
         notify_unknown_session_is_noop,
         log_unknown_session_is_noop,
@@ -366,6 +378,144 @@ terminate_kills_streaming_worker(_Config) ->
     receive
         {'DOWN', WRef, process, Worker, killed} -> ok
     after 5000 -> ct:fail(worker_not_killed)
+    end.
+
+buffered_dispatch_runs_in_worker(_Config) ->
+    {_Id, Pid} = start(60000),
+    %% A buffered tool runs in a worker, not the session process: the tool's
+    %% pid is reported and differs from the session pid.
+    Params = #{~"name" => ~"block", ~"arguments" => #{watch => self()}},
+    Caller = spawn(fun() -> arizona_mcp_session:dispatch(Pid, ~"tools/call", Params, 7) end),
+    Worker =
+        receive
+            {block_started, W} -> W
+        after 5000 -> ct:fail(worker_did_not_start)
+        end,
+    ?assertNotEqual(Pid, Worker),
+    ?assertNotEqual(Caller, Worker),
+    %% The session stays responsive while the buffered tool blocks: a cancel is
+    %% served and frees the caller with a -32603.
+    ok = arizona_mcp_session:cancel(Pid, 7),
+    ?assertMatch({reply, _}, arizona_mcp_session:dispatch(Pid, ~"ping", #{}, 8)).
+
+buffered_cancel_frees_caller(_Config) ->
+    {_Id, Pid} = start(60000),
+    Self = self(),
+    %% A blocking buffered tool from another process; cancelling it by id frees
+    %% that caller with a -32603 and leaves the session serving.
+    Params = #{~"name" => ~"block", ~"arguments" => #{watch => Self}},
+    _Caller = spawn(fun() ->
+        Result = arizona_mcp_session:dispatch(Pid, ~"tools/call", Params, 7),
+        Self ! {caller_result, Result}
+    end),
+    receive
+        {block_started, _W} -> ok
+    after 5000 -> ct:fail(block_did_not_start)
+    end,
+    ok = arizona_mcp_session:cancel(Pid, 7),
+    receive
+        {caller_result, R} -> ?assertMatch({error, #{~"error" := #{~"code" := -32603}}}, R)
+    after 5000 -> ct:fail(caller_not_freed)
+    end,
+    ?assertMatch({reply, _}, arizona_mcp_session:dispatch(Pid, ~"ping", #{}, 8)).
+
+buffered_worker_crash_frees_caller(_Config) ->
+    {_Id, Pid} = start(60000),
+    %% An untrappable worker death (the tool kills itself, bypassing the crash
+    %% guard) frees the caller with a -32603 rather than hanging it.
+    R = arizona_mcp_session:dispatch(Pid, ~"tools/call", #{~"name" => ~"selfkill"}, 7),
+    ?assertMatch({error, #{~"error" := #{~"code" := -32603}}}, R),
+    ?assertMatch({reply, _}, arizona_mcp_session:dispatch(Pid, ~"ping", #{}, 8)).
+
+buffered_block_does_not_wedge_session(_Config) ->
+    {_Id, Pid} = start(100),
+    Self = self(),
+    %% A never-returning buffered tool no longer wedges the session: with a 100ms
+    %% idle TTL the session is still reaped, and teardown kills the stuck worker.
+    Params = #{~"name" => ~"block", ~"arguments" => #{watch => Self}},
+    _Caller = spawn(fun() ->
+        Result = arizona_mcp_session:dispatch(Pid, ~"tools/call", Params, 7),
+        Self ! {caller_result, Result}
+    end),
+    Worker =
+        receive
+            {block_started, W} -> W
+        after 5000 -> ct:fail(block_did_not_start)
+        end,
+    SRef = erlang:monitor(process, Pid),
+    WRef = erlang:monitor(process, Worker),
+    receive
+        {'DOWN', SRef, process, Pid, normal} -> ok
+    after 5000 -> ct:fail(session_wedged)
+    end,
+    receive
+        {'DOWN', WRef, process, Worker, killed} -> ok
+    after 5000 -> ct:fail(worker_not_killed)
+    end.
+
+buffered_requests_serialize(_Config) ->
+    {_Id, Pid} = start(60000),
+    Self = self(),
+    %% A first buffered tool blocks, holding the single worker slot.
+    P1 = #{~"name" => ~"block", ~"arguments" => #{watch => Self}},
+    _C1 = spawn(fun() ->
+        R1 = arizona_mcp_session:dispatch(Pid, ~"tools/call", P1, 7),
+        Self ! {r1, R1}
+    end),
+    receive
+        {block_started, _} -> ok
+    after 5000 -> ct:fail(block_did_not_start)
+    end,
+    %% A second request queues behind it -- one worker at a time, so it must not
+    %% run while the first blocks.
+    _C2 = spawn(fun() ->
+        R2 = arizona_mcp_session:dispatch(Pid, ~"ping", #{}, 8),
+        Self ! {r2, R2}
+    end),
+    receive
+        {r2, _} -> ct:fail(ran_out_of_order)
+    after 300 -> ok
+    end,
+    %% Cancelling the first frees the slot, so the queued request then runs.
+    ok = arizona_mcp_session:cancel(Pid, 7),
+    receive
+        {r1, R1} -> ?assertMatch({error, #{~"error" := #{~"code" := -32603}}}, R1)
+    after 5000 -> ct:fail(first_not_freed)
+    end,
+    receive
+        {r2, R2} -> ?assertMatch({reply, _}, R2)
+    after 5000 -> ct:fail(queued_not_run)
+    end.
+
+cancel_queued_buffered_request(_Config) ->
+    {_Id, Pid} = start(60000),
+    Self = self(),
+    P1 = #{~"name" => ~"block", ~"arguments" => #{watch => Self}},
+    _C1 = spawn(fun() ->
+        R1 = arizona_mcp_session:dispatch(Pid, ~"tools/call", P1, 7),
+        Self ! {r1, R1}
+    end),
+    receive
+        {block_started, _} -> ok
+    after 5000 -> ct:fail(block_did_not_start)
+    end,
+    _C2 = spawn(fun() ->
+        R2 = arizona_mcp_session:dispatch(Pid, ~"ping", #{}, 8),
+        Self ! {r2, R2}
+    end),
+    %% Let the second request enqueue, then cancel it while it is still queued
+    %% (not the active one); its caller is freed with a -32603.
+    timer:sleep(50),
+    ok = arizona_mcp_session:cancel(Pid, 8),
+    receive
+        {r2, R2} -> ?assertMatch({error, #{~"error" := #{~"code" := -32603}}}, R2)
+    after 5000 -> ct:fail(queued_not_cancelled)
+    end,
+    %% The active (blocking) request is untouched; cancel it to clean up.
+    ok = arizona_mcp_session:cancel(Pid, 7),
+    receive
+        {r1, _} -> ok
+    after 5000 -> ct:fail(active_not_freed)
     end.
 
 notify_without_channel_is_noop(_Config) ->


### PR DESCRIPTION
# Description

Session requests now run in a worker process, so a slow tool can no longer block the session. It stays responsive to cancels, idle reap, and server pushes while a tool runs, and a never-returning buffered tool no longer wedges it (it gets cancelled or idle-reaped instead of becoming a zombie). Buffered requests are served through a one-at-a-time queue so their state threading stays serialized, and a `notifications/cancelled` (or a client disconnect) now frees a buffered caller too. A streaming `tools/call` switches to reading a state snapshot with no write-back, so the serialized buffered queue is the only path that mutates session state and nothing races on it.

The per-session queue is left unbounded for now (a misbehaving client only backs up its own session); a depth cap fits the later resource-limits work.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
