### PR TITLE
Add per-route session caps, a dispatch queue cap, and SSE keep-alive

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1160,6 +1160,19 @@ cursor. Because the cursor is an offset, it assumes a stable list across pages -
 mid-pagination can skip or repeat an item (acceptable for the near-static MCP lists, and a
 `list_changed` notification has the client re-list anyway).
 
+### Resource limits and keep-alive
+
+Three opt-in knobs bound a session-mode route. `max_sessions` caps the live sessions **per route**
+(the registry tags each session with the request path it opened on and counts by it, so two routes
+sharing a handler module still cap independently); an `initialize` past the cap is answered with a
+`503` plus a JSON-RPC error body. The count is read just before starting, so a burst of concurrent
+initializes can admit a few over the cap -- fine for a soft limit. `session_max_pending` (default
+100) bounds the per-session buffered-dispatch queue; a dispatch arriving with the queue full is
+rejected with a -32603 rather than enqueued. `session_keepalive_ms` (default 30s, `infinity`
+disables) makes the session emit a periodic `roadrunner_sse:comment/1` over an attached channel so
+idle proxies don't close the stream; the comment carries no event id, so it is never buffered for
+resumption, and the timer runs only while a channel is attached.
+
 ### Capability gating and security
 
 `init/1` returns an atom-keyed capability map; the transport serves `resources/*` and `prompts/*`

--- a/src/arizona_mcp.erl
+++ b/src/arizona_mcp.erl
@@ -145,21 +145,26 @@ them at 100.
 
 ## Operational notes
 
-Session mode starts one process per `initialize`, and the count is
-unbounded -- a public deployment should gate the endpoint with the `auth`
-hook and a reverse-proxy rate limit. An abandoned session is reaped after
-its idle TTL (`session_ttl_ms`, default 5 minutes). Every request runs in a
-worker, so app code never blocks the session process: it stays responsive to
-cancels, idle-reap, and server pushes even while a tool runs. Buffered requests
-are served one at a time (so their state threading stays serialized) and bounded
-by `request_timeout_ms` (default 60s): a slower tool frees the client with a
--32603 while the session keeps running it. Any request is cancellable by a
+Session mode starts one process per `initialize`. The per-route session count
+is bounded by `max_sessions` (an `initialize` past the cap gets a `503`);
+unset, it is unbounded, so a public deployment should also gate the endpoint
+with the `auth` hook and a reverse-proxy rate limit. An abandoned session is
+reaped after its idle TTL (`session_ttl_ms`, default 5 minutes). Every request
+runs in a worker, so app code never blocks the session process: it stays
+responsive to cancels, idle-reap, and server pushes even while a tool runs.
+Buffered requests are served one at a time (so their state threading stays
+serialized) and bounded by `request_timeout_ms` (default 60s): a slower tool
+frees the client with a -32603 while the session keeps running it; queued
+buffered requests are capped at `session_max_pending` (default 100), past which
+a dispatch is rejected. Any request is cancellable by a
 `notifications/cancelled {requestId}` or a client disconnect, which frees the
 caller and kills the worker. An in-flight streaming worker holds its session
 alive (it is not idle-reaped mid-run); every worker is killed if the session is
-torn down. The optional `terminate/2` callback runs when a session ends (DELETE,
-idle TTL, or shutdown); it does **not** run in stateless mode, which has no
-session to end.
+torn down. An attached SSE channel gets a periodic keep-alive comment
+(`session_keepalive_ms`, default 30s; `infinity` disables) so idle proxies
+don't drop it. The optional `terminate/2` callback runs when a session ends
+(DELETE, idle TTL, or shutdown); it does **not** run in stateless mode, which
+has no session to end.
 
 Clients that use `fetch` (browsers and the official MCP SDK) refuse to
 connect to ports on the WHATWG Fetch "bad ports" blocklist, so mount the

--- a/src/arizona_mcp_handler.erl
+++ b/src/arizona_mcp_handler.erl
@@ -97,6 +97,16 @@ protocol contract holds even when a tool raises.
 %% `request_timeout_ms` opt. Generous, since a tool may legitimately run a while.
 -define(DEFAULT_REQUEST_TIMEOUT_MS, 60000).
 
+%% Cap on queued (not-yet-running) buffered requests per session, overridable via
+%% the route's `session_max_pending` opt. Generous -- a well-behaved client has
+%% at most a handful in flight.
+-define(DEFAULT_MAX_PENDING, 100).
+
+%% Interval between SSE keep-alive comments over an attached channel, overridable
+%% via the route's `session_keepalive_ms` opt (`infinity` disables it). Shorter
+%% than common 60s proxy idle timeouts.
+-define(DEFAULT_KEEPALIVE_MS, 30000).
+
 %% --------------------------------------------------------------------
 %% API Functions
 %% --------------------------------------------------------------------
@@ -389,7 +399,7 @@ reply_session(#{method := Method, params := Params, id := Id} = Request, Req, Op
             session_notification(Method, Params, Req),
             roadrunner_resp:status(202);
         _ when Method =:= ~"initialize" ->
-            session_initialize(Params, Id, Opts);
+            session_initialize(Params, Id, Req, Opts);
         _ ->
             session_request(Method, Params, Id, Request, Req, request_timeout(Opts))
     end.
@@ -414,7 +424,29 @@ session_notification(_Method, _Params, _Req) ->
 request_timeout(Opts) ->
     maps:get(request_timeout_ms, Opts, ?DEFAULT_REQUEST_TIMEOUT_MS).
 
-session_initialize(Params, Id, #{handler := Mod} = Opts) ->
+session_initialize(Params, Id, Req, Opts) ->
+    %% The route key is the request path, so the `max_sessions` cap is per route
+    %% (two routes sharing a handler module still cap independently).
+    RouteKey = roadrunner_req:path(Req),
+    case at_capacity(RouteKey, Opts) of
+        true ->
+            roadrunner_resp:json(503, arizona_jsonrpc:error(Id, -32603, ~"Server at capacity"));
+        false ->
+            start_initialized_session(Params, Id, RouteKey, Opts)
+    end.
+
+%% Reject a new session once this route is at its `max_sessions` cap. The count
+%% is read just before starting, so a burst of concurrent initializes can admit
+%% a few over the cap -- fine for a soft limit.
+at_capacity(RouteKey, Opts) ->
+    case maps:get(max_sessions, Opts, infinity) of
+        infinity ->
+            false;
+        Max ->
+            arizona_mcp_session_registry:count(RouteKey) >= Max
+    end.
+
+start_initialized_session(Params, Id, RouteKey, #{handler := Mod} = Opts) ->
     SessionId = generate_session_id(),
     %% A crashing `init/1` is guarded the same way the stateless path guards
     %% dispatch: answer `-32603` rather than killing the connection.
@@ -426,7 +458,10 @@ session_initialize(Params, Id, #{handler := Mod} = Opts) ->
         {ServerInfo, #{caps := Caps} = Session} = open_session(Mod, InitParams, page_size(Opts)),
         SessionOpts = #{
             ttl_ms => maps:get(session_ttl_ms, Opts, ?DEFAULT_TTL_MS),
-            buffer_max => maps:get(session_buffer_max, Opts, ?DEFAULT_BUFFER_MAX)
+            buffer_max => maps:get(session_buffer_max, Opts, ?DEFAULT_BUFFER_MAX),
+            max_pending => maps:get(session_max_pending, Opts, ?DEFAULT_MAX_PENDING),
+            keepalive_ms => maps:get(session_keepalive_ms, Opts, ?DEFAULT_KEEPALIVE_MS),
+            route_key => RouteKey
         },
         {ok, _Pid} = arizona_mcp_sup:start_session(SessionId, Session, SessionOpts),
         Result = arizona_jsonrpc:result(Id, initialize_result(ServerInfo, Caps, Params)),

--- a/src/arizona_mcp_session.erl
+++ b/src/arizona_mcp_session.erl
@@ -81,11 +81,25 @@ sends `DELETE`) does not leak; every served request resets it.
     %% never blocks on app code. One worker at a time keeps the state threading
     %% serialized; the rest wait their turn in `dispatch_q`.
     dispatch_active :: active_dispatch() | undefined,
-    dispatch_q :: queue:queue(pending_dispatch())
+    dispatch_q :: queue:queue(pending_dispatch()),
+    %% Cap on queued (not-yet-running) buffered requests; a dispatch arriving
+    %% with the queue already full is rejected rather than enqueued.
+    max_pending :: pos_integer(),
+    %% Periodic SSE keep-alive comment over an attached channel, so idle proxies
+    %% don't close the stream. `infinity` disables it.
+    keepalive_ms :: pos_integer() | infinity,
+    keepalive_timer :: reference() | undefined
 }).
 
 -type state() :: #state{}.
--type session_opts() :: #{ttl_ms := pos_integer(), buffer_max := pos_integer()}.
+-type session_opts() :: #{
+    ttl_ms := pos_integer(),
+    buffer_max := pos_integer(),
+    max_pending := pos_integer(),
+    keepalive_ms := pos_integer() | infinity,
+    %% The request path the session was opened on, for the per-route session cap.
+    route_key := binary()
+}.
 %% A queued buffered request awaiting its turn: the caller to reply to, its
 %% request id, and the method/params to run.
 -type pending_dispatch() :: {gen_server:from(), arizona_jsonrpc:id(), binary(), map()}.
@@ -234,9 +248,16 @@ stop(Pid) ->
     SessionId :: binary(),
     Session :: arizona_mcp_handler:session(),
     SessionOpts :: session_opts().
-init({SessionId, Session, #{ttl_ms := TtlMs, buffer_max := BufferMax}}) ->
+init({SessionId, Session, SessionOpts}) ->
+    #{
+        ttl_ms := TtlMs,
+        buffer_max := BufferMax,
+        max_pending := MaxPending,
+        keepalive_ms := KeepaliveMs,
+        route_key := RouteKey
+    } = SessionOpts,
     proc_lib:set_label({arizona_mcp_session, SessionId}),
-    ok = arizona_mcp_session_registry:add(SessionId, self()),
+    ok = arizona_mcp_session_registry:add(SessionId, self(), RouteKey),
     Channels = subscribe_channels(Session),
     State = #state{
         id = SessionId,
@@ -249,7 +270,10 @@ init({SessionId, Session, #{ttl_ms := TtlMs, buffer_max := BufferMax}}) ->
         buffer_max = BufferMax,
         streams = #{},
         dispatch_active = undefined,
-        dispatch_q = queue:new()
+        dispatch_q = queue:new(),
+        max_pending = MaxPending,
+        keepalive_ms = KeepaliveMs,
+        keepalive_timer = undefined
     },
     {ok, refresh_ttl(State)}.
 
@@ -273,9 +297,17 @@ handle_call({dispatch, Method, Params, Id}, From, State) ->
             %% Everything else runs in a worker, replied to asynchronously, so a
             %% slow tool never blocks the session process (it stays responsive to
             %% cancels, idle-reap, and channel pushes). One worker at a time keeps
-            %% the state threading serialized; the rest wait in the queue.
-            Q1 = queue:in({From, Id, Method, Params}, State#state.dispatch_q),
-            {noreply, refresh_ttl(start_next_dispatch(State#state{dispatch_q = Q1}))}
+            %% the state threading serialized; the rest wait in the queue, up to
+            %% `max_pending` -- past that the session is overloaded and rejects.
+            #state{dispatch_q = Q, max_pending = MaxPending} = State,
+            case queue:len(Q) >= MaxPending of
+                true ->
+                    Error = arizona_jsonrpc:error(Id, -32603, ~"Session overloaded"),
+                    {reply, {error, Error}, State};
+                false ->
+                    Q1 = queue:in({From, Id, Method, Params}, Q),
+                    {noreply, refresh_ttl(start_next_dispatch(State#state{dispatch_q = Q1}))}
+            end
     end;
 handle_call({attach_channel, ChannelPid, LastEventId}, _From, State) ->
     case channel_alive(State) of
@@ -289,7 +321,7 @@ handle_call({attach_channel, ChannelPid, LastEventId}, _From, State) ->
             Mon = erlang:monitor(process, ChannelPid),
             Attached = Cleared#state{channel = ChannelPid, channel_mon = Mon},
             Replayed = replay(parse_last_event_id(LastEventId), Attached),
-            {reply, ok, refresh_ttl(Replayed)}
+            {reply, ok, arm_keepalive(refresh_ttl(Replayed))}
     end.
 
 -spec handle_cast(term(), state()) -> {noreply, state()}.
@@ -380,6 +412,14 @@ handle_info({'DOWN', MonRef, process, _WorkerPid, _Reason}, #state{streams = Str
         error ->
             {noreply, State}
     end;
+handle_info(mcp_keepalive, #state{channel = undefined} = State) ->
+    %% The channel detached before this tick; nothing to keep alive.
+    {noreply, State};
+handle_info(mcp_keepalive, #state{channel = ChannelPid} = State) ->
+    %% A comment line keeps idle proxies from closing the SSE stream. It carries
+    %% no event id, so it is never buffered for resumption.
+    ChannelPid ! {mcp_event, roadrunner_sse:comment(~"keepalive")},
+    {noreply, arm_keepalive(State)};
 handle_info(session_ttl_expired, State) ->
     {stop, normal, State};
 handle_info(_Info, State) ->
@@ -580,7 +620,8 @@ clear_channel(#state{channel = undefined} = State) ->
     State;
 clear_channel(#state{channel_mon = Mon} = State) ->
     demonitor_channel(Mon),
-    State#state{channel = undefined, channel_mon = undefined}.
+    %% No channel left to keep alive.
+    cancel_keepalive(State#state{channel = undefined, channel_mon = undefined}).
 
 %% Detach the channel: stop monitoring it, forget it, and re-arm the idle
 %% timer (the session is connectionless again and may be abandoned).
@@ -598,7 +639,7 @@ demonitor_channel(Mon) ->
 %% Cancel any pending timer, then arm a fresh one only when nothing holds it
 %% (so a streaming tool is never idle-reaped mid-run).
 refresh_ttl(#state{ttl_timer = Old, ttl_ms = TtlMs} = State) ->
-    cancel_ttl(Old),
+    cancel_timer(Old),
     case held_open(State) of
         true ->
             State#state{ttl_timer = undefined};
@@ -611,8 +652,23 @@ refresh_ttl(#state{ttl_timer = Old, ttl_ms = TtlMs} = State) ->
 held_open(#state{channel = Channel, streams = Streams}) ->
     Channel =/= undefined orelse Streams =/= #{}.
 
-cancel_ttl(undefined) ->
+%% Arm the periodic keep-alive timer, but only when enabled and a channel is
+%% attached (there is nothing to keep alive otherwise).
+arm_keepalive(#state{keepalive_ms = infinity} = State) ->
+    State;
+arm_keepalive(#state{channel = undefined} = State) ->
+    State;
+arm_keepalive(#state{keepalive_ms = Ms, keepalive_timer = Old} = State) ->
+    cancel_timer(Old),
+    Ref = erlang:send_after(Ms, self(), mcp_keepalive),
+    State#state{keepalive_timer = Ref}.
+
+cancel_keepalive(#state{keepalive_timer = Old} = State) ->
+    cancel_timer(Old),
+    State#state{keepalive_timer = undefined}.
+
+cancel_timer(undefined) ->
     ok;
-cancel_ttl(Ref) ->
+cancel_timer(Ref) ->
     _ = erlang:cancel_timer(Ref),
     ok.

--- a/src/arizona_mcp_session_registry.erl
+++ b/src/arizona_mcp_session_registry.erl
@@ -18,9 +18,10 @@ Sessions add themselves on start and remove themselves on terminate; a
 %% --------------------------------------------------------------------
 
 -export([create_table/0]).
--export([add/2]).
+-export([add/3]).
 -export([remove/1]).
 -export([lookup/1]).
+-export([count/1]).
 
 %% --------------------------------------------------------------------
 %% Macros
@@ -41,12 +42,17 @@ create_table() ->
     _ = ets:new(?TABLE, [named_table, public, {read_concurrency, true}]),
     ok.
 
--doc "Record a session id -> pid mapping. Called from the session's `init/1`.".
--spec add(SessionId, Pid) -> ok when
+-doc """
+Record a session id -> pid mapping, tagged with its route key (the request
+path it was opened on) so `count/1` can enforce a per-route `max_sessions`
+cap. Called from the session's `init/1`.
+""".
+-spec add(SessionId, Pid, RouteKey) -> ok when
     SessionId :: binary(),
-    Pid :: pid().
-add(SessionId, Pid) ->
-    true = ets:insert(?TABLE, {SessionId, Pid}),
+    Pid :: pid(),
+    RouteKey :: binary().
+add(SessionId, Pid, RouteKey) ->
+    true = ets:insert(?TABLE, {SessionId, Pid, RouteKey}),
     ok.
 
 -doc "Drop a session id mapping. Called from the session's `terminate/2`.".
@@ -64,7 +70,7 @@ id, or for a stale row whose process has died (sweeping the row).
     SessionId :: binary().
 lookup(SessionId) ->
     case ets:lookup(?TABLE, SessionId) of
-        [{_, Pid}] ->
+        [{_, Pid, _Mod}] ->
             case is_process_alive(Pid) of
                 true ->
                     {ok, Pid};
@@ -75,3 +81,14 @@ lookup(SessionId) ->
         [] ->
             error
     end.
+
+-doc """
+Count the live sessions opened on route `RouteKey`, for the per-route
+`max_sessions` cap. Counts table rows directly (a stale row of a crashed
+session is swept on its next `lookup/1`), so the count is approximate under a
+burst of concurrent `initialize`s -- acceptable for a soft capacity limit.
+""".
+-spec count(RouteKey) -> non_neg_integer() when
+    RouteKey :: binary().
+count(RouteKey) ->
+    ets:select_count(?TABLE, [{{'_', '_', RouteKey}, [], [true]}]).

--- a/test/arizona_mcp_e2e_SUITE.erl
+++ b/test/arizona_mcp_e2e_SUITE.erl
@@ -35,6 +35,7 @@
     session_cancel_stops_stream/1,
     session_disconnect_cancels_stream/1,
     session_buffered_cancel_frees_request/1,
+    session_max_sessions_503/1,
     auth_missing_token_401/1,
     auth_valid_token_ok/1,
     session_init_crash_internal_error/1
@@ -76,6 +77,7 @@ all() ->
         session_cancel_stops_stream,
         session_disconnect_cancels_stream,
         session_buffered_cancel_frees_request,
+        session_max_sessions_503,
         auth_missing_token_401,
         auth_valid_token_ok,
         session_init_crash_internal_error
@@ -108,6 +110,11 @@ init_per_suite(Config) ->
         {mcp, ~"/mcp-paged", arizona_mcp_test_server, #{
             origins => [?ALLOWED_ORIGIN],
             page_size => 2
+        }},
+        {mcp, ~"/mcp-capped", arizona_mcp_test_server, #{
+            origins => [?ALLOWED_ORIGIN],
+            sessions => true,
+            max_sessions => 1
         }}
     ],
     {ok, _} = arizona_roadrunner_server:start(?LISTENER, #{
@@ -546,6 +553,14 @@ session_buffered_cancel_frees_request(Config) ->
     Data = recv_until(Sock, ~"-32603", 5000),
     ?assertNotEqual(nomatch, binary:match(Data, ~"-32603")),
     gen_tcp:close(Sock).
+
+session_max_sessions_503(Config) ->
+    %% A route capped at one session: the first initialize opens it, the second
+    %% is rejected with a 503 (the route is at capacity).
+    R1 = post(Config, "/mcp-capped", [], initialize_body()),
+    ?assertEqual(200, status_code(R1)),
+    R2 = post(Config, "/mcp-capped", [], initialize_body()),
+    ?assertEqual(503, status_code(R2)).
 
 %% --------------------------------------------------------------------
 %% Auth-gated tests (/mcp-auth, auth => bearer hook)

--- a/test/arizona_mcp_session_SUITE.erl
+++ b/test/arizona_mcp_session_SUITE.erl
@@ -35,6 +35,10 @@
     buffered_block_does_not_wedge_session/1,
     buffered_requests_serialize/1,
     cancel_queued_buffered_request/1,
+    buffered_queue_cap_rejects/1,
+    keepalive_pings_channel/1,
+    keepalive_off_when_infinity/1,
+    keepalive_stops_on_detach/1,
     notify_without_channel_is_noop/1,
     notify_unknown_session_is_noop/1,
     log_unknown_session_is_noop/1,
@@ -81,6 +85,10 @@ all() ->
         buffered_block_does_not_wedge_session,
         buffered_requests_serialize,
         cancel_queued_buffered_request,
+        buffered_queue_cap_rejects,
+        keepalive_pings_channel,
+        keepalive_off_when_infinity,
+        keepalive_stops_on_detach,
         notify_without_channel_is_noop,
         notify_unknown_session_is_noop,
         log_unknown_session_is_noop,
@@ -518,6 +526,71 @@ cancel_queued_buffered_request(_Config) ->
     after 5000 -> ct:fail(active_not_freed)
     end.
 
+buffered_queue_cap_rejects(_Config) ->
+    {_Id, Pid} = start_opts(#{max_pending => 1}),
+    Self = self(),
+    %% Occupy the single worker slot with a blocking tool.
+    P1 = #{~"name" => ~"block", ~"arguments" => #{watch => Self}},
+    _C1 = spawn(fun() ->
+        R1 = arizona_mcp_session:dispatch(Pid, ~"tools/call", P1, 7),
+        Self ! {r1, R1}
+    end),
+    receive
+        {block_started, _} -> ok
+    after 5000 -> ct:fail(block_did_not_start)
+    end,
+    %% One queued request fills the cap (max_pending = 1).
+    _C2 = spawn(fun() ->
+        R2 = arizona_mcp_session:dispatch(Pid, ~"ping", #{}, 8),
+        Self ! {r2, R2}
+    end),
+    timer:sleep(50),
+    %% A further buffered request is rejected: the queue is full.
+    R3 = arizona_mcp_session:dispatch(Pid, ~"ping", #{}, 9),
+    ?assertMatch({error, #{~"error" := #{~"code" := -32603}}}, R3),
+    %% Cancelling the blocker drains the queued (not rejected) request.
+    ok = arizona_mcp_session:cancel(Pid, 7),
+    receive
+        {r2, R2} -> ?assertMatch({reply, _}, R2)
+    after 5000 -> ct:fail(queued_not_run)
+    end.
+
+keepalive_pings_channel(_Config) ->
+    {_Id, Pid} = start_opts(#{keepalive_ms => 50}),
+    ok = arizona_mcp_session:attach_channel(Pid, self(), undefined),
+    %% With keep-alive enabled, the attached channel receives a periodic comment.
+    receive
+        {mcp_event, Frame} ->
+            ?assertNotEqual(nomatch, binary:match(iolist_to_binary(Frame), ~"keepalive"))
+    after 5000 -> ct:fail(no_keepalive)
+    end.
+
+keepalive_off_when_infinity(_Config) ->
+    {_Id, Pid} = start(60000),
+    ok = arizona_mcp_session:attach_channel(Pid, self(), undefined),
+    %% keepalive_ms = infinity (the helper default) disables it: no comment.
+    receive
+        {mcp_event, _} -> ct:fail(unexpected_keepalive)
+    after 200 -> ok
+    end.
+
+keepalive_stops_on_detach(_Config) ->
+    {_Id, Pid} = start_opts(#{keepalive_ms => 50}),
+    ok = arizona_mcp_session:attach_channel(Pid, self(), undefined),
+    receive
+        {mcp_event, _} -> ok
+    after 5000 -> ct:fail(no_keepalive)
+    end,
+    ok = arizona_mcp_session:detach_channel(Pid, self()),
+    %% A sync dispatch flushes the detach cast; after it, the timer is cancelled,
+    %% so no further comments arrive.
+    ?assertMatch({reply, _}, arizona_mcp_session:dispatch(Pid, ~"ping", #{}, 1)),
+    flush_events(),
+    receive
+        {mcp_event, _} -> ct:fail(keepalive_after_detach)
+    after 200 -> ok
+    end.
+
 notify_without_channel_is_noop(_Config) ->
     {_Id, Pid} = start(60000),
     ok = arizona_mcp_session:notify(Pid, ~"notifications/message", #{}),
@@ -606,7 +679,14 @@ terminate_calls_app(_Config) ->
         page_size => 50,
         log_min_severity => 1
     },
-    {ok, Pid} = arizona_mcp_sup:start_session(Id, Session, #{ttl_ms => 60000, buffer_max => 256}),
+    SessionOpts = #{
+        ttl_ms => 60000,
+        buffer_max => 256,
+        max_pending => 100,
+        keepalive_ms => infinity,
+        route_key => ~"/test"
+    },
+    {ok, Pid} = arizona_mcp_sup:start_session(Id, Session, SessionOpts),
     ok = arizona_mcp_session:stop(Pid),
     receive
         {mcp_terminated, _Reason} -> ok
@@ -655,15 +735,32 @@ start(TtlMs) ->
     start(TtlMs, 256).
 
 start(TtlMs, BufferMax) ->
+    start_opts(#{ttl_ms => TtlMs, buffer_max => BufferMax}).
+
+%% Start a session with `Overrides` merged over the default opts, so a test can
+%% set just the knob it exercises (e.g. `max_pending`, `keepalive_ms`).
+start_opts(Overrides) ->
     Id = integer_to_binary(erlang:unique_integer([positive])),
-    Opts = #{ttl_ms => TtlMs, buffer_max => BufferMax},
-    {ok, Pid} = arizona_mcp_sup:start_session(Id, session(), Opts),
+    Base = #{
+        ttl_ms => 60000,
+        buffer_max => 256,
+        max_pending => 100,
+        keepalive_ms => infinity,
+        route_key => ~"/test"
+    },
+    {ok, Pid} = arizona_mcp_sup:start_session(Id, session(), maps:merge(Base, Overrides)),
     {Id, Pid}.
 
 recv_event() ->
     receive
         {mcp_event, Frame} -> iolist_to_binary(Frame)
     after 5000 -> ct:fail(no_event)
+    end.
+
+flush_events() ->
+    receive
+        {mcp_event, _} -> flush_events()
+    after 0 -> ok
     end.
 
 session() ->


### PR DESCRIPTION
# Description

Three opt-in limits for a session-mode MCP route. `max_sessions` caps the live sessions per route (the registry counts by the request path a session opened on, so two routes sharing a handler module cap independently); an initialize past the cap gets a 503. `session_max_pending` (default 100) bounds the per-session buffered-dispatch queue, rejecting a dispatch past it with a -32603. `session_keepalive_ms` (default 30s, `infinity` disables) emits a periodic SSE comment over an attached channel so idle proxies don't close the stream.

All three default to off or safe, so a route that doesn't set them behaves exactly as before.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
