### PR TITLE
Add a dev-introspection MCP server example and how-to guide

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,125 @@
+# MCP servers
+
+Arizona can serve the [Model Context Protocol](https://modelcontextprotocol.io) (MCP), so an AI
+agent (Claude Code, Cursor, the MCP Inspector, ...) can call into your app. You write a handler
+module that exposes **tools**, **resources**, and **prompts**, and mount it on a route. The
+transport is MCP's Streamable HTTP (JSON-RPC over HTTP POST, with an optional SSE channel for
+server-initiated messages); it rides the same roadrunner listener as the rest of your app.
+
+Two shapes fall out of the same engine:
+
+- A **dev tool**, in the spirit of [Tidewave](https://github.com/tidewave-ai/tidewave_phoenix):
+  a coding agent introspects your *running* dev app (its routes, its docs) and runs code against
+  it. Localhost, single developer, trusted.
+- A **user-facing server**: your app exposes its features as tools to end-users' agents at
+  runtime. Untrusted and concurrent, so the session, auth, and resource-limit features earn their
+  keep.
+
+The rest of this guide builds the dev tool. The full worked example is
+[`arizona_demo_mcp`][demo], mounted at `/mcp` in the dev server.
+
+[demo]: https://github.com/arizona-framework/arizona/blob/main/test/support/arizona_demo_mcp.erl
+
+## The behaviour
+
+An MCP server is a module with `-behaviour(arizona_mcp)`. Only three callbacks are required --
+`init/1`, `tools/1`, and `handle_tool/4` -- the rest (resources, prompts, completion, logging) are
+optional and gated by the capabilities `init/1` advertises.
+
+```erlang
+-module(my_mcp).
+-behaviour(arizona_mcp).
+-export([init/1, tools/1, handle_tool/4]).
+
+init(_InitParams) ->
+    %% {ok, ServerInfo, Capabilities, State}
+    {ok, #{name => ~"my_app_dev", version => ~"0.1.0"}, #{tools => #{}}, #{}}.
+
+tools(_State) ->
+    [
+        #{
+            name => ~"list_routes",
+            description => ~"List the routes this app serves",
+            input_schema => #{type => ~"object", properties => #{}}
+        }
+    ].
+
+handle_tool(~"list_routes", _Args, _Ctx, State) ->
+    Lines = [io_lib:format("~p ~ts", [Type, Path]) || {Type, Path, _, _} <- my_app:routes()],
+    {reply, iolist_to_binary(lists:join($\n, Lines)), State}.
+```
+
+`handle_tool/4` returns `{reply, Result, State}` (a binary, or a map with `content` /
+`structured_content`) or `{error, Message, State}` for an in-band tool error. The returned `State`
+threads back into the session, so state mutated by one call is visible to the next.
+
+## Mounting it
+
+Add an `mcp` route. For a dev tool, run it in **session mode** (so per-session state, like a REPL's
+bindings, persists across calls) and gate it with the `Origin` allowlist:
+
+```erlang
+{mcp, ~"/mcp", my_mcp, #{
+    sessions => true,
+    origins => [~"http://localhost:4040"]
+}}
+```
+
+The `Origin` check is a DNS-rebinding defense: a request with no `Origin` (a CLI agent) is allowed;
+a browser `Origin` must be in the allowlist. That alone is the reason to keep the gate on even on
+localhost -- it stops a malicious web page from driving your dev MCP server.
+
+### Connecting an agent
+
+```bash
+claude mcp add --transport http my-app-dev http://localhost:4040/mcp
+# or, to explore by hand:
+npx @modelcontextprotocol/inspector
+```
+
+## Introspection tools
+
+The demo exposes a handful, each a thin wrapper over data the running node already has:
+
+- `list_routes` -- `arizona_test_server:routes()` (point this at wherever your app declares routes).
+- `get_docs` -- a module's or function's documentation via `code:get_doc/1` (EEP-48).
+- `app_info` -- `application:get_key/2`, `erlang:system_info/1`.
+- `reloader_status` -- the dev reloader's current compile error via `arizona_reloader:get_error/0`.
+
+## `eval`: powerful, and a footgun
+
+The demo's `eval` tool runs Erlang in the live node and keeps its bindings across calls (a REPL the
+agent drives), by scanning/parsing/evaluating against the session's `erl_eval` bindings:
+
+```erlang
+handle_tool(~"eval", #{~"code" := Code}, _Ctx, #{bindings := Bindings} = State) ->
+    case eval_code(Code, Bindings) of
+        {ok, Value, NewBindings} -> {reply, format_value(Value), State#{bindings := NewBindings}};
+        {error, Message} -> {error, Message, State}
+    end.
+```
+
+This is what makes a dev tool genuinely useful -- the agent can inspect any state and call any
+function. It is also **arbitrary remote code execution**. Only ever mount `eval` on a dev-only,
+localhost route behind the `Origin` allowlist, and never on anything reachable by an untrusted
+client. Running it in session mode means a slow eval runs in the session's worker, so it is
+cancellable and bounded by `request_timeout_ms` rather than wedging the session.
+
+## Route options
+
+All optional, with safe defaults; a route that sets none behaves as a plain stateless MCP server.
+
+| Option | Default | Meaning |
+| ------ | ------- | ------- |
+| `sessions` | `false` | Opt into stateful sessions (`initialize` mints an `Mcp-Session-Id`). |
+| `origins` | `[]` | `Origin` allowlist (no-`Origin` requests are always allowed). |
+| `auth` | none | A per-route auth hook run after the `Origin` check. |
+| `max_sessions` | unbounded | Cap on live sessions for this route; `initialize` past it gets a `503`. |
+| `session_ttl_ms` | `300000` | Idle timeout before an abandoned session is reaped. |
+| `request_timeout_ms` | `60000` | How long a buffered request waits before the client gets a timeout. |
+| `session_max_pending` | `100` | Cap on queued buffered requests per session. |
+| `session_keepalive_ms` | `30000` | SSE keep-alive comment interval (`infinity` disables). |
+| `page_size` | `50` | Page size for `*/list` pagination. |
+
+See [architecture.md](architecture.md) for how the transport, sessions, and dispatch work under the
+hood.

--- a/rebar.config
+++ b/rebar.config
@@ -124,6 +124,7 @@
         {"test/arizona_mcp_e2e_SUITE.erl", [unnecessary_function_arguments]},
         {"test/arizona_mcp_conformance_SUITE.erl", [unnecessary_function_arguments]},
         {"test/arizona_mcp_session_SUITE.erl", [unnecessary_function_arguments]},
+        {"test/arizona_demo_mcp_SUITE.erl", [unnecessary_function_arguments]},
         {"test/arizona_router_SUITE.erl", [unnecessary_function_arguments]},
         {"test/arizona_pubsub_SUITE.erl", [unnecessary_function_arguments]},
         {"test/arizona_reloader_SUITE.erl", [unnecessary_function_arguments]},
@@ -182,7 +183,8 @@
         "CONTRIBUTING.md",
         "LICENSE.md",
         "docs/architecture.md",
-        "docs/native.md"
+        "docs/native.md",
+        "docs/mcp.md"
     ]},
     {main, "README.md"},
     {api_reference, false},

--- a/test/arizona_demo_mcp_SUITE.erl
+++ b/test/arizona_demo_mcp_SUITE.erl
@@ -1,0 +1,82 @@
+-module(arizona_demo_mcp_SUITE).
+-include_lib("stdlib/include/assert.hrl").
+
+-export([all/0]).
+-export([
+    list_routes_lists_mcp_route/1,
+    get_module_docs/1,
+    get_function_docs/1,
+    app_info_reports_version/1,
+    reloader_status_ok/1,
+    eval_returns_value/1,
+    eval_bindings_persist/1,
+    eval_error_is_in_band/1
+]).
+
+all() ->
+    [
+        list_routes_lists_mcp_route,
+        get_module_docs,
+        get_function_docs,
+        app_info_reports_version,
+        reloader_status_ok,
+        eval_returns_value,
+        eval_bindings_persist,
+        eval_error_is_in_band
+    ].
+
+list_routes_lists_mcp_route(_Config) ->
+    {reply, Text, _} = call(~"list_routes", #{}),
+    ?assertMatch({_, _}, binary:match(Text, ~"arizona_demo_mcp")),
+    ?assertMatch({_, _}, binary:match(Text, ~"/mcp")).
+
+get_module_docs(_Config) ->
+    %% The demo module's own moduledoc mentions Tidewave.
+    {reply, Text, _} = call(~"get_docs", #{~"module" => ~"arizona_demo_mcp"}),
+    ?assertMatch({_, _}, binary:match(Text, ~"Tidewave")).
+
+get_function_docs(_Config) ->
+    %% The tool returns a function's docs as non-empty text.
+    Args = #{~"module" => ~"arizona_mcp", ~"function" => ~"progress"},
+    ?assertMatch({reply, Bin, _} when is_binary(Bin) andalso Bin =/= <<>>, call(~"get_docs", Args)).
+
+app_info_reports_version(_Config) ->
+    {reply, Text, _} = call(~"app_info", #{}),
+    ?assertMatch({_, _}, binary:match(Text, ~"arizona")),
+    ?assertMatch({_, _}, binary:match(Text, ~"OTP")).
+
+reloader_status_ok(_Config) ->
+    %% Clear any compile error a prior suite may have left in persistent_term.
+    ok = arizona_reloader:clear_error(),
+    {reply, Text, _} = call(~"reloader_status", #{}),
+    ?assertMatch({_, _}, binary:match(Text, ~"ok")).
+
+eval_returns_value(_Config) ->
+    ?assertMatch({reply, ~"3", _}, call(~"eval", #{~"code" => ~"1 + 2."})).
+
+eval_bindings_persist(_Config) ->
+    %% A binding set in one eval is visible in the next (the session holds them).
+    {reply, _, State1} = eval(~"X = 41.", state()),
+    ?assertMatch({reply, ~"42", _}, eval(~"X + 1.", State1)).
+
+eval_error_is_in_band(_Config) ->
+    %% A parse/runtime failure comes back as an in-band tool error, not a crash.
+    ?assertMatch({error, Bin, _} when is_binary(Bin), call(~"eval", #{~"code" => ~"1 +."})).
+
+%% --------------------------------------------------------------------
+%% Helpers
+%% --------------------------------------------------------------------
+
+state() ->
+    {ok, _Info, _Caps, State} = arizona_demo_mcp:init(#{}),
+    State.
+
+ctx() ->
+    #{token => undefined, to => undefined}.
+
+call(Tool, Args) ->
+    arizona_demo_mcp:handle_tool(Tool, Args, ctx(), state()).
+
+%% Run an eval against a given session state, so a test can thread bindings.
+eval(Code, State) ->
+    arizona_demo_mcp:handle_tool(~"eval", #{~"code" => Code}, ctx(), State).

--- a/test/support/arizona_demo_mcp.erl
+++ b/test/support/arizona_demo_mcp.erl
@@ -1,0 +1,172 @@
+-module(arizona_demo_mcp).
+-moduledoc """
+A worked example MCP server: a dev-time introspection tool for an Arizona app,
+in the spirit of Tidewave. A coding agent connects to it (mounted at `/mcp` in
+`arizona_test_server`) and can ask the running app about itself, then run code
+against it.
+
+Tools:
+
+- `list_routes` -- the routes the dev server serves.
+- `get_docs` -- a module's (or function's) documentation, read from its EEP-48
+  doc chunk.
+- `app_info` -- Arizona version, OTP release, node, process count.
+- `reloader_status` -- the dev reloader's current compile error, if any.
+- `eval` -- **run Erlang in the live node**, with bindings that persist across
+  calls (the session holds them). This is the powerful, Tidewave-style tool, and
+  it is a remote-code-execution surface: only ever mount it on a trusted,
+  dev-only, localhost route behind the `Origin` allowlist. Never expose it.
+
+It runs in **session mode** so `eval`'s bindings carry across calls (a REPL the
+agent drives) and so a slow eval runs in the session's worker without blocking
+the session. Tools-only: `init/1`, `tools/1`, `handle_tool/4` are the only
+callbacks an MCP server must implement.
+""".
+-behaviour(arizona_mcp).
+
+-export([init/1]).
+-export([tools/1]).
+-export([handle_tool/4]).
+
+init(_InitParams) ->
+    {ok, #{name => ~"arizona_dev_tools", version => ~"0.1.0"}, #{tools => #{}}, #{
+        bindings => erl_eval:new_bindings()
+    }}.
+
+tools(_State) ->
+    [
+        #{
+            name => ~"list_routes",
+            description => ~"List the routes the dev server serves",
+            input_schema => #{type => ~"object", properties => #{}}
+        },
+        #{
+            name => ~"get_docs",
+            description => ~"Documentation for a module, or a function within it",
+            input_schema => #{
+                type => ~"object",
+                properties => #{
+                    module => #{type => ~"string"},
+                    function => #{type => ~"string"}
+                },
+                required => [~"module"]
+            }
+        },
+        #{
+            name => ~"app_info",
+            description => ~"Arizona version, OTP release, node, and process count",
+            input_schema => #{type => ~"object", properties => #{}}
+        },
+        #{
+            name => ~"reloader_status",
+            description => ~"The dev reloader's current compile error, if any",
+            input_schema => #{type => ~"object", properties => #{}}
+        },
+        #{
+            name => ~"eval",
+            description => ~"Evaluate Erlang in the live node (dev only); bindings persist",
+            input_schema => #{
+                type => ~"object",
+                properties => #{code => #{type => ~"string"}},
+                required => [~"code"]
+            }
+        }
+    ].
+
+handle_tool(~"list_routes", _Args, _Ctx, State) ->
+    Lines = [format_route(Route) || Route <- arizona_test_server:routes()],
+    {reply, iolist_to_binary(lists:join($\n, Lines)), State};
+handle_tool(~"get_docs", #{~"module" := ModBin} = Args, _Ctx, State) ->
+    Module = binary_to_atom(ModBin),
+    Docs =
+        case Args of
+            #{~"function" := FnBin} -> function_docs(Module, binary_to_atom(FnBin));
+            _ -> module_docs(Module)
+        end,
+    {reply, Docs, State};
+handle_tool(~"app_info", _Args, _Ctx, State) ->
+    {reply, app_info(), State};
+handle_tool(~"reloader_status", _Args, _Ctx, State) ->
+    Status =
+        case arizona_reloader:get_error() of
+            undefined -> ~"ok (no compile error)";
+            Error -> iolist_to_binary(io_lib:format("compile error: ~tp", [Error]))
+        end,
+    {reply, Status, State};
+handle_tool(~"eval", #{~"code" := Code}, _Ctx, #{bindings := Bindings} = State) ->
+    case eval_code(Code, Bindings) of
+        {ok, Value, NewBindings} ->
+            {reply, format_value(Value), State#{bindings := NewBindings}};
+        {error, Message} ->
+            {error, Message, State}
+    end.
+
+%% --------------------------------------------------------------------
+%% Internal functions
+%% --------------------------------------------------------------------
+
+%% A route is `{Type, Path, Handler, _Opts}` (live/controller/mcp) or
+%% `{Type, Path, _}` (ws/asset, no handler module).
+format_route({Type, Path, Handler, _Opts}) when is_atom(Handler) ->
+    io_lib:format("~p ~ts -> ~p", [Type, Path, Handler]);
+format_route({Type, Path, _}) ->
+    io_lib:format("~p ~ts", [Type, Path]).
+
+module_docs(Module) ->
+    case code:get_doc(Module) of
+        {ok, {docs_v1, _, _, _, ModuleDoc, _, _}} ->
+            doc_text(ModuleDoc);
+        {error, Reason} ->
+            iolist_to_binary(io_lib:format("no docs: ~tp", [Reason]))
+    end.
+
+function_docs(Module, Fn) ->
+    case code:get_doc(Module) of
+        {ok, {docs_v1, _, _, _, _, _, Docs}} ->
+            case [doc_text(Doc) || {{function, F, _A}, _, _, Doc, _} <- Docs, F =:= Fn] of
+                [] -> ~"(no documentation for that function)";
+                Texts -> iolist_to_binary(lists:join(~"\n\n", Texts))
+            end;
+        {error, Reason} ->
+            iolist_to_binary(io_lib:format("no docs: ~tp", [Reason]))
+    end.
+
+doc_text(#{<<"en">> := Doc}) -> Doc;
+doc_text(_) -> ~"(no documentation)".
+
+app_info() ->
+    Vsn =
+        case application:get_key(arizona, vsn) of
+            {ok, V} -> V;
+            undefined -> "unknown"
+        end,
+    iolist_to_binary(
+        io_lib:format("arizona ~s, OTP ~s, node ~p, ~p processes", [
+            Vsn,
+            erlang:system_info(otp_release),
+            node(),
+            erlang:system_info(process_count)
+        ])
+    ).
+
+%% Scan/parse/eval the code against the session's persistent bindings. Any
+%% failure (parse or runtime) comes back as an in-band tool error, never a crash.
+eval_code(Code, Bindings) ->
+    try
+        {ok, Tokens, _} = erl_scan:string(ensure_dot(binary_to_list(Code))),
+        {ok, Exprs} = erl_parse:parse_exprs(Tokens),
+        {value, Value, NewBindings} = erl_eval:exprs(Exprs, Bindings),
+        {ok, Value, NewBindings}
+    catch
+        Class:Reason ->
+            {error, iolist_to_binary(io_lib:format("~p: ~tp", [Class, Reason]))}
+    end.
+
+ensure_dot(Str) ->
+    case lists:reverse(string:trim(Str)) of
+        [$. | _] -> Str;
+        _ -> Str ++ "."
+    end.
+
+format_value(Value) ->
+    iolist_to_binary(io_lib:format("~tp", [Value])).

--- a/test/support/arizona_test_server.erl
+++ b/test/support/arizona_test_server.erl
@@ -1,9 +1,18 @@
 -module(arizona_test_server).
--export([start/0, stop/0, port/0]).
+-export([start/0, stop/0, port/0, routes/0]).
 
 start() ->
+    {ok, _} = arizona_roadrunner_server:start(http, #{
+        transport_opts => [{port, port()}],
+        routes => routes()
+    }),
+    ok.
+
+%% The dev server's routes. Exposed so the demo MCP server's `list_routes` tool
+%% can introspect them (see arizona_demo_mcp).
+routes() ->
     Layouts = [{arizona_layout, render}],
-    Routes = [
+    [
         {live, <<"/">>, arizona_page, #{
             bindings => #{title => <<"Welcome">>},
             layouts => Layouts
@@ -90,13 +99,15 @@ start() ->
         {live, <<"/native/removable">>, arizona_native_removable, #{}},
         {live, <<"/native/menu">>, arizona_native_menu, #{}},
         {ws, <<"/ws">>, #{}},
-        {asset, <<"/priv">>, {priv_dir, arizona, "static/assets/js"}}
-    ],
-    {ok, _} = arizona_roadrunner_server:start(http, #{
-        transport_opts => [{port, port()}],
-        routes => Routes
-    }),
-    ok.
+        {asset, <<"/priv">>, {priv_dir, arizona, "static/assets/js"}},
+        %% Dev-introspection MCP server (see arizona_demo_mcp). Session mode so
+        %% the agent's eval bindings persist across calls; CLI agents send no
+        %% Origin (allowed), and the localhost browser origin is allowed too.
+        {mcp, <<"/mcp">>, arizona_demo_mcp, #{
+            sessions => true,
+            origins => [iolist_to_binary([<<"http://localhost:">>, integer_to_binary(port())])]
+        }}
+    ].
 
 stop() ->
     arizona_roadrunner_server:stop(http).


### PR DESCRIPTION
# Description

A worked-example MCP server for dev-time introspection, in the spirit of Tidewave, mounted at `/mcp` in the dev server. A coding agent can list the app's routes, read module and function docs, get app and reloader status, and run Erlang in the live node with bindings that persist across calls. It runs in session mode, so a slow eval runs in the session's worker rather than wedging it.

The `eval` tool is arbitrary remote code execution, so it is mounted only on a dev-only localhost route behind the `Origin` allowlist, and the guide says so loudly. A how-to in `docs/mcp.md` walks through building an MCP server with Arizona (the behaviour, mounting, connecting an agent, the route options).

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
