### PR TITLE
Diff content slots to OP_TEXT so siblings survive a re-render

### DIFF
--- a/.claude/rules/erlang.md
+++ b/.claude/rules/erlang.md
@@ -203,6 +203,16 @@ shared with the live-render-root transform. (This mirrors `?each`, whose callbac
 already accepts bare elements; the difference is that `?each` keys items for per-item
 diffing while a conditional is a single slot.)
 
+A conditional may also return a `?stateful`/`?stateless` descriptor from a branch -- the
+idiomatic `case ?get(flag) of true -> ?stateful(child, #{id => ~"c"}); false -> ~"" end`.
+A content slot is anchored by its `<!--az:X-->...<!--/az-->` comment markers in SSR, so
+any branch value (the empty string, a binary, a nested template, or a child descriptor)
+patches **in place** via `?OP_TEXT`, preserving the slot's siblings and the enclosing
+element. (`arizona_diff:make_op/3` always emits `?OP_TEXT`, never `?OP_UPDATE`, for a
+nested-template value -- an `?OP_UPDATE` would `innerHTML`-overwrite the enclosing element,
+which is catastrophic when the slot's `az` is that element's own `az`, e.g. a conditional
+child rendered directly under the view root.)
+
 **Known limitation:** embedding a component (a `?stateless`/`?stateful` descriptor) as an
 `?each` item child compiles and renders at SSR but **crashes on the first diff** -- the
 per-item diff keys a list item by `to_bin` of its first dynamic, which fails on a nested

--- a/.claude/rules/erlang.md
+++ b/.claude/rules/erlang.md
@@ -213,6 +213,18 @@ nested-template value -- an `?OP_UPDATE` would `innerHTML`-overwrite the enclosi
 which is catastrophic when the slot's `az` is that element's own `az`, e.g. a conditional
 child rendered directly under the view root.)
 
+The same rule applies to a **plain-list `?each` in a content slot**: it is marker-anchored
+exactly like any other dynamic-text child (no wrapper element carries the slot `az`), so its
+container patch is the marker-aware `?OP_TEXT` -- `make_op/3` (the `?EACH` list clause) and
+`arizona_diff:full_update/5` emit `?OP_TEXT`, never `?OP_UPDATE`. This is what lets a
+plain-list `?each` sit **among static sibling content** in one slot: re-rendering the list
+replaces only the each's marker span, leaving the siblings intact. An `?OP_UPDATE` here would
+`innerHTML`-wipe the enclosing element's static siblings (the client's `resolveEl` finds no
+element for the slot `az` and falls back to that enclosing element); a sole-child `?each` only
+appeared to work with `?OP_UPDATE` by coincidence. (Stream `?each` -- the `order`-keyed clause
+-- still uses `?OP_UPDATE` for its container full-render and `az-key`-addressed incremental
+ops; the unkeyed plain-list marker rule does not apply to it.)
+
 **Known limitation:** embedding a component (a `?stateless`/`?stateful` descriptor) as an
 `?each` item child compiles and renders at SSR but **crashes on the first diff** -- the
 per-item diff keys a list item by `to_bin` of its first dynamic, which fails on a nested

--- a/assets/js/arizona.test.js
+++ b/assets/js/arizona.test.js
@@ -273,6 +273,209 @@ describe('applyOps -- OP.UPDATE', () => {
 });
 
 // ---------------------------------------------------------------------------
+// 6b. Regression: a plain-list ?each among static siblings in one content slot.
+//
+// SSR anchors the each by `<!--az:strip:2-->...<!--/az-->` comment markers
+// between sibling element children -- there is NO element carrying az="strip:2".
+// resolveEl('v:strip:2') therefore finds no element, strips the trailing
+// ":<slot>" and falls back to the enclosing element az="strip". The container
+// op MUST be the marker-aware OP.TEXT (replace marker content); OP.UPDATE writes
+// innerHTML on the fallback element and wipes the static sibling .item divs.
+// Mirrors arizona_diff_SUITE:diff_each_among_siblings_uses_text_op.
+// ---------------------------------------------------------------------------
+
+describe('applyOps -- plain-list each among static siblings', () => {
+    // SSR shape: two static .item divs, then a marker-delimited each slot, all
+    // direct children of <div class="strip" az="strip">.
+    const stripHtml = (eachContent) =>
+        '<div class="strip" az="strip">' +
+        '<div class="item" az="strip:0"><!--az:strip:0-->A<!--/az--></div>' +
+        '<div class="item" az="strip:1"><!--az:strip:1-->B<!--/az--></div>' +
+        `<!--az:strip:2-->${eachContent}<!--/az-->` +
+        '</div>';
+
+    it('OP.TEXT preserves static siblings across toggle on->off->on', () => {
+        setupView('v', stripHtml(''));
+        const strip = document.querySelector('.strip');
+        const itemHtml = (k) => `<div class="item" az="strip:2:0"><span>${k}</span></div>`;
+
+        // toggle ON: [] -> [k1]
+        applyOps([[OP.TEXT, 'v:strip:2', itemHtml('k1')]]);
+        // static siblings survive
+        expect(strip.querySelectorAll('.item').length).toBe(3);
+        expect(strip.children[0].textContent).toBe('A');
+        expect(strip.children[1].textContent).toBe('B');
+        expect(strip.querySelector('[az="strip:2:0"]').textContent).toBe('k1');
+
+        // toggle OFF: [k1] -> []
+        applyOps([[OP.TEXT, 'v:strip:2', '']]);
+        expect(strip.querySelectorAll('.item').length).toBe(2);
+        expect(strip.children[0].textContent).toBe('A');
+        expect(strip.children[1].textContent).toBe('B');
+
+        // toggle ON again: [] -> [k2]
+        applyOps([[OP.TEXT, 'v:strip:2', itemHtml('k2')]]);
+        expect(strip.querySelectorAll('.item').length).toBe(3);
+        expect(strip.children[0].textContent).toBe('A');
+        expect(strip.children[1].textContent).toBe('B');
+        expect(strip.querySelector('[az="strip:2:0"]').textContent).toBe('k2');
+    });
+
+    it('OP.UPDATE (the old buggy op) clobbers the static siblings', () => {
+        // Documents the failure mode the diff fix avoids: with no element
+        // carrying az="strip:2", resolveEl falls back to the .strip element and
+        // innerHTML wipes the static .item siblings.
+        setupView('v', stripHtml(''));
+        const strip = document.querySelector('.strip');
+        applyOps([
+            [OP.UPDATE, 'v:strip:2', '<div class="item" az="strip:2:0"><span>k1</span></div>'],
+        ]);
+        // Only the each item remains; the two static siblings are gone.
+        expect(strip.querySelectorAll('.item').length).toBe(1);
+        expect(strip.textContent).toBe('k1');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// 6c. Type switch: an `arizona_stream` binding becomes a plain list (and back).
+//
+// The only path where the plain-list OP_TEXT change touches streams. SSR anchors
+// BOTH a stream each and a plain-list each by the same `<!--az:X-->...<!--/az-->`
+// content-slot markers (arizona_html:text_slot_open/1; verified against real
+// arizona_render output). A stream addresses its visible items by `az-key`
+// ELEMENT children; the comment markers are never the target of a stream op
+// (insert/remove/move/patch all query `:scope > [az-key]`), so the marker
+// survives every incremental mutation.
+//
+// When the binding switches stream -> list, arizona_diff routes
+// diff_list/4 -> full_update/5 -> OP_TEXT (op code 0). OP_TEXT's handler
+// (applyTextOp -> updateMarkerContent) finds the surviving `<!--az:X-->` marker
+// and replaces ONLY the span between the markers: the list renders as real
+// elements (NOT escaped text) and any static siblings of the slot survive.
+//
+// The reverse (list -> stream) stays on OP_UPDATE (innerHTML on the resolved
+// container), which is correct when the stream each is the addressable element
+// (sole child of its container). Mirrors arizona_stream_SUITE:
+// list_type_switch_stream_to_list / list_type_switch_list_to_stream.
+// ---------------------------------------------------------------------------
+
+describe('applyOps -- stream <-> plain-list type switch', () => {
+    // Real SSR shape for a stream each that is the SOLE child of <ul az="0">:
+    // the slot az ("0") coincides with the <ul>'s az, so resolveEl('v:0')
+    // returns the <ul> and the keyed <li>s live between its markers.
+    const ssrStreamSole = (items) =>
+        '<ul az="0"><!--az:0-->' +
+        items.map((t) => `<li az="i" az-key="${t}"><!--az:i-->${t}<!--/az--></li>`).join('') +
+        '<!--/az--></ul>';
+
+    // Real SSR shape for a stream each among static siblings: the static <span>
+    // carries az="strip:0", the each slot is the marker pair az="strip:1" with
+    // NO element carrying that az (resolveEl falls back to the .strip element).
+    const ssrStreamAmongSiblings = (items) =>
+        '<div class="strip" az="strip">' +
+        '<span az="strip:0"><!--az:strip:0-->S<!--/az--></span>' +
+        '<!--az:strip:1-->' +
+        items.map((t) => `<li az="i" az-key="${t}"><!--az:i-->${t}<!--/az--></li>`).join('') +
+        '<!--/az--></div>';
+
+    const listItem = (t) => `<li az="L"><!--az:L-->${t}<!--/az--></li>`;
+
+    /** True if `el` has a direct-child comment marker `az:<az>` (the slot anchor). */
+    const hasMarker = (el, az) =>
+        Array.from(el.childNodes).some((n) => n.nodeType === 8 && n.data === `az:${az}`);
+
+    it('SSR anchors a stream each by the same content-slot marker as a list', () => {
+        setupView('v', ssrStreamSole(['1']));
+        const ul = document.querySelector('ul');
+        // The marker is a direct child of the container after SSR (Q1).
+        expect(hasMarker(ul, '0')).toBe(true);
+        // The keyed item is a real element between the markers.
+        expect(ul.querySelector('[az-key="1"]').textContent).toBe('1');
+    });
+
+    it('stream insert/remove/move never delete the slot marker (Q2)', () => {
+        setupView('v', ssrStreamSole(['1']));
+        const ul = document.querySelector('ul');
+        applyOps([
+            [OP.INSERT, 'v:0', '2', -1, '<li az="i" az-key="2"><!--az:i-->2<!--/az--></li>'],
+        ]);
+        expect(hasMarker(ul, '0')).toBe(true);
+        applyOps([[OP.MOVE, 'v:0', '2', null]]);
+        expect(hasMarker(ul, '0')).toBe(true);
+        applyOps([[OP.REMOVE, 'v:0', '1']]);
+        // Marker still present after the full mutation sequence.
+        expect(hasMarker(ul, '0')).toBe(true);
+    });
+
+    it('stream -> list (no runtime mutation) renders real HTML, not escaped text', () => {
+        setupView('v', ssrStreamSole(['1', '2']));
+        const ul = document.querySelector('ul');
+        // Switch the binding stream -> list: diff emits OP_TEXT on the slot.
+        applyOps([[OP.TEXT, 'v:0', listItem('X') + listItem('Y')]]);
+        // Rendered as REAL <li> elements (escaped text would be 0 elements).
+        const lis = ul.querySelectorAll('li');
+        expect(lis.length).toBe(2);
+        expect(lis[0].textContent).toBe('X');
+        expect(lis[1].textContent).toBe('Y');
+        // Crucially NOT escaped: the raw "<li" markup must not survive as text.
+        expect(ul.textContent).not.toContain('<li');
+        // Marker preserved for subsequent diffs.
+        expect(hasMarker(ul, '0')).toBe(true);
+    });
+
+    it('stream -> list switch keeps static siblings of the slot (Q3)', () => {
+        setupView('v', ssrStreamAmongSiblings(['1']));
+        const strip = document.querySelector('.strip');
+        // Switch stream -> list via the marker-aware OP_TEXT.
+        applyOps([[OP.TEXT, 'v:strip:1', listItem('X')]]);
+        // The static <span> sibling survives (the OP_UPDATE fallback would wipe it).
+        expect(strip.querySelector('[az="strip:0"]')).not.toBeNull();
+        expect(strip.querySelector('[az="strip:0"]').textContent).toBe('S');
+        // The list item rendered as a real element inside the marker.
+        const li = strip.querySelector('[az="L"]');
+        expect(li).not.toBeNull();
+        expect(li.textContent).toBe('X');
+    });
+
+    it('stream -> list after a runtime insert still renders the list as real HTML', () => {
+        // A runtime-inserted keyed item lands after <!--/az--> (insertItemEl
+        // appends to the container). The subsequent stream->list OP_TEXT replaces
+        // the marker span correctly -- the NEW list is real HTML inside the
+        // markers and the static sibling survives -- even though the prior
+        // runtime-inserted item is left as an orphan after the closing marker.
+        // This orphan is the separate "stream among siblings" concern tracked in
+        // docs/architecture.md, not an OP_TEXT regression.
+        setupView('v', ssrStreamAmongSiblings(['1']));
+        const strip = document.querySelector('.strip');
+        applyOps([
+            [OP.INSERT, 'v:strip:1', '2', -1, '<li az="i" az-key="2"><!--az:i-->2<!--/az--></li>'],
+        ]);
+        applyOps([[OP.TEXT, 'v:strip:1', listItem('X')]]);
+        // Static sibling intact and the list slot holds the real list element.
+        expect(strip.querySelector('[az="strip:0"]').textContent).toBe('S');
+        const slotLi = strip.querySelector('[az="L"]');
+        expect(slotLi).not.toBeNull();
+        expect(slotLi.textContent).toBe('X');
+        // Real elements, not escaped text.
+        expect(strip.innerHTML).toContain('<li az="L"');
+    });
+
+    it('reverse list -> stream stays correct for a sole-child each (OP_UPDATE)', () => {
+        // SSR plain-list each, sole child of <ul az="0"> (resolveEl returns the
+        // <ul>, which IS the slot element). list -> stream emits OP_UPDATE.
+        setupView('v', '<ul az="0"><!--az:0-->' + listItem('A') + '<!--/az--></ul>');
+        const ul = document.querySelector('ul');
+        applyOps([[OP.UPDATE, 'v:0', '<li az="i" az-key="1"><!--az:i-->X<!--/az--></li>']]);
+        // Now keyed-by az-key, addressable by stream ops; renders real HTML.
+        expect(ul.querySelector('[az-key="1"]').textContent).toBe('X');
+        applyOps([
+            [OP.INSERT, 'v:0', '2', -1, '<li az="i" az-key="2"><!--az:i-->Y<!--/az--></li>'],
+        ]);
+        expect(ul.querySelectorAll('[az-key]').length).toBe(2);
+    });
+});
+
+// ---------------------------------------------------------------------------
 // 7. applyOps -- OP.REMOVE_NODE
 // ---------------------------------------------------------------------------
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -998,18 +998,52 @@ map appears in the `Changed` map (via `maps:intersect`). If none do, the dynamic
 
 ## Op codes
 
-| Code | Name             | Args                       | Description                                       |
-| ---- | ---------------- | -------------------------- | ------------------------------------------------- |
-| 0    | `OP_TEXT`        | `[target, value]`          | Update text node                                  |
-| 1    | `OP_SET_ATTR`    | `[target, attr, value]`    | Set attribute                                     |
-| 2    | `OP_REM_ATTR`    | `[target, attr]`           | Remove attribute                                  |
-| 3    | `OP_UPDATE`      | `[target, html]`           | innerHTML replacement (diff engine)               |
-| 4    | `OP_REMOVE_NODE` | `[target]`                 | Remove element                                    |
-| 5    | `OP_INSERT`      | `[target, key, pos, html]` | Stream insert (pos=-1 -> append, otherwise index) |
-| 6    | `OP_REMOVE`      | `[target, key]`            | Stream remove                                     |
-| 7    | `OP_ITEM_PATCH`  | `[target, key, innerOps]`  | Stream item patch                                 |
-| 8    | `OP_REPLACE`     | `[target, html]`           | outerHTML replacement (navigate)                  |
-| 9    | `OP_MOVE`        | `[target, key, afterKey]`  | Stream move (afterKey=null -> prepend)            |
+| Code | Name             | Args                       | Description                                            |
+| ---- | ---------------- | -------------------------- | ------------------------------------------------------ |
+| 0    | `OP_TEXT`        | `[target, value]`          | Replace marker content (text, nested tmpl, plain each) |
+| 1    | `OP_SET_ATTR`    | `[target, attr, value]`    | Set attribute                                          |
+| 2    | `OP_REM_ATTR`    | `[target, attr]`           | Remove attribute                                       |
+| 3    | `OP_UPDATE`      | `[target, html]`           | innerHTML replacement (stream container full render)   |
+| 4    | `OP_REMOVE_NODE` | `[target]`                 | Remove element                                         |
+| 5    | `OP_INSERT`      | `[target, key, pos, html]` | Stream insert (pos=-1 -> append, otherwise index)      |
+| 6    | `OP_REMOVE`      | `[target, key]`            | Stream remove                                          |
+| 7    | `OP_ITEM_PATCH`  | `[target, key, innerOps]`  | Stream item patch                                      |
+| 8    | `OP_REPLACE`     | `[target, html]`           | outerHTML replacement (navigate)                       |
+| 9    | `OP_MOVE`        | `[target, key, afterKey]`  | Stream move (afterKey=null -> prepend)                 |
+
+A content-slot dynamic -- a value, a nested template, *or a plain-list `?each`* -- is anchored
+by `<!--az:X-->...<!--/az-->` comment markers in SSR (no wrapper element carries the slot `az`),
+so its diff patch is the marker-aware `OP_TEXT`: it replaces only the span between the markers,
+leaving the slot's static siblings and the enclosing element intact. `OP_UPDATE` (innerHTML on
+the resolved element) is reserved for the **stream** `?each` container full render, where the
+container is the addressable element and items carry `az-key` for incremental ops. Emitting
+`OP_UPDATE` for a marker-anchored slot is a bug: the client's `resolveEl` finds no element for
+the slot `az`, falls back to the enclosing element, and innerHTML clobbers its siblings. See
+`arizona_diff`'s `make_op/3` (the `?EACH` list clause vs. the `order`-keyed stream clause) and
+`full_update/5`.
+
+The **stream -> list** type switch is consistent with this: a binding that was an
+`arizona_stream` and becomes a plain list routes through `diff_list/4 -> full_update/5 -> OP_TEXT`,
+which replaces only the surviving marker span -- so the list renders as real HTML and the slot's
+siblings survive. The stream's keyed `az-key` items are element children, and stream ops
+(insert/remove/move/patch query `:scope > [az-key]`) never delete the comment markers, so the
+marker is still present at switch time.
+
+**Known limitation -- the stream `?each` container is not yet marker-anchored for incremental
+ops.** Two consequences, both independent of the `OP_TEXT` content-slot fix:
+
+- **list -> stream among static siblings:** the reverse switch stays on `OP_UPDATE`, which is
+  correct only when the stream each is the addressable element (its slot `az` is the enclosing
+  element, i.e. the each is the sole child of its container). When a stream each shares a content
+  slot with static siblings, `OP_UPDATE` falls back to the enclosing element and clobbers them --
+  the same class of bug the plain-list `OP_TEXT` change fixed for lists.
+- **runtime-inserted item orphaned on stream -> list:** `insertItemEl` appends keyed children to
+  the container element, which places a runtime-inserted item *after* the closing `<!--/az-->`
+  marker. A subsequent stream -> list `OP_TEXT` correctly re-renders the marker span but leaves
+  that orphan behind.
+
+The fix for both is to anchor stream items between the slot markers (and make stream
+insert/move marker-relative), tracked as a follow-up.
 
 ## Target scoping
 

--- a/e2e/parallel/arizona_mixed_children.spec.js
+++ b/e2e/parallel/arizona_mixed_children.spec.js
@@ -7,9 +7,6 @@ import { expect, test } from '@playwright/test';
 const wsReady = (page) =>
     page.waitForFunction(() => document.documentElement.classList.contains('az-connected'));
 
-/** The parent view root. */
-const _view = (page) => page.locator('#mixed[az-view]');
-
 /** The stateless card child (inside section.left). */
 const card = (page) => page.locator('#mixed section.left > div');
 
@@ -27,6 +24,20 @@ const showBtn = (page) => page.locator(`#mixed button[az-click*='"show"']`);
 const hideBtn = (page) => page.locator(`#mixed button[az-click*='"hide"']`);
 
 const updateCardBtn = (page) => page.locator(`#mixed button[az-click*='"update_card"']`);
+
+const toggleRowsBtn = (page) => page.locator(`#mixed button[az-click*='"toggle_rows"']`);
+
+/** The strip holding two static .item siblings + a plain-list each. */
+const strip = (page) => page.locator('#mixed .strip');
+
+const stripStaticA = (page) => page.locator('#mixed .strip .static-a');
+
+const stripStaticB = (page) => page.locator('#mixed .strip .static-b');
+
+const stripEachItems = (page) => page.locator('#mixed .strip .each-item');
+
+/** The sole-child each control. */
+const refsItems = (page) => page.locator('#mixed .refs .ref-item');
 
 // ---------------------------------------------------------------------------
 // SSR -- initial render
@@ -217,5 +228,85 @@ test.describe('Mixed children -- combined operations', () => {
         await showBtn(page).click();
         await expect(rackSection(page)).toHaveClass('rack present');
         await expect(messagePara(page)).toHaveText('Showing: World');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Plain-list each among static siblings -- the OP_TEXT regression scenario
+//
+// .strip holds two static .item siblings (static-a, static-b) sharing the
+// content slot with a plain-list ?each(rows). Toggling rows on/off must patch
+// only the each's marker span; the two static .item siblings must survive every
+// toggle. The pre-fix OP_UPDATE wrote innerHTML on the resolved-by-fallback
+// .strip element and wiped the static siblings.
+// ---------------------------------------------------------------------------
+
+test.describe('Mixed children -- plain-list each among static siblings', () => {
+    test('SSR: static siblings present, each empty', async ({ page }) => {
+        await page.goto('/mixed');
+        await expect(stripStaticA(page)).toHaveText('A');
+        await expect(stripStaticB(page)).toHaveText('B');
+        await expect(stripEachItems(page)).toHaveCount(0);
+    });
+
+    test('toggle on: each items appear, static siblings survive', async ({ page }) => {
+        await page.goto('/mixed');
+        await wsReady(page);
+        await toggleRowsBtn(page).click();
+        await expect(stripEachItems(page)).toHaveCount(2);
+        // The two static siblings must still be present and unchanged.
+        await expect(stripStaticA(page)).toHaveText('A');
+        await expect(stripStaticB(page)).toHaveText('B');
+        await expect(strip(page).locator('.item')).toHaveCount(4);
+    });
+
+    test('toggle on->off->on: static siblings survive every cycle', async ({ page }) => {
+        await page.goto('/mixed');
+        await wsReady(page);
+        // on
+        await toggleRowsBtn(page).click();
+        await expect(stripEachItems(page)).toHaveCount(2);
+        await expect(stripStaticA(page)).toHaveText('A');
+        await expect(stripStaticB(page)).toHaveText('B');
+        // off
+        await toggleRowsBtn(page).click();
+        await expect(stripEachItems(page)).toHaveCount(0);
+        await expect(stripStaticA(page)).toHaveText('A');
+        await expect(stripStaticB(page)).toHaveText('B');
+        // on again
+        await toggleRowsBtn(page).click();
+        await expect(stripEachItems(page)).toHaveCount(2);
+        await expect(stripStaticA(page)).toHaveText('A');
+        await expect(stripStaticB(page)).toHaveText('B');
+    });
+
+    test('each item content renders correctly', async ({ page }) => {
+        await page.goto('/mixed');
+        await wsReady(page);
+        await toggleRowsBtn(page).click();
+        await expect(stripEachItems(page).first().locator('.k')).toHaveText('k1');
+        await expect(stripEachItems(page).first().locator('.v')).toHaveText('v1');
+        await expect(stripEachItems(page).nth(1).locator('.k')).toHaveText('k2');
+        await expect(stripEachItems(page).nth(1).locator('.v')).toHaveText('v2');
+    });
+
+    test('control: sole-child each (.refs) toggles correctly', async ({ page }) => {
+        await page.goto('/mixed');
+        await wsReady(page);
+        await expect(refsItems(page)).toHaveCount(0);
+        await toggleRowsBtn(page).click();
+        await expect(refsItems(page)).toHaveCount(2);
+        await toggleRowsBtn(page).click();
+        await expect(refsItems(page)).toHaveCount(0);
+    });
+
+    test('toggling rows does not affect the card, rack, or message', async ({ page }) => {
+        await page.goto('/mixed');
+        await wsReady(page);
+        await toggleRowsBtn(page).click();
+        await expect(card(page)).toHaveClass('card');
+        await expect(cardSpan(page)).toHaveText('Initial');
+        await expect(rackSection(page)).toHaveClass('rack absent');
+        await expect(messagePara(page)).toHaveText('Hello');
     });
 });

--- a/rebar.config
+++ b/rebar.config
@@ -154,6 +154,7 @@
         {"test/support/arizona_native_menu.erl", [unnecessary_function_arguments]},
         {"test/support/arizona_bench_chain_a.erl", [unnecessary_function_arguments]},
         {"test/support/arizona_transitions.erl", [unnecessary_function_arguments]},
+        {"test/support/arizona_conditional_child.erl", [unnecessary_function_arguments]},
         {"include/arizona_effect.hrl", [single_use_hrl_attrs]},
         {"include/arizona_stateful.hrl", [single_use_hrl_attrs]},
         {"include/arizona_common.hrl", [unused_macros, single_use_hrl_attrs]},

--- a/src/arizona_diff.erl
+++ b/src/arizona_diff.erl
@@ -25,7 +25,10 @@ op codes:
 A `?each` over a **plain list** is unkeyed: its items render as bare HTML
 with no `az-key`, so there is no per-item DOM address to patch. Any change
 (item content or list length) therefore re-renders the whole list with a
-single `?OP_UPDATE`; an unchanged list emits nothing.
+single `?OP_TEXT` patching the slot's `<!--az:X-->...<!--/az-->` marker
+content; an unchanged list emits nothing. (`?OP_TEXT`, not `?OP_UPDATE`: a
+plain-list each is marker-anchored in a content slot, so innerHTML on the
+fallback enclosing element would clobber the slot's static siblings.)
 
 Use an `arizona_stream` when you need **keyed, incremental** updates --
 per-item `?OP_ITEM_PATCH`/`?OP_INSERT`/`?OP_REMOVE`/`?OP_MOVE` and stable
@@ -472,7 +475,7 @@ diff_list(Az, #{source := Items, template := Tmpl}, #{items := OldItemsList}, Vi
             %% content or length change re-renders the whole list: a plain list
             %% is unkeyed (no per-item `az-key` to address -- that is what
             %% `arizona_stream` is for), so the only correct patch is a single
-            %% `?OP_UPDATE` of the container's content.
+            %% full render of the container's marker content.
             case {Changed, NewTail, OldTail} of
                 {false, [], []} ->
                     {[], NewSnap, Views2};
@@ -481,9 +484,14 @@ diff_list(Az, #{source := Items, template := Tmpl}, #{items := OldItemsList}, Vi
             end
     end.
 
+%% A plain-list `?each` is marker-anchored in a content slot (no wrapper element
+%% carries the slot az), so the full re-render patches the marker content via
+%% `?OP_TEXT` -- never `?OP_UPDATE` (innerHTML), which clobbers the slot's static
+%% siblings when resolveEl falls back to the enclosing element. Mirrors the
+%% `make_op/3` plain-list each clause and the nested-template content-slot fix.
 full_update(Az, Tmpl, NewItemsList, NewSnap, Views) ->
     HTML = arizona_render:zip_list_fp(Tmpl, NewItemsList),
-    {[[?OP_UPDATE, Az, HTML]], NewSnap, Views}.
+    {[[?OP_TEXT, Az, HTML]], NewSnap, Views}.
 
 %% Walk new/old item dynamics in lockstep to detect whether any item changed and
 %% to thread child views through. Returns `Changed` plus the leftover tails, so
@@ -758,10 +766,25 @@ make_op(_Az, #{view_id := VId, s := S, d := NewD}, #{view_id := _, s := S, d := 
 %% `case ?get(flag) of true -> ?stateful(...); false -> ~"" end` produces.
 make_op(Az, #{s := _, d := _} = NewNested, _Old) ->
     [?OP_TEXT, Az, arizona_render:zip_or_fp(NewNested)];
+%% A plain-list `?each` in a content slot is anchored by the slot's
+%% `<!--az:X-->...<!--/az-->` comment markers, exactly like the nested-template
+%% case above (every dynamic-text child is marker-wrapped in SSR -- see
+%% arizona_html:text_slot_open/1). There is no wrapper element carrying
+%% `az="X"`, so `?OP_TEXT` (replace marker content) is correct and `?OP_UPDATE`
+%% (innerHTML) is wrong: when the each sits among static siblings, the client's
+%% resolveEl finds no element for the slot az and falls back to the enclosing
+%% element, where innerHTML wipes every sibling. The marker is present whether
+%% or not the each is the sole child, so `?OP_TEXT` is uniformly correct (the
+%% old sole-child each only "worked" with `?OP_UPDATE` by coincidence).
 make_op(Az, #{t := ?EACH, items := Items, template := Tmpl}, _Old) when
     is_list(Items)
 ->
-    [?OP_UPDATE, Az, arizona_render:zip_list_fp(Tmpl, Items)];
+    [?OP_TEXT, Az, arizona_render:zip_list_fp(Tmpl, Items)];
+%% Stream (`order`-keyed) each: kept on `?OP_UPDATE` for the container-level
+%% full render. Streams address items by `az-key` for incremental ops and are
+%% used as a list container's content -- the unkeyed plain-list marker fix does
+%% not apply; an analogous mixed-siblings concern for streams is tracked
+%% separately (see docs/architecture.md).
 make_op(Az, #{t := ?EACH, items := Items, order := Order, template := Tmpl}, _Old) ->
     [?OP_UPDATE, Az, arizona_render:zip_stream_fp(Tmpl, Items, Order)];
 make_op(Az, remove, {attr, Attr, _}) ->

--- a/src/arizona_diff.erl
+++ b/src/arizona_diff.erl
@@ -746,10 +746,18 @@ make_op(Az, {attr, Attr, Val}, _Old) ->
     [?OP_SET_ATTR, Az, Attr, arizona_template:to_bin(Val)];
 make_op(_Az, #{view_id := VId, s := S, d := NewD}, #{view_id := _, s := S, d := OldD}) ->
     [VId, diff_child_dynamics(NewD, OldD)];
-make_op(Az, #{s := _, d := _} = NewNested, #{s := _, d := _}) ->
+%% A nested template/snapshot in a content slot is always anchored by the
+%% slot's `<!--az:X-->...<!--/az-->` comment markers, whatever the slot held
+%% before (a binary, the empty string, or another template). `?OP_TEXT`
+%% replaces only the marker content, leaving the slot's siblings -- and the
+%% enclosing element -- intact. `?OP_UPDATE` (innerHTML) would be wrong: when
+%% the slot's `Az` is the enclosing element's own `az` (a conditional
+%% `?stateful` child rendered directly under the view root), it overwrites the
+%% whole element and drops every sibling. That is the empty(`~""`) ->
+%% descriptor transition the idiomatic
+%% `case ?get(flag) of true -> ?stateful(...); false -> ~"" end` produces.
+make_op(Az, #{s := _, d := _} = NewNested, _Old) ->
     [?OP_TEXT, Az, arizona_render:zip_or_fp(NewNested)];
-make_op(Az, #{s := _, d := _} = Tmpl, _Old) ->
-    [?OP_UPDATE, Az, arizona_render:zip_or_fp(Tmpl)];
 make_op(Az, #{t := ?EACH, items := Items, template := Tmpl}, _Old) when
     is_list(Items)
 ->

--- a/test/arizona_SUITE.erl
+++ b/test/arizona_SUITE.erl
@@ -798,7 +798,7 @@ list_render_v(Config) when is_list(Config) ->
     ).
 
 list_diff_same_length(Config) when is_list(Config) ->
-    %% Same count, changed values → single OP_UPDATE (plain lists re-render whole)
+    %% Same count, changed values → single OP_TEXT (plain lists re-render whole)
     Items1 = [#{id => 1, text => <<"A">>}, #{id => 2, text => <<"B">>}],
     Items2 = [#{id => 1, text => <<"X">>}, #{id => 2, text => <<"B">>}],
     Bindings0 = #{id => <<"test">>, items => Items1},
@@ -841,9 +841,10 @@ list_diff_same_length(Config) when is_list(Config) ->
     {Ops, _Snap1, _V1} = arizona_diff:diff(Tmpl1, Snap0, V0, Changed),
     %% Plain lists are unkeyed and re-render whole on any change (keyed
     %% incremental per-item updates are arizona_stream's job), so a same-length
-    %% content change is a single OP_UPDATE.
+    %% content change is a single marker-aware OP_TEXT (opcode 0) -- not
+    %% OP_UPDATE, which would innerHTML-clobber the slot's static siblings.
     ?assertEqual(1, length(Ops)),
-    [[3, <<"0">>, _HTML]] = Ops.
+    [[0, <<"0">>, _HTML]] = Ops.
 
 list_diff_same_length_no_change(Config) when is_list(Config) ->
     %% Same count, same values → no ops
@@ -889,7 +890,7 @@ list_diff_same_length_no_change(Config) when is_list(Config) ->
     ?assertEqual([], Ops).
 
 list_diff_different_length(Config) when is_list(Config) ->
-    %% Different count → single OP_UPDATE
+    %% Different count → single OP_TEXT
     Items1 = [#{id => 1, text => <<"A">>}, #{id => 2, text => <<"B">>}],
     Items2 = [
         #{id => 1, text => <<"A">>},
@@ -934,9 +935,9 @@ list_diff_different_length(Config) when is_list(Config) ->
         f => <<"test">>
     },
     {Ops, _Snap1, _V1} = arizona_diff:diff(Tmpl1, Snap0, V0, Changed),
-    %% Length mismatch → single OP_UPDATE (opcode 3)
+    %% Length mismatch → single OP_TEXT (opcode 0)
     ?assertEqual(1, length(Ops)),
-    [[3, <<"0">>, _HTML]] = Ops.
+    [[0, <<"0">>, _HTML]] = Ops.
 
 list_ssr(Config) when is_list(Config) ->
     %% SSR with list comprehension
@@ -1042,7 +1043,7 @@ list_empty(Config) when is_list(Config) ->
     ?assertEqual(<<"<ul az=\"0\"></ul>">>, iolist_to_binary(HTML)).
 
 list_diff_empty_to_populated(Config) when is_list(Config) ->
-    %% [] → [a, b] -- length mismatch → OP_UPDATE
+    %% [] → [a, b] -- length mismatch → OP_TEXT
     ListTmpl = #{
         t => 0,
         s => [
@@ -1083,10 +1084,10 @@ list_diff_empty_to_populated(Config) when is_list(Config) ->
     },
     {Ops, _Snap1, _V1} = arizona_diff:diff(Tmpl1, Snap0, V0, Changed),
     ?assertEqual(1, length(Ops)),
-    [[3, <<"0">>, _HTML]] = Ops.
+    [[0, <<"0">>, _HTML]] = Ops.
 
 list_diff_populated_to_empty(Config) when is_list(Config) ->
-    %% [a, b] → [] -- length mismatch → OP_UPDATE
+    %% [a, b] → [] -- length mismatch → OP_TEXT
     Items1 = [#{id => 1, text => <<"A">>}, #{id => 2, text => <<"B">>}],
     ListTmpl = #{
         t => 0,
@@ -1127,10 +1128,10 @@ list_diff_populated_to_empty(Config) when is_list(Config) ->
     },
     {Ops, _Snap1, _V1} = arizona_diff:diff(Tmpl1, Snap0, V0, Changed),
     ?assertEqual(1, length(Ops)),
-    [[3, <<"0">>, _HTML]] = Ops.
+    [[0, <<"0">>, _HTML]] = Ops.
 
 list_diff_shorter(Config) when is_list(Config) ->
-    %% [a, b, c] → [a, b] -- length decrease → OP_UPDATE
+    %% [a, b, c] → [a, b] -- length decrease → OP_TEXT
     Items1 = [
         #{id => 1, text => <<"A">>},
         #{id => 2, text => <<"B">>},
@@ -1176,7 +1177,7 @@ list_diff_shorter(Config) when is_list(Config) ->
     },
     {Ops, _Snap1, _V1} = arizona_diff:diff(Tmpl1, Snap0, V0, Changed),
     ?assertEqual(1, length(Ops)),
-    [[3, <<"0">>, _HTML]] = Ops.
+    [[0, <<"0">>, _HTML]] = Ops.
 
 list_diff_deps_skip(Config) when is_list(Config) ->
     %% diff/4 with unchanged deps skips list eval entirely
@@ -1223,7 +1224,7 @@ list_diff_deps_skip(Config) when is_list(Config) ->
 
 list_diff2(Config) when is_list(Config) ->
     %% diff/2 path -- tests make_op fix for EACH snapshots
-    %% diff/2 has no EACH-aware path, so make_op emits OP_UPDATE
+    %% diff/2 has no EACH-aware path, so make_op emits the marker-aware OP_TEXT
     Items1 = [#{id => 1, text => <<"A">>}],
     Items2 = [#{id => 1, text => <<"X">>}],
     ListTmpl = #{
@@ -1261,13 +1262,13 @@ list_diff2(Config) when is_list(Config) ->
         f => <<"test">>
     },
     {Ops, _Snap1} = arizona_diff:diff(Tmpl1, Snap0),
-    %% diff/2 falls through to make_op → OP_UPDATE (opcode 3)
+    %% diff/2 falls through to make_op → OP_TEXT (opcode 0)
     ?assertEqual(1, length(Ops)),
-    [[3, <<"0">>, _HTML]] = Ops.
+    [[0, <<"0">>, _HTML]] = Ops.
 
 list_diff3(Config) when is_list(Config) ->
     %% diff/3 path -- tests make_op fix via views path
-    %% diff/3 has no EACH-aware path, so make_op emits OP_UPDATE
+    %% diff/3 has no EACH-aware path, so make_op emits the marker-aware OP_TEXT
     Items1 = [#{id => 1, text => <<"A">>}],
     Items2 = [#{id => 1, text => <<"X">>}],
     ListTmpl = #{
@@ -1305,9 +1306,9 @@ list_diff3(Config) when is_list(Config) ->
         f => <<"test">>
     },
     {Ops, _Snap1, _V1} = arizona_diff:diff(Tmpl1, Snap0, #{}),
-    %% diff/3 falls through to make_op → OP_UPDATE (opcode 3)
+    %% diff/3 falls through to make_op → OP_TEXT (opcode 0)
     ?assertEqual(1, length(Ops)),
-    [[3, <<"0">>, _HTML]] = Ops.
+    [[0, <<"0">>, _HTML]] = Ops.
 
 %% =============================================================================
 %% Mixed stateless + dynamic children
@@ -1413,6 +1414,10 @@ mixed_children_roundtrip(Config) when is_list(Config) ->
         )
     ).
 
+%% An each payload (`t` => EACH): `d` is a list of per-item dynamics-lists, each
+%% zipped against the shared item statics `s`.
+mixed_render_html(#{<<"t">> := 0, <<"s">> := S, <<"d">> := Items}) ->
+    [arizona_render:zip(S, [mixed_render_html(X) || X <- ItemD]) || ItemD <- Items];
 mixed_render_html(#{<<"f">> := _, <<"s">> := S, <<"d">> := D}) ->
     arizona_render:zip(S, [mixed_render_html(X) || X <- D]);
 mixed_render_html(#{<<"f">> := _, <<"d">> := D}) ->

--- a/test/arizona_diff_SUITE.erl
+++ b/test/arizona_diff_SUITE.erl
@@ -15,6 +15,7 @@
     diff_only_changed_emits_ops/1,
     diff_remove_node_op/1,
     diff_replace_with_template_op/1,
+    diff_empty_to_template_uses_text_op/1,
     diff_list_content_change_full_update/1,
     diff_list_first_item_change_full_update/1,
     diff_list_grew_full_update/1,
@@ -43,6 +44,7 @@ groups() ->
             diff_mixed_op,
             diff_remove_node_op,
             diff_replace_with_template_op,
+            diff_empty_to_template_uses_text_op,
             diff_list_content_change_full_update,
             diff_list_first_item_change_full_update,
             diff_list_grew_full_update,
@@ -216,13 +218,18 @@ diff_remove_node_op(Config) when is_list(Config) ->
     {Ops, _} = arizona_diff:diff(NewTmpl, OldSnap),
     ?assertEqual([[?OP_REMOVE_NODE, <<"0">>]], Ops).
 
+%% A content slot whose value changes from a plain binary to a nested template
+%% patches the slot's marker content with ?OP_TEXT -- never ?OP_UPDATE
+%% (innerHTML), which would clobber the enclosing element when the slot's az is
+%% the element's own az. See diff_empty_to_template_uses_text_op for the
+%% empty(~"") -> ?stateful descriptor case this protects.
 diff_replace_with_template_op(Config) when is_list(Config) ->
     OldSnap = #{
-        s => [<<"<div az=\"0\">">>, <<"</div>">>],
+        s => [<<"<div az=\"0\"><!--az:0-->">>, <<"<!--/az--></div>">>],
         d => [{<<"0">>, <<"plain">>}]
     },
     NewTmpl = #{
-        s => [<<"<div az=\"0\">">>, <<"</div>">>],
+        s => [<<"<div az=\"0\"><!--az:0-->">>, <<"<!--/az--></div>">>],
         d => [
             {<<"0">>, fun() ->
                 #{s => [<<"<b>">>, <<"</b>">>], d => [{<<"i">>, <<"bold">>}], f => <<"test">>}
@@ -234,7 +241,7 @@ diff_replace_with_template_op(Config) when is_list(Config) ->
     ?assertEqual(
         [
             [
-                ?OP_UPDATE,
+                ?OP_TEXT,
                 <<"0">>,
                 #{
                     <<"f">> => <<"test">>,
@@ -245,6 +252,42 @@ diff_replace_with_template_op(Config) when is_list(Config) ->
         ],
         Ops
     ).
+
+%% Regression: a content slot transitioning from the empty string (`~""`) to a
+%% nested template -- the shape `case ?get(flag) of true -> ?stateful(...);
+%% false -> ~"" end` produces -- must patch the slot's marker content via
+%% ?OP_TEXT, leaving its siblings (and the enclosing element) intact. The bug
+%% was emitting ?OP_UPDATE here, whose innerHTML write clobbered the whole
+%% enclosing element when the slot's az equalled the element's own az (a
+%% conditional ?stateful child directly under the view root).
+diff_empty_to_template_uses_text_op(Config) when is_list(Config) ->
+    %% Statics model: <main az="X-0" id="app"><h1>..</h1><!--az:X-0-->SLOT
+    %% <!--/az--><footer>..</footer></main> -- the slot's az (X-0) is the same
+    %% as the enclosing <main>'s az, exactly as a view root + conditional child.
+    Statics = [
+        <<"<main az=\"X-0\" id=\"app\"><h1 az=\"X-1\">t</h1><!--az:X-0-->">>,
+        <<"<!--/az--><footer az=\"X-2\">f</footer></main>">>
+    ],
+    OldSnap = #{
+        s => Statics,
+        d => [{<<"X-1">>, <<"t">>}, {<<"X-0">>, <<>>}, {<<"X-2">>, <<"f">>}]
+    },
+    NewTmpl = #{
+        s => Statics,
+        d => [
+            {<<"X-1">>, fun() -> <<"t">> end},
+            {<<"X-0">>, fun() ->
+                #{s => [<<"<div>child</div>">>], d => [], f => <<"child_fp">>}
+            end},
+            {<<"X-2">>, fun() -> <<"f">> end}
+        ],
+        f => <<"X">>
+    },
+    {Ops, _} = arizona_diff:diff(NewTmpl, OldSnap),
+    %% Exactly one op, an ?OP_TEXT on the slot -- not an ?OP_UPDATE on X-0
+    %% (which the client resolves to the <main> root and would innerHTML-wipe).
+    ?assertMatch([[?OP_TEXT, <<"X-0">>, #{<<"f">> := <<"child_fp">>}]], Ops),
+    ?assertNotMatch([[?OP_UPDATE, <<"X-0">>, _]], Ops).
 
 %% Plain-list `?each` diffing: any change re-renders the whole list with a
 %% single OP_UPDATE -- never a per-item OP_ITEM_PATCH (plain lists are unkeyed,

--- a/test/arizona_diff_SUITE.erl
+++ b/test/arizona_diff_SUITE.erl
@@ -21,6 +21,8 @@
     diff_list_grew_full_update/1,
     diff_list_shrank_full_update/1,
     diff_list_no_change_no_ops/1,
+    diff_each_among_siblings_uses_text_op/1,
+    diff_each_among_siblings_to_empty_uses_text_op/1,
     diff_text_op/1,
     no_diff_diff3/1,
     no_diff_diff4_top_level/1,
@@ -50,6 +52,8 @@ groups() ->
             diff_list_grew_full_update,
             diff_list_shrank_full_update,
             diff_list_no_change_no_ops,
+            diff_each_among_siblings_uses_text_op,
+            diff_each_among_siblings_to_empty_uses_text_op,
             diff_only_changed_emits_ops,
             diff_bool_attr_add,
             diff_bool_attr_remove,
@@ -290,9 +294,12 @@ diff_empty_to_template_uses_text_op(Config) when is_list(Config) ->
     ?assertNotMatch([[?OP_UPDATE, <<"X-0">>, _]], Ops).
 
 %% Plain-list `?each` diffing: any change re-renders the whole list with a
-%% single OP_UPDATE -- never a per-item OP_ITEM_PATCH (plain lists are unkeyed,
-%% so there is no `az-key` to patch). Regression for the "stream item az-key=...
-%% not found for patch" bug. These cover every boolean branch of the diff:
+%% single OP_TEXT (the marker-aware container patch) -- never a per-item
+%% OP_ITEM_PATCH (plain lists are unkeyed, so there is no `az-key` to patch).
+%% Regression for the "stream item az-key=... not found for patch" bug. OP_TEXT
+%% (not OP_UPDATE) because a plain-list each is anchored by content-slot comment
+%% markers; see diff_each_among_siblings_uses_text_op. These cover every boolean
+%% branch of the diff:
 %%   diff_list_zip:  InnerOps =/= [] (head)  |  RestChanged (tail)  |  neither
 %%   diff_list:      Changed  |  NewTail =/= [] (grew)  |  OldTail =/= [] (shrank)
 
@@ -320,12 +327,13 @@ each_list_diff(Old, New) ->
     {Ops, _Snap, _Views} = arizona_diff:diff(NewTmpl, OldSnap, #{}, #{names => true}),
     Ops.
 
-%% Assert exactly one OP_UPDATE (full re-render), no per-item OP_ITEM_PATCH, and
-%% return the rendered item-dynamics list from the (fingerprinted) payload.
+%% Assert exactly one OP_TEXT (full marker-aware re-render), no per-item
+%% OP_ITEM_PATCH, and return the rendered item-dynamics list from the
+%% (fingerprinted) payload.
 assert_full_update(Ops) ->
-    ?assertMatch([[?OP_UPDATE, <<"0">>, #{<<"t">> := ?EACH}]], Ops),
+    ?assertMatch([[?OP_TEXT, <<"0">>, #{<<"t">> := ?EACH}]], Ops),
     ?assertEqual([], [Op || Op <- Ops, hd(Op) =:= ?OP_ITEM_PATCH]),
-    [[?OP_UPDATE, <<"0">>, #{<<"d">> := ItemDs}]] = Ops,
+    [[?OP_TEXT, <<"0">>, #{<<"d">> := ItemDs}]] = Ops,
     ItemDs.
 
 %% Last item's content changes: head item unchanged (InnerOps == []) so the
@@ -358,6 +366,89 @@ diff_list_shrank_full_update(Config) when is_list(Config) ->
 diff_list_no_change_no_ops(Config) when is_list(Config) ->
     Items = [#{name => <<"a">>}, #{name => <<"b">>}],
     ?assertEqual([], each_list_diff(Items, Items)).
+
+%% Regression: a plain-list `?each` sitting *among static sibling content* in the
+%% same content slot. SSR anchors the each by its `<!--az:X-->...<!--/az-->`
+%% comment markers (like every dynamic-text child) -- there is NO wrapper element
+%% carrying `az="X"`. So the container op must be the marker-aware ?OP_TEXT: the
+%% client's resolveEl can't find an element for the each's marker az and falls
+%% back to the *enclosing* element, where ?OP_UPDATE's innerHTML would wipe the
+%% static sibling content. The mixed-siblings shape is what breaks; a sole-child
+%% each only "works" with ?OP_UPDATE by coincidence (the fallback element is the
+%% right one). diff_each_among_siblings_to_empty_uses_text_op covers the reverse
+%% (non-empty -> []) toggle. Build the snapshot/template with sibling dynamics
+%% before the each so the each's az is a marker slot distinct from the parent.
+
+%% Diff a plain-list `?each` placed after two static sibling dynamics (the
+%% sibling dynamics are unchanged, so only the each should emit an op). The each
+%% transitions `Old` -> `New`. Returns the full op list.
+each_among_siblings_diff(Old, New) ->
+    ItemTmpl = #{
+        t => ?EACH,
+        s => [<<"<div class=\"item\" az=\"strip:2:0\"><span>">>, <<"</span></div>">>],
+        d => fun(I) -> [{<<"strip:2:0">>, maps:get(name, I)}] end,
+        f => <<"item">>
+    },
+    {OldItems, _} = arizona_eval:render_list_items(Old, ItemTmpl, {#{}, #{}}),
+    %% Statics model:
+    %%   <div class="strip" az="strip">
+    %%     <div class="item" az="strip:0"><!--az:strip:0-->A<!--/az--></div>
+    %%     <div class="item" az="strip:1"><!--az:strip:1-->B<!--/az--></div>
+    %%     <!--az:strip:2-->EACH<!--/az-->
+    %%   </div>
+    %% The each's az (strip:2) is a marker slot, NOT any element's own az.
+    Statics = [
+        <<"<div class=\"strip\" az=\"strip\">",
+            "<div class=\"item\" az=\"strip:0\"><!--az:strip:0-->">>,
+        <<"<!--/az--></div><div class=\"item\" az=\"strip:1\"><!--az:strip:1-->">>,
+        <<"<!--/az--></div><!--az:strip:2-->">>,
+        <<"<!--/az--></div>">>
+    ],
+    OldSnap = #{
+        s => Statics,
+        d => [
+            {<<"strip:0">>, <<"A">>},
+            {<<"strip:1">>, <<"B">>},
+            {<<"strip:2">>, #{t => ?EACH, items => OldItems, template => ItemTmpl}}
+        ],
+        deps => [#{a => true}, #{b => true}, #{rows => true}],
+        f => <<"strip">>
+    },
+    NewTmpl = #{
+        s => Statics,
+        d => [
+            {<<"strip:0">>, fun() -> <<"A">> end},
+            {<<"strip:1">>, fun() -> <<"B">> end},
+            {<<"strip:2">>, fun() -> arizona_template:each(New, ItemTmpl) end, {m, 1}}
+        ],
+        f => <<"strip">>
+    },
+    {Ops, _Snap, _Views} = arizona_diff:diff(NewTmpl, OldSnap, #{}, #{rows => true}),
+    Ops.
+
+%% `[]` -> non-empty: the each must patch its marker slot via ?OP_TEXT, never
+%% ?OP_UPDATE (which would innerHTML-wipe the static sibling .item divs). The
+%% unchanged sibling dynamics (strip:0/strip:1) must emit no ops.
+diff_each_among_siblings_uses_text_op(Config) when is_list(Config) ->
+    Ops = each_among_siblings_diff([], [#{name => <<"k">>}]),
+    ?assertMatch([[?OP_TEXT, <<"strip:2">>, #{<<"t">> := ?EACH}]], Ops),
+    ?assertNotMatch([[?OP_UPDATE, <<"strip:2">>, _]], Ops),
+    %% Siblings untouched: no op targets strip:0 or strip:1.
+    ?assertEqual(
+        [],
+        [Op || Op <- Ops, lists:member(lists:nth(2, Op), [<<"strip:0">>, <<"strip:1">>])]
+    ),
+    [[?OP_TEXT, <<"strip:2">>, #{<<"d">> := ItemDs}]] = Ops,
+    ?assertEqual([[<<"k">>]], ItemDs).
+
+%% non-empty -> `[]`: the reverse toggle must also use ?OP_TEXT (clearing only
+%% the marker content), leaving the static siblings intact.
+diff_each_among_siblings_to_empty_uses_text_op(Config) when is_list(Config) ->
+    Ops = each_among_siblings_diff([#{name => <<"k">>}], []),
+    ?assertMatch([[?OP_TEXT, <<"strip:2">>, #{<<"t">> := ?EACH}]], Ops),
+    ?assertNotMatch([[?OP_UPDATE, <<"strip:2">>, _]], Ops),
+    [[?OP_TEXT, <<"strip:2">>, #{<<"d">> := ItemDs}]] = Ops,
+    ?assertEqual([], ItemDs).
 
 diff_only_changed_emits_ops(Config) when is_list(Config) ->
     OldSnap = #{

--- a/test/arizona_live_SUITE.erl
+++ b/test/arizona_live_SUITE.erl
@@ -55,6 +55,7 @@
     live_navigate_carries_root_bindings/1,
     live_page_child_mount/1,
     live_parent_change_child_stable/1,
+    live_conditional_child_toggle_patches_slot/1,
     live_parent_event_updates_children/1,
     mount_and_render_basic/1,
     mount_and_render_custom_bindings/1,
@@ -113,6 +114,7 @@ groups() ->
             live_child_multiple_events,
             live_parent_event_updates_children,
             live_parent_change_child_stable,
+            live_conditional_child_toggle_patches_slot,
             live_child_then_parent_sync,
             live_counter2_child_event,
             live_inc_then_dec,
@@ -372,6 +374,43 @@ live_parent_change_child_stable(Config) when is_list(Config) ->
     %% Change parent title -- counter deps (count) unchanged, no counter ops
     {ok, Ops, []} = arizona_live:handle_event(Pid, <<"page">>, <<"title_change">>, #{}),
     ?assertMatch([[?OP_TEXT, _, <<"Changed">>]], Ops).
+
+%% Regression: a conditional `?stateful` in a content slot, toggled from the
+%% empty string to the child descriptor, must patch only the slot via ?OP_TEXT
+%% -- never ?OP_UPDATE on the slot's az, which the client resolves to the
+%% enclosing element (when the slot's az is that element's own az, as for a
+%% conditional child directly under the view root) and innerHTML-wipes, taking
+%% every sibling with it. This is the `case ?get(flag) of true ->
+%% ?stateful(...); false -> ~"" end` pattern.
+live_conditional_child_toggle_patches_slot(Config) when is_list(Config) ->
+    {ok, Pid} = arizona_live:start_link(
+        arizona_conditional_child, #{}, undefined, []
+    ),
+    {ok, _} = arizona_live:mount(Pid),
+    %% Toggle false -> true: the child appears. Exactly one ?OP_TEXT on the
+    %% slot, carrying the child template -- not an ?OP_UPDATE (which would
+    %% clobber the <main> root and drop <header>/<footer>).
+    {ok, ShowOps, []} = arizona_live:handle_event(Pid, <<"app">>, <<"toggle">>, #{}),
+    ?assertMatch([[?OP_TEXT, _, #{<<"s">> := _, <<"d">> := _}]], ShowOps),
+    [[_Op, SlotAz, _Payload]] = ShowOps,
+    %% No op may be an ?OP_UPDATE -- that is the bug's signature.
+    ?assertEqual(
+        [], [Op || [Op | _] <- ShowOps, Op =:= ?OP_UPDATE]
+    ),
+    %% Toggle true -> false: the child is removed via an empty ?OP_TEXT on the
+    %% same slot, leaving the siblings in place.
+    {ok, HideOps, []} = arizona_live:handle_event(Pid, <<"app">>, <<"toggle">>, #{}),
+    ?assertMatch([[?OP_TEXT, SlotAz, <<>>]], HideOps),
+    %% Toggle on again: the child re-mounts via the same single ?OP_TEXT slot
+    %% patch. The payload is fingerprint-deduped (statics omitted, the client
+    %% has them cached from the first show), so only `f`/`d` are present.
+    {ok, ReshowOps, []} = arizona_live:handle_event(Pid, <<"app">>, <<"toggle">>, #{}),
+    ?assertMatch([[?OP_TEXT, SlotAz, #{<<"f">> := _, <<"d">> := _}]], ReshowOps),
+    %% The re-mounted child is a live view again: its own event drives a diff on
+    %% the child, proving the Views accounting survives the off/on cycle (no
+    %% leaked or dropped child view).
+    {ok, ChildOps, []} = arizona_live:handle_event(Pid, <<"child">>, <<"inc">>, #{}),
+    ?assertMatch([[?OP_TEXT, _, <<"1">>]], ChildOps).
 
 live_child_then_parent_sync(Config) when is_list(Config) ->
     %% KEY EDGE CASE: child increments to 2, then parent adds +1.

--- a/test/arizona_stream_SUITE.erl
+++ b/test/arizona_stream_SUITE.erl
@@ -3266,7 +3266,9 @@ insert_after(Key, Ref, [Ref | T]) -> [Ref, Key | T];
 insert_after(Key, Ref, [H | T]) -> [H | insert_after(Key, Ref, T)].
 
 list_type_switch_stream_to_list(Config) when is_list(Config) ->
-    %% Old was a stream, new is a plain list → OP_UPDATE
+    %% Old was a stream, new is a plain list → marker-aware OP_TEXT (a plain-list
+    %% each is anchored by content-slot comment markers, so the container patch
+    %% is OP_TEXT, not OP_UPDATE).
     KeyFun = fun(#{id := Id}) -> Id end,
     Stream0 = arizona_stream:new(KeyFun, [#{id => 1, text => <<"A">>}]),
     StreamTmpl = #{
@@ -3311,7 +3313,7 @@ list_type_switch_stream_to_list(Config) when is_list(Config) ->
     },
     {Ops, _Snap1, _V1} = arizona_diff:diff(Tmpl1, Snap0, V0, Changed),
     ?assertEqual(1, length(Ops)),
-    [[3, <<"0">>, _HTML]] = Ops.
+    [[0, <<"0">>, _HTML]] = Ops.
 
 list_type_switch_list_to_stream(Config) when is_list(Config) ->
     %% Old was a plain list, new is a stream → OP_UPDATE

--- a/test/support/arizona_conditional_child.erl
+++ b/test/support/arizona_conditional_child.erl
@@ -1,0 +1,39 @@
+-module(arizona_conditional_child).
+-moduledoc """
+Parent view that toggles a `?stateful` child in a content slot.
+
+Models the idiomatic `case ?get(flag) of true -> ?stateful(...); false ->
+~"" end` pattern: a stateful root with stable sibling elements before and
+after a conditional child slot. At mount the flag is `false`, so the slot
+renders the empty string; a `toggle` event flips it `true`, mounting the
+child. The diff of that transition must patch only the slot (an ?OP_TEXT on
+the marker content), leaving every sibling -- and the root element -- intact.
+""".
+-include("arizona_stateful.hrl").
+-export([mount/1, render/1, handle_event/3]).
+
+-spec mount(az:bindings()) -> az:mount_ret().
+mount(Init) ->
+    Bindings = #{
+        id => maps:get(id, Init, ~"app"),
+        show => false
+    },
+    {Bindings, #{}}.
+
+-spec render(az:bindings()) -> az:template().
+render(Bindings) ->
+    ?html(
+        {main, [{id, ?get(id)}], [
+            {header, [], [~"Header"]},
+            case ?get(show) of
+                true -> ?stateful(arizona_counter, #{id => ~"child", count => 0});
+                false -> ~""
+            end,
+            {footer, [], [~"Footer"]}
+        ]}
+    ).
+
+-spec handle_event(az:event_name(), az:event_payload(), az:bindings()) ->
+    az:handle_event_ret().
+handle_event(~"toggle", _Payload, Bindings) ->
+    {Bindings#{show => not maps:get(show, Bindings, false)}, #{}, []}.

--- a/test/support/arizona_mixed_children.erl
+++ b/test/support/arizona_mixed_children.erl
@@ -19,10 +19,19 @@
 %%       DYN_TEXT                             <- content(arizona:get(data))
 %%     </section>
 %%     <p az="M">DYN_TEXT</p>               <- arizona:get(message)
+%%     <div class="strip">                  <- mixed siblings + plain-list each
+%%       <div class="item static-a">...</div>
+%%       <div class="item static-b">...</div>
+%%       <!--az:STRIP-->EACH<!--/az-->        <- ?each(rows): must use OP_TEXT so
+%%     </div>                                    the static .item siblings survive
+%%     <div class="refs">                   <- sole-child each control
+%%       <!--az:REFS-->EACH<!--/az-->          <- ?each(rows): still correct
+%%     </div>
 %%     <div class="actions">
 %%       <button az-click="show" ...>Show</button>
 %%       <button az-click="hide">Hide</button>
 %%       <button az-click="update_card" ...>Update Card</button>
+%%       <button az-click="toggle_rows">Toggle Rows</button>
 %%     </div>
 %%   </div>
 
@@ -35,7 +44,10 @@ mount(_Bindings) ->
             data => undefined,
             card_class => ~"card",
             card_label => ~"Initial",
-            message => ~"Hello"
+            message => ~"Hello",
+            a => ~"A",
+            b => ~"B",
+            rows => []
         },
         #{}
     }.
@@ -55,6 +67,35 @@ render(Bindings) ->
                 content(?get(data))
             ]},
             {p, [], [?get(message)]},
+            %% Mixed siblings: two static-ish .item divs (dynamic text inside)
+            %% sharing the content slot with a plain-list ?each. Toggling `rows`
+            %% must patch only the each's marker span; the static .item siblings
+            %% must survive. Before the OP_TEXT fix, the each emitted OP_UPDATE
+            %% which innerHTML-wiped the strip's static siblings.
+            {'div', [{class, ~"strip"}], [
+                {'div', [{class, ~"item static-a"}], [{span, [], [?get(a)]}]},
+                {'div', [{class, ~"item static-b"}], [{span, [], [?get(b)]}]},
+                ?each(
+                    fun(#{k := K, v := V}) ->
+                        {'div', [{class, ~"item each-item"}], [
+                            {span, [{class, ~"k"}], [K]}, {span, [{class, ~"v"}], [V]}
+                        ]}
+                    end,
+                    ?get(rows)
+                )
+            ]},
+            %% Sole-child control: the each is the only child of .refs, so the
+            %% slot az coincides with the parent. Must keep working after the fix.
+            {'div', [{class, ~"refs"}], [
+                ?each(
+                    fun(#{k := K, v := V}) ->
+                        {'div', [{class, ~"ref-item"}], [
+                            {span, [], [K]}, {span, [], [V]}
+                        ]}
+                    end,
+                    ?get(rows)
+                )
+            ]},
             {'div', [{class, ~"actions"}], [
                 {button, [{az_click, arizona_js:push_event(~"show", #{~"text" => ~"World"})}],
                     ~"Show"},
@@ -66,7 +107,8 @@ render(Bindings) ->
                                 ~"class" => ~"card-updated", ~"label" => ~"Updated"
                             })}
                     ],
-                    ~"Update Card"}
+                    ~"Update Card"},
+                {button, [{az_click, arizona_js:push_event(~"toggle_rows")}], ~"Toggle Rows"}
             ]}
         ]}
     ).
@@ -103,6 +145,13 @@ handle_event(~"hide", _Payload, Bindings) ->
     };
 handle_event(~"update_card", #{~"class" := C, ~"label" := L}, Bindings) ->
     {Bindings#{card_class => C, card_label => L}, #{}, []};
+handle_event(~"toggle_rows", _Payload, Bindings) ->
+    Rows =
+        case maps:get(rows, Bindings) of
+            [] -> [#{k => ~"k1", v => ~"v1"}, #{k => ~"k2", v => ~"v2"}];
+            _ -> []
+        end,
+    {Bindings#{rows => Rows}, #{}, []};
 handle_event(~"connected", _Payload, Bindings) ->
     {Bindings, #{}, []}.
 


### PR DESCRIPTION
# Description

A content-slot nested template (an `?OP_UPDATE` conditional `?stateful` child) or a plain-list `?each` re-rendered with `?OP_UPDATE`, which runs `innerHTML` on the enclosing element when the slot's `az` has no element of its own, wiping the slot's static siblings. Both now diff to `?OP_TEXT`, patching only the slot's `<!--az:X-->...<!--/az-->` marker content and leaving siblings (and the root) intact.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
