### PR TITLE
Allow a local named-function reference as an ?each callback

### DIFF
--- a/.claude/rules/erlang.md
+++ b/.claude/rules/erlang.md
@@ -148,16 +148,28 @@ Adding `'az-nodiff'` to an element's attribute list marks it as a compile-time d
 `?each` compiles each item into a per-item template (`#{s, d, f}`) for fine-grained diffing
 (insert/move/update). So the callback's body must be an **element** (`{Tag, Attrs, Children}`),
 a list of elements, or a static/mixed fragment. A bare value, a runtime binary, an `?html(...)`
-call, a `?stateful`/`?stateless` descriptor, a `case`/`if`, or a `fun name/arity` reference
-compiles to one opaque value slot. A scalar value renders and diffs (keyed by content) but
-gets no per-item diffing -- a comprehension is the right tool; a template or descriptor value
-goes further and **crashes on the first diff** (`bad_template_value`, when `to_bin/1` hits the
-stored template/descriptor). A template or descriptor wrapped in a bare list (`[?stateless(...)]`)
-is the same trap. The parse transform rejects all of these at compile time
-(`each_body_not_element` / `each_fun_ref_not_allowed`). A 2-arg (stream/map) callback is
-rejected the same way but with `each_stream_body_not_element`: a stream/map keys each item for
-per-item diffing and has **no comprehension fallback**, so the body must be an element (wrap the
-value: `fun(Item, Key) -> {li, [], [Item]} end`).
+call, a `?stateful`/`?stateless` descriptor, or a `case`/`if` compiles to one opaque value
+slot. A scalar value renders and diffs (keyed by content) but gets no per-item diffing -- a
+comprehension is the right tool; a template or descriptor value goes further and **crashes on
+the first diff** (`bad_template_value`, when `to_bin/1` hits the stored template/descriptor). A
+template or descriptor wrapped in a bare list (`[?stateless(...)]`) is the same trap. The parse
+transform rejects all of these at compile time (`each_body_not_element`). A 2-arg (stream/map)
+callback is rejected the same way but with `each_stream_body_not_element`: a stream/map keys
+each item for per-item diffing and has **no comprehension fallback**, so the body must be an
+element (wrap the value: `fun(Item, Key) -> {li, [], [Item]} end`).
+
+The callback may be an inline fun **or a local single-clause function reference** (`fun row/1`,
+or `fun row/2` for a stream/map): the parse transform resolves the reference to the function's
+body and inlines it exactly like an anonymous fun, so the **same** element-body rules apply (a
+non-element body still raises `each_body_not_element`/`each_stream_body_not_element`). The named
+function's now-orphaned definition is covered by auto-injected `nowarn_unused_function` /
+`-ignore_xref`, so it needn't be exported or otherwise used. A **same-module** explicit ref
+(`fun ?MODULE:row/1`) resolves to the local body just like `fun row/1`. Rejected: a
+**genuinely remote** reference (`fun other_mod:row/1`, or a variable module `fun M:row/1` --
+body not visible to inline, `each_remote_fun_ref`), an **imported** function used as a bare
+`fun row/1` (its body lives in another module, so it isn't found -- `each_named_fun_undefined`),
+and a **multi-clause** function (can't map to one shared per-item template,
+`each_named_fun_multi_clause`; collapse the clauses into a `case` inside the returned element).
 
 - Plain values: use a list comprehension or `lists:map/2` (no per-item diffing, fine for
   small or static lists).
@@ -170,6 +182,9 @@ value: `fun(Item, Key) -> {li, [], [Item]} end`).
 ?each(fun(U) -> case U of #{name := N} -> ?html({li,[],N}); _ -> ~"-" end end, ?get(users))
 %% ok: the conditional is a child of a stable element
 ?each(fun(U) -> {li, [], [case U of #{name := N} -> N; _ -> ~"-" end]} end, ?get(users))
+%% ok: a local single-clause named fun, resolved and inlined (same element-body rules)
+row(U) -> {li, [], [case U of #{name := N} -> N; _ -> ~"-" end]}.
+?each(fun row/1, ?get(users))
 %% plain values: a comprehension, not ?each
 {ul, [], [[<<"#", Tag/binary>> || Tag <- ?get(tags)]]}
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -330,12 +330,26 @@ template/descriptor and raises `bad_template_value`. So `compile_each` rejects a
 `text_dynamic` body (`each_body_not_element` for a 1-arg/list callback,
 `each_stream_body_not_element` for a 2-arg/stream-or-map callback -- the two differ only in fix
 advice, since a list has a comprehension fallback and a stream/map, keyed per item, does not)
-and a fun reference (`each_fun_ref_not_allowed`, its return can't be inspected) at compile
-time. It also rejects a bare list whose item is a
+at compile time. It also rejects a bare list whose item is a
 template or descriptor (`[?html(...)]`, `[?stateless(...)]`) -- the item lands in the same
 fragile value slot -- while keeping a list of elements or a static/dynamic-text fragment.
 Map plain values with a list comprehension / `lists:map` (no per-item diffing); put a
 conditional inside an element child (`{li, [], [case ... end]}`).
+
+The callback may be an inline fun **or a local single-clause function reference** (`fun row/1`,
+or `fun row/2` for a stream/map). `compile_each` looks the function up in the module's forms
+(`collect_fun_defs/1`) and inlines its clause through the same path, so the identical body rules
+apply (a non-element body still raises `each_body_not_element`/`each_stream_body_not_element`).
+Inlining orphans the named function, so `parse_transform/2` injects
+`-compile({nowarn_unused_function, ...})` and `-ignore_xref(...)` for the consumed pairs --
+the function needn't be exported or otherwise used. A **same-module** explicit ref
+(`fun ?MODULE:row/1`, module literal = the current module) is rewritten to the bare local form
+and resolved identically. Rejected: a **genuinely remote** reference (`each_remote_fun_ref` --
+another module's, or a variable module, body isn't visible to inline; an `-import`ed function
+referenced as a bare `fun row/1` falls through to `each_named_fun_undefined` since it isn't in
+`FunDefs`) and a **multi-clause** function (`each_named_fun_multi_clause` -- clauses would select
+different per-item structures, but there is only one shared per-item template); collapse
+multiple clauses into a `case` inside the returned element.
 
 A per-item **component** (`{li, [], [?stateless(...)]}`) compiles and renders but currently
 **crashes on the first diff**: the list-each diff in `arizona_diff` (`diff_list_zip/4`) keys a

--- a/src/arizona_parse_transform.erl
+++ b/src/arizona_parse_transform.erl
@@ -136,13 +136,85 @@ parse_transform(Forms, _Options) ->
     File = extract_file(Forms),
     Module = extract_module(Forms),
     IsLive = has_behaviour(Forms, arizona_stateful),
+    FunDefs = collect_fun_defs(Forms),
     try
-        Transformed = [transform_form(mark_targets(Form, none), Module, IsLive) || Form <- Forms],
-        erl_syntax:revert_forms(Transformed)
+        Transformed = [
+            transform_form(mark_targets(Form, none), Module, IsLive, FunDefs)
+         || Form <- Forms
+        ],
+        WithSuppressions = inject_each_callback_suppressions(Transformed, Forms, FunDefs, Module),
+        erl_syntax:revert_forms(WithSuppressions)
     catch
         throw:{arizona_parse_error, Line, Reason} ->
             {error, [{File, [{Line, ?MODULE, Reason}]}], []}
     end.
+
+%% Map every `{Name, Arity}` to its clause list, so a `?each(fun Name/Arity, _)`
+%% callback can be resolved to its body and inlined like an anonymous fun.
+collect_fun_defs(Forms) ->
+    #{{Name, Arity} => Clauses || {function, _, Name, Arity, Clauses} <- Forms}.
+
+%% A local `fun Name/Arity` ?each callback is inlined into the per-item template, so
+%% the function loses its only reference. Suppress the resulting unused-function
+%% warning (compiler, under warnings_as_errors) and xref finding (locals_not_used /
+%% exports_not_used) by injecting -compile(nowarn_unused_function) and -ignore_xref
+%% attributes for the consumed pairs. A no-op when the function is also used elsewhere.
+inject_each_callback_suppressions(Forms, OrigForms, FunDefs, Module) ->
+    case collect_each_callback_pairs(OrigForms, FunDefs, Module) of
+        [] ->
+            Forms;
+        Pairs ->
+            insert_suppression_attrs(Forms, Pairs)
+    end.
+
+%% Scan the original forms (pre-mark_targets, so every ?each is still spelled `each`
+%% -- mark_targets only renames nested each to native_each/terminal_each and never
+%% touches the fun argument) for local `fun Name/Arity` (and same-module
+%% `fun ?MODULE:Name/Arity`) callbacks. Returns the deduped pairs defined in this module.
+collect_each_callback_pairs(Forms, FunDefs, Module) ->
+    Pairs = each_callback_pairs(Forms, #{}, Module),
+    [Pair || Pair := _ <- Pairs, is_map_key(Pair, FunDefs)].
+
+each_callback_pairs(
+    {call, _, {remote, _, {atom, _, Mod}, {atom, _, each}}, [Callback | _]} = Node, Acc, Module
+) when
+    Mod =:= arizona_template; Mod =:= az
+->
+    Acc1 =
+        case each_callback_pair(Callback, Module) of
+            {ok, Pair} -> Acc#{Pair => true};
+            none -> Acc
+        end,
+    each_callback_pairs(tuple_to_list(Node), Acc1, Module);
+each_callback_pairs(Node, Acc, Module) when is_tuple(Node) ->
+    each_callback_pairs(tuple_to_list(Node), Acc, Module);
+each_callback_pairs(Nodes, Acc, Module) when is_list(Nodes) ->
+    lists:foldl(fun(N, A) -> each_callback_pairs(N, A, Module) end, Acc, Nodes);
+each_callback_pairs(_Node, Acc, _Module) ->
+    Acc.
+
+%% A local `fun Name/Arity` or same-module `fun ?MODULE:Name/Arity` callback -- the pair to
+%% suppress. An inline fun or a genuinely remote ref contributes nothing.
+each_callback_pair({'fun', _, {function, Name, Arity}}, _Module) ->
+    {ok, {Name, Arity}};
+each_callback_pair(
+    {'fun', _, {function, {atom, _, Module}, {atom, _, Name}, {integer, _, Arity}}}, Module
+) ->
+    {ok, {Name, Arity}};
+each_callback_pair(_Callback, _Module) ->
+    none.
+
+insert_suppression_attrs(Forms, Pairs) ->
+    {Before, [ModAttr | After]} = lists:splitwith(
+        fun(Form) -> not is_module_attr(Form) end, Forms
+    ),
+    Anno = element(2, ModAttr),
+    NowarnAttr = {attribute, Anno, compile, {nowarn_unused_function, Pairs}},
+    IgnoreXrefAttr = {attribute, Anno, ignore_xref, Pairs},
+    Before ++ [ModAttr, NowarnAttr, IgnoreXrefAttr | After].
+
+is_module_attr({attribute, _, module, _}) -> true;
+is_module_attr(_) -> false.
 
 %% Top-down pre-pass threading the enclosing render target `Ctx` (`none` outside
 %% any template, else `html` | `native` | `terminal`). Two jobs:
@@ -246,10 +318,21 @@ format_error(each_stream_body_not_element) ->
     "diffing, which a single-value body throws away. Unlike a list there is no comprehension "
     "fallback (a comprehension has no stream/keyed semantics): wrap the value in an element, "
     "e.g. fun(Item, Key) -> {li, [], [Item]} end";
-format_error(each_fun_ref_not_allowed) ->
-    "an ?each callback must be an inline fun returning an element; a fun reference can't "
-    "be checked to return one (and a reference returning a template breaks diffing). Inline "
-    "it (fun(I) -> {li, [], [...]} end)";
+format_error(each_named_fun_multi_clause) ->
+    "an ?each callback given as a local fun reference (fun name/1 or fun name/2) must have a "
+    "single clause -- ?each inlines the function's body into one shared per-item template, so "
+    "multiple clauses (which would select different per-item structures) can't be compiled to "
+    "a single template. Collapse them into one clause with a case inside the returned element: "
+    "name(I) -> {li, [], [case I of ... end]}";
+format_error(each_named_fun_undefined) ->
+    "the ?each callback references a local fun (fun name/1 or fun name/2) that is not defined "
+    "in this module. Define it as a single-clause function returning an element, or inline the "
+    "callback (fun(I) -> {li, [], [...]} end)";
+format_error(each_remote_fun_ref) ->
+    "an ?each callback cannot be a remote fun reference (fun mod:name/arity) -- ?each inlines "
+    "the callback body to build a per-item template, which is impossible across a module "
+    "boundary. Inline it (fun(I) -> {li, [], [...]} end), or move the body into a single-clause "
+    "local function and pass fun name/1";
 format_error(live_render_not_single_element) ->
     "arizona_stateful render/1 must return a single root element, not a list";
 format_error(live_render_missing_id) ->
@@ -419,24 +502,24 @@ has_behaviour([{attribute, _, behavior, B} | _], B) -> true;
 has_behaviour([_ | Rest], B) -> has_behaviour(Rest, B);
 has_behaviour([], _) -> false.
 
-transform_form({function, L, render, 1, Clauses}, Module, true) ->
-    {function, L, render, 1, [transform_live_render_clause(C, Module) || C <- Clauses]};
-transform_form({function, L, Name, Arity, Clauses}, Module, _IsLive) ->
-    {function, L, Name, Arity, [transform_clause(C, Module) || C <- Clauses]};
-transform_form(Form, _Module, _IsLive) ->
+transform_form({function, L, render, 1, Clauses}, Module, true, FunDefs) ->
+    {function, L, render, 1, [transform_live_render_clause(C, Module, FunDefs) || C <- Clauses]};
+transform_form({function, L, Name, Arity, Clauses}, Module, _IsLive, FunDefs) ->
+    {function, L, Name, Arity, [transform_clause(C, Module, FunDefs) || C <- Clauses]};
+transform_form(Form, _Module, _IsLive, _FunDefs) ->
     Form.
 
-transform_clause({clause, L, Patterns, Guards, Body0}, Module) ->
+transform_clause({clause, L, Patterns, Guards, Body0}, Module, FunDefs) ->
     check_tracked_get_targets(Patterns, Body0),
     Body = normalize_tail_binds(Body0),
     Inline = collect_inline(Body),
-    Body1 = [transform_expr(Expr, Module, Inline) || Expr <- Body],
+    Body1 = [transform_expr(Expr, Module, Inline, FunDefs) || Expr <- Body],
     {clause, L, Patterns, Guards, suppress_unused_inline_matches(Body1, Inline)}.
 
-transform_expr(Expr, Module, Inline) ->
-    erl_syntax_lib:map(fun(Node) -> transform_node(Node, Module, Inline) end, Expr).
+transform_expr(Expr, Module, Inline, FunDefs) ->
+    erl_syntax_lib:map(fun(Node) -> transform_node(Node, Module, Inline, FunDefs) end, Expr).
 
-transform_node(Node, Module, Inline) ->
+transform_node(Node, Module, Inline, FunDefs) ->
     N = erl_syntax:revert(Node),
     case N of
         {call, L, {remote, _, {atom, _, Mod}, {atom, _, html}}, [Arg]} when
@@ -459,7 +542,14 @@ transform_node(Node, Module, Inline) ->
         {call, L, {remote, _, {atom, _, Mod}, {atom, _, each}}, [FunArg, SourceArg]} when
             Mod =:= arizona_template; Mod =:= az
         ->
-            compile_each(inline_vars(FunArg, Inline), inline_vars(SourceArg, Inline), L, Module);
+            compile_each(
+                inline_vars(FunArg, Inline),
+                inline_vars(SourceArg, Inline),
+                L,
+                Module,
+                arizona_html,
+                FunDefs
+            );
         {call, L, {remote, _, {atom, _, Mod}, {atom, _, native_each}}, [FunArg, SourceArg]} when
             Mod =:= arizona_template; Mod =:= az
         ->
@@ -468,7 +558,8 @@ transform_node(Node, Module, Inline) ->
                 inline_vars(SourceArg, Inline),
                 L,
                 Module,
-                arizona_native
+                arizona_native,
+                FunDefs
             );
         {call, L, {remote, _, {atom, _, Mod}, {atom, _, terminal_each}}, [FunArg, SourceArg]} when
             Mod =:= arizona_template; Mod =:= az
@@ -478,7 +569,8 @@ transform_node(Node, Module, Inline) ->
                 inline_vars(SourceArg, Inline),
                 L,
                 Module,
-                arizona_terminal
+                arizona_terminal,
+                FunDefs
             );
         %% Sugar: `arizona_template:stateless(atom, Props)` with a literal atom
         %% callback is rewritten to `arizona_template:stateless(fun atom/1, Props)`.
@@ -494,15 +586,15 @@ transform_node(Node, Module, Inline) ->
             N
     end.
 
-transform_live_render_clause({clause, L, Patterns, Guards, Body}, Module) ->
+transform_live_render_clause({clause, L, Patterns, Guards, Body}, Module, FunDefs) ->
     check_tracked_get_targets(Patterns, Body),
     {Init0, [Last]} = lists:split(length(Body) - 1, Body),
     %% Only the init statements are normalized: the last expr carries the live root
-    %% template and is handled by transform_live_render_last/3.
+    %% template and is handled by transform_live_render_last/4.
     Init = normalize_tail_binds(Init0),
     Inline = collect_inline(Init ++ [Last]),
-    TransformedInit = [transform_expr(Expr, Module, Inline) || Expr <- Init],
-    TransformedLast = transform_live_render_last(Last, Module, Inline),
+    TransformedInit = [transform_expr(Expr, Module, Inline, FunDefs) || Expr <- Init],
+    TransformedLast = transform_live_render_last(Last, Module, Inline, FunDefs),
     Body1 = TransformedInit ++ [TransformedLast],
     {clause, L, Patterns, Guards, suppress_unused_inline_matches(Body1, Inline)}.
 
@@ -511,29 +603,29 @@ transform_live_render_clause({clause, L, Patterns, Guards, Body}, Module) ->
 %% root. Walk each tail position (shared with content-slot expansion via
 %% map_tail_exprs/3), compiling the root at each leaf; non-tail sub-expressions
 %% are transformed normally.
-transform_live_render_last(Expr, Module, Inline) ->
+transform_live_render_last(Expr, Module, Inline, FunDefs) ->
     map_tail_exprs(
         Expr,
-        fun(Leaf) -> transform_live_render_leaf(Leaf, Module, Inline) end,
-        fun(NonTail) -> transform_expr(NonTail, Module, Inline) end
+        fun(Leaf) -> transform_live_render_leaf(Leaf, Module, Inline, FunDefs) end,
+        fun(NonTail) -> transform_expr(NonTail, Module, Inline, FunDefs) end
     ).
 
-transform_live_render_leaf(Expr, Module, Inline) ->
+transform_live_render_leaf(Expr, Module, Inline, FunDefs) ->
     case erl_syntax:revert(Expr) of
         {call, L, {remote, _, {atom, _, Mod}, {atom, _, html}}, [Arg]} when
             Mod =:= arizona_template; Mod =:= az
         ->
             validate_live_root(Arg, L, Inline),
-            Arg1 = transform_expr(Arg, Module, Inline),
+            Arg1 = transform_expr(Arg, Module, Inline, FunDefs),
             compile_template(inline_vars(Arg1, Inline), L, Module, true);
         {call, L, {remote, _, {atom, _, Mod}, {atom, _, native}}, [Arg]} when
             Mod =:= arizona_template; Mod =:= az
         ->
             validate_live_root(Arg, L, Inline),
-            Arg1 = transform_expr(Arg, Module, Inline),
+            Arg1 = transform_expr(Arg, Module, Inline, FunDefs),
             compile_template(inline_vars(Arg1, Inline), L, Module, true, arizona_native);
         _ ->
-            transform_expr(Expr, Module, Inline)
+            transform_expr(Expr, Module, Inline, FunDefs)
     end.
 
 %% Walk the tail (value-producing) positions of a control-flow expression,
@@ -969,10 +1061,7 @@ maybe_target_opt(arizona_terminal, Opts) ->
 maybe_target_opt(_Backend, Opts) ->
     Opts.
 
-compile_each(FunAST, SourceAST, Line, Module) ->
-    compile_each(FunAST, SourceAST, Line, Module, arizona_html).
-
-compile_each(FunAST, SourceAST, Line, Module, Backend) ->
+compile_each(FunAST, SourceAST, Line, Module, Backend, FunDefs) ->
     case FunAST of
         {'fun', _, {clauses, [{clause, _, [ItemVar, KeyVar], Guards, Body}]}} ->
             {Prefix, LastExpr} = split_fun_body(Body),
@@ -996,14 +1085,45 @@ compile_each(FunAST, SourceAST, Line, Module, Backend) ->
             build_each_ast(
                 Line, SourceAST, [ItemVar], Guards, Prefix, S1, D1, Fingerprint, Opts
             );
-        %% `fun name/arity` / `fun Mod:name/arity` -- a reference can't be checked to
-        %% return an element, and a reference returning a template breaks diffing.
+        %% Local `fun Name/1` or `fun Name/2` ref: resolve its single clause and compile
+        %% it exactly like an inline fun, so the same element-body validation runs. The
+        %% looked-up clause is the original untransformed body, which is what the inline
+        %% path expects. (Its now-orphaned definition is covered by the injected
+        %% nowarn_unused_function / ignore_xref attributes.)
+        {'fun', L, {function, Name, Arity}} when Arity =:= 1; Arity =:= 2 ->
+            compile_named_each(Name, Arity, SourceAST, Line, L, Module, Backend, FunDefs);
+        %% A local ref of any other arity isn't a valid callback (1 = list, 2 = stream/map).
         {'fun', L, {function, _Name, _Arity}} ->
-            parse_error(each_fun_ref_not_allowed, L);
+            parse_error(invalid_each_fun, L);
+        %% Same-module explicit ref `fun ?MODULE:Name/Arity` (literal module = this module):
+        %% the body is visible here, so rewrite to the bare local form and re-dispatch -- it
+        %% then behaves exactly like `fun Name/Arity` (resolve + inline, or the same
+        %% arity/multi-clause/undefined errors).
+        {'fun', L, {function, {atom, _, Module}, {atom, _, Name}, {integer, _, Arity}}} ->
+            compile_each(
+                {'fun', L, {function, Name, Arity}}, SourceAST, Line, Module, Backend, FunDefs
+            );
+        %% A remote `fun Mod:Name/Arity` ref to another module: its body isn't visible at
+        %% compile time, so it can't be inlined into the per-item template.
         {'fun', L, {function, _Mod, _Name, _Arity}} ->
-            parse_error(each_fun_ref_not_allowed, L);
+            parse_error(each_remote_fun_ref, L);
         _ ->
             parse_error(invalid_each_fun, Line)
+    end.
+
+%% Resolve a local `Name/Arity` callback (from a bare `fun Name/Arity` or a same-module
+%% `fun ?MODULE:Name/Arity`) to its single clause and compile it via the inline-fun path.
+%% `L` is the fun-ref location (for the error/synthesized clause); `Line` the each call site.
+compile_named_each(Name, Arity, SourceAST, Line, L, Module, Backend, FunDefs) ->
+    case FunDefs of
+        #{{Name, Arity} := [Clause]} ->
+            compile_each(
+                {'fun', L, {clauses, [Clause]}}, SourceAST, Line, Module, Backend, FunDefs
+            );
+        #{{Name, Arity} := [_ | _]} ->
+            parse_error(each_named_fun_multi_clause, L);
+        #{} ->
+            parse_error(each_named_fun_undefined, L)
     end.
 
 %% An ?each callback must build a per-item template: its body must be an element, a list

--- a/test/arizona_parse_transform_SUITE.erl
+++ b/test/arizona_parse_transform_SUITE.erl
@@ -8,7 +8,22 @@
     az_each_inside_html/1,
     each_with_named_fun_ref/1,
     each_with_named_fun_ref_arity_2/1,
+    each_named_fun_ref_non_element_rejected/1,
+    each_named_fun_ref_arity_2_non_element_rejected/1,
     each_with_remote_fun_ref/1,
+    each_named_fun_ref_diffs/1,
+    each_named_fun_ref_pattern_param/1,
+    each_named_fun_ref_guard/1,
+    each_named_fun_ref_prefix_body/1,
+    each_named_fun_ref_nested_each/1,
+    each_named_fun_multi_clause_rejected/1,
+    each_named_fun_wrong_arity_rejected/1,
+    each_named_fun_undefined_rejected/1,
+    each_named_fun_ref_private_local_strict/1,
+    each_named_fun_same_module_ref/1,
+    each_named_fun_imported_rejected/1,
+    each_named_fun_variable_module_rejected/1,
+    each_named_fun_ref_native/1,
     each_body_html_wrapped_rejected/1,
     each_body_descriptor_rejected/1,
     each_body_case_rejected/1,
@@ -351,7 +366,22 @@ groups() ->
             template2_empty_list_render,
             each_with_named_fun_ref,
             each_with_named_fun_ref_arity_2,
+            each_named_fun_ref_non_element_rejected,
+            each_named_fun_ref_arity_2_non_element_rejected,
             each_with_remote_fun_ref,
+            each_named_fun_ref_diffs,
+            each_named_fun_ref_pattern_param,
+            each_named_fun_ref_guard,
+            each_named_fun_ref_prefix_body,
+            each_named_fun_ref_nested_each,
+            each_named_fun_multi_clause_rejected,
+            each_named_fun_wrong_arity_rejected,
+            each_named_fun_undefined_rejected,
+            each_named_fun_ref_private_local_strict,
+            each_named_fun_same_module_ref,
+            each_named_fun_imported_rejected,
+            each_named_fun_variable_module_rejected,
+            each_named_fun_ref_native,
             each_body_html_wrapped_rejected,
             each_body_descriptor_rejected,
             each_body_case_rejected,
@@ -3853,30 +3883,57 @@ invalid_element_binary_tag(Config) when is_list(Config) ->
 
 %% each/2 rejects `fun name/arity` references -- a reference can't be checked to return
 %% an element, so it must be inlined (or use ?stateless inside an element).
+%% A local single-clause `fun Name/1` ref is resolved and inlined: when its body is a
+%% valid element, the each compiles like an inline fun.
 each_with_named_fun_ref(Config) when is_list(Config) ->
-    assert_parse_error(
+    Mod = compile_module(
         "-module(pt_each_named_ref). "
+        "-export([render/1, row/1]). "
+        "row(Name) -> {'li', [], [Name]}. "
+        "render(Bindings) -> "
+        "    arizona_template:html({'ul', [], [arizona_template:each(fun row/1, "
+        "        arizona_template:get(items, Bindings, []))]}). "
+    ),
+    ?assert(is_map(Mod:render(#{items => [~"a", ~"b"]}))).
+
+%% A local single-clause `fun Name/2` ref over a stream/map is resolved and inlined too.
+each_with_named_fun_ref_arity_2(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_each_named_ref_2). "
+        "-export([render/1, row/2]). "
+        "row(Item, _Key) -> {'li', [], [Item]}. "
+        "render(Bindings) -> "
+        "    arizona_template:html({'ul', [], [arizona_template:each(fun row/2, "
+        "        arizona_template:get(items, Bindings))]}). "
+    ),
+    ?assert(is_map(Mod:render(#{items => #{1 => ~"a"}}))).
+
+%% The named-ref path runs the SAME body validation as an inline fun: a non-element body
+%% (here a bare binary) is rejected with each_body_not_element.
+each_named_fun_ref_non_element_rejected(Config) when is_list(Config) ->
+    assert_parse_error(
+        "-module(pt_each_named_non_element). "
         "-export([render/1, row/1]). "
         "row(Name) -> <<\"row:\", Name/binary>>. "
         "render(Bindings) -> "
         "    arizona_template:each(fun row/1, "
         "        arizona_template:get(items, Bindings, [])). ",
-        fun(R) -> R =:= each_fun_ref_not_allowed end
+        fun(R) -> R =:= each_body_not_element end
     ).
 
-%% each/2 rejects 2-arity fun references too.
-each_with_named_fun_ref_arity_2(Config) when is_list(Config) ->
+%% Likewise for a 2-arg named ref: a non-element body yields the stream error.
+each_named_fun_ref_arity_2_non_element_rejected(Config) when is_list(Config) ->
     assert_parse_error(
-        "-module(pt_each_named_ref_2). "
+        "-module(pt_each_named_non_element_2). "
         "-export([render/1, row/2]). "
         "row(Item, Key) -> <<Key/binary, \"=\", Item/binary>>. "
         "render(Bindings) -> "
         "    arizona_template:each(fun row/2, "
         "        arizona_template:get(items, Bindings, [])). ",
-        fun(R) -> R =:= each_fun_ref_not_allowed end
+        fun(R) -> R =:= each_stream_body_not_element end
     ).
 
-%% each/2 rejects `fun Mod:Name/Arity` remote references too.
+%% each/2 rejects `fun Mod:Name/Arity` remote references: the body isn't visible to inline.
 each_with_remote_fun_ref(Config) when is_list(Config) ->
     assert_parse_error(
         "-module(pt_each_remote_ref). "
@@ -3884,8 +3941,183 @@ each_with_remote_fun_ref(Config) when is_list(Config) ->
         "render(Bindings) -> "
         "    arizona_template:each(fun erlang:integer_to_binary/1, "
         "        arizona_template:get(items, Bindings, [])). ",
-        fun(R) -> R =:= each_fun_ref_not_allowed end
+        fun(R) -> R =:= each_remote_fun_ref end
     ).
+
+%% A named-ref callback whose element holds a conditional child diffs per-item, exactly
+%% like the inline-fun equivalent (each_body_conditional_child_diffs).
+each_named_fun_ref_diffs(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_each_named_diffs). "
+        "-export([render/1, row/1]). "
+        "row(U) -> {'li', [], [case U of #{name := N} -> N; _ -> ~\"-\" end]}. "
+        "render(Bindings) -> "
+        "    arizona_template:html({'ul', [], [arizona_template:each(fun row/1, "
+        "        arizona_template:get(users, Bindings))]}). "
+    ),
+    B0 = #{users => [#{name => ~"Ada"}]},
+    {_HTML, Snap0, V0} = arizona_render:render(Mod:render(B0), #{}),
+    B1 = #{users => [#{name => ~"Grace"}]},
+    Changed = compute_changed(B0, B1),
+    {Ops, _Snap1, _V1} = arizona_diff:diff(Mod:render(B1), Snap0, V0, Changed),
+    ?assertNotEqual([], Ops).
+
+%% A named-ref callback with a map-pattern parameter head: the pattern becomes the per-item
+%% `d` fun parameter and resolves correctly.
+each_named_fun_ref_pattern_param(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_each_named_pattern). "
+        "-export([render/1, row/1]). "
+        "row(#{name := N}) -> {'li', [], [N]}. "
+        "render(Bindings) -> "
+        "    arizona_template:html({'ul', [], [arizona_template:each(fun row/1, "
+        "        arizona_template:get(users, Bindings))]}). "
+    ),
+    ?assert(is_map(Mod:render(#{users => [#{name => ~"Ada"}]}))).
+
+%% A named-ref callback with a guard: the guard is carried onto the per-item `d` fun clause.
+each_named_fun_ref_guard(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_each_named_guard). "
+        "-export([render/1, row/1]). "
+        "row(X) when is_map(X) -> {'li', [], [maps:get(n, X)]}. "
+        "render(Bindings) -> "
+        "    arizona_template:html({'ul', [], [arizona_template:each(fun row/1, "
+        "        arizona_template:get(users, Bindings))]}). "
+    ),
+    ?assert(is_map(Mod:render(#{users => [#{n => ~"Ada"}]}))).
+
+%% A named-ref callback with statements before the element (a prefix body): the prefix runs
+%% per item inside the generated `d` fun.
+each_named_fun_ref_prefix_body(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_each_named_prefix). "
+        "-export([render/1, row/1]). "
+        "row(I) -> N = integer_to_binary(I), {'li', [], [N]}. "
+        "render(Bindings) -> "
+        "    arizona_template:html({'ul', [], [arizona_template:each(fun row/1, "
+        "        arizona_template:get(ns, Bindings))]}). "
+    ),
+    ?assert(is_map(Mod:render(#{ns => [1, 2]}))).
+
+%% A named-ref callback whose body itself contains a nested ?each (with its own named ref):
+%% both resolve via the module-global lookup and the recursive compile path.
+each_named_fun_ref_nested_each(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_each_named_nested). "
+        "-export([render/1, section/1, item/1]). "
+        "item(I) -> {'li', [], [I]}. "
+        "section(S) -> {'ul', [], [arizona_template:each(fun item/1, "
+        "    arizona_template:get(items, S))]}. "
+        "render(Bindings) -> "
+        "    arizona_template:html({'div', [], [arizona_template:each(fun section/1, "
+        "        arizona_template:get(sections, Bindings))]}). "
+    ),
+    ?assert(is_map(Mod:render(#{sections => [#{items => [~"a"]}]}))).
+
+%% A multi-clause local ref can't map to one shared per-item template -- rejected.
+each_named_fun_multi_clause_rejected(Config) when is_list(Config) ->
+    assert_parse_error(
+        "-module(pt_each_named_multi). "
+        "-export([render/1, row/1]). "
+        "row(a) -> {'li', [], [~\"a\"]}; "
+        "row(X) -> {'li', [], [X]}. "
+        "render(Bindings) -> "
+        "    arizona_template:each(fun row/1, "
+        "        arizona_template:get(items, Bindings, [])). ",
+        fun(R) -> R =:= each_named_fun_multi_clause end
+    ).
+
+%% A local ref of an arity other than 1 or 2 isn't a valid callback -- rejected as
+%% invalid_each_fun (1 = list item, 2 = stream/map item+key).
+each_named_fun_wrong_arity_rejected(Config) when is_list(Config) ->
+    assert_parse_error(
+        "-module(pt_each_named_arity3). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:each(fun row/3, "
+        "        arizona_template:get(items, Bindings, [])). ",
+        fun(R) -> R =:= invalid_each_fun end
+    ).
+
+%% A local ref to a function not defined in this module -- rejected with a clear message.
+each_named_fun_undefined_rejected(Config) when is_list(Config) ->
+    assert_parse_error(
+        "-module(pt_each_named_undef). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:each(fun missing_row/1, "
+        "        arizona_template:get(items, Bindings, [])). ",
+        fun(R) -> R =:= each_named_fun_undefined end
+    ).
+
+%% Load-bearing: a PRIVATE (non-exported) callback used only by ?each is inlined, orphaning
+%% it. The injected nowarn_unused_function attribute must let this compile under
+%% warnings_as_errors (compile_module_strict). Without the injection, the unused `row/1`
+%% would fail the build.
+each_named_fun_ref_private_local_strict(Config) when is_list(Config) ->
+    Mod = compile_module_strict(
+        "-module(pt_each_named_private). "
+        "-export([render/1]). "
+        "row(N) -> {'li', [], [N]}. "
+        "render(Bindings) -> "
+        "    arizona_template:html({'ul', [], [arizona_template:each(fun row/1, "
+        "        arizona_template:get(items, Bindings, []))]}). "
+    ),
+    ?assert(is_map(Mod:render(#{items => [~"a", ~"b"]}))).
+
+%% A same-module explicit ref `fun ?MODULE:row/1` (here the literal module name) resolves to
+%% the local body exactly like `fun row/1`. With a PRIVATE callback, compile_module_strict
+%% also proves the suppression covers the same-module form under warnings_as_errors.
+each_named_fun_same_module_ref(Config) when is_list(Config) ->
+    Mod = compile_module_strict(
+        "-module(pt_each_same_mod). "
+        "-export([render/1]). "
+        "row(N) -> {'li', [], [N]}. "
+        "render(Bindings) -> "
+        "    arizona_template:html({'ul', [], [arizona_template:each(fun pt_each_same_mod:row/1, "
+        "        arizona_template:get(items, Bindings, []))]}). "
+    ),
+    ?assert(is_map(Mod:render(#{items => [~"a", ~"b"]}))).
+
+%% An imported function referenced as a bare `fun row/1` looks local but its body lives in
+%% another module, so it isn't in this module's FunDefs -- rejected as undefined.
+each_named_fun_imported_rejected(Config) when is_list(Config) ->
+    assert_parse_error(
+        "-module(pt_each_imported). "
+        "-export([render/1]). "
+        "-import(other_mod, [row/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:each(fun row/1, "
+        "        arizona_template:get(items, Bindings, [])). ",
+        fun(R) -> R =:= each_named_fun_undefined end
+    ).
+
+%% A remote ref whose module is a variable (`fun M:row/1`) can't be resolved -- rejected.
+each_named_fun_variable_module_rejected(Config) when is_list(Config) ->
+    assert_parse_error(
+        "-module(pt_each_var_mod). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    M = other_mod, "
+        "    arizona_template:each(fun M:row/1, "
+        "        arizona_template:get(items, Bindings, [])). ",
+        fun(R) -> R =:= each_remote_fun_ref end
+    ).
+
+%% A named-fun ?each inside ?native goes through the native_each rewrite: the callback is
+%% resolved/inlined with the native backend, and a PRIVATE callback is suppressed the same
+%% way (compile_module_strict -> warnings_as_errors).
+each_named_fun_ref_native(Config) when is_list(Config) ->
+    Mod = compile_module_strict(
+        "-module(pt_each_named_native). "
+        "-export([render/1]). "
+        "row(#{text := T}, Key) -> {'Text', [{az_key, Key}], [T]}. "
+        "render(Bindings) -> "
+        "    arizona_template:native({'Column', [{id, arizona_template:get(id, Bindings)}], "
+        "        [arizona_template:each(fun row/2, arizona_template:get(items, Bindings))]}). "
+    ),
+    ?assert(is_map(Mod:render(#{id => ~"c", items => #{1 => #{text => ~"a"}}}))).
 
 %% Wrapping the element in ?html(...) yields a template value (a text_dynamic slot that
 %% crashes on diff) -- rejected; return the element literal directly.

--- a/test/support/arizona_each_named_fun.erl
+++ b/test/support/arizona_each_named_fun.erl
@@ -1,0 +1,33 @@
+-module(arizona_each_named_fun).
+-include("arizona_stateful.hrl").
+-export([mount/1, render/1]).
+
+%% Regression fixture: a PRIVATE (non-exported) function used only as a `?each`
+%% callback. The parse transform inlines `stat_row/1`'s body into the per-item
+%% template, orphaning the function. This module exercises the injected
+%% `nowarn_unused_function` (compiler, test profile runs warnings_as_errors) and
+%% `-ignore_xref` (xref locals_not_used) suppressions end-to-end under `make ci`.
+
+-spec mount(az:bindings()) -> az:mount_ret().
+mount(Props) ->
+    Bindings = #{
+        id => maps:get(id, Props, ~"stats"),
+        stats => maps:get(stats, Props, [{~"Users", ~"42"}, {~"Online", ~"7"}])
+    },
+    {Bindings, #{}}.
+
+-spec render(az:bindings()) -> az:template().
+render(Bindings) ->
+    ?html(
+        {'div', [{id, ?get(id)}], [
+            {ul, [], [
+                ?each(fun stat_row/1, ?get(stats))
+            ]}
+        ]}
+    ).
+
+stat_row({Label, Value}) ->
+    {li, [], [
+        {span, [{class, ~"label"}], [Label]},
+        {span, [{class, ~"value"}], [Value]}
+    ]}.


### PR DESCRIPTION
# Description

`?each` now accepts a local single-clause `fun name/1` (or `fun name/2` for streams/maps), not just an inline fun: the parse transform resolves the reference to the function's clause and inlines its body through the same path, so the identical element-body rules apply, and injects `nowarn_unused_function` / `-ignore_xref` for the now-orphaned definition. A same-module `fun ?MODULE:name/1` resolves the same way; remote, imported, and multi-clause references are rejected with dedicated errors.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
