### PR TITLE
Accept a whole-body ?html/?native/?terminal as an ?each callback body

### DIFF
--- a/.claude/rules/erlang.md
+++ b/.claude/rules/erlang.md
@@ -147,8 +147,8 @@ Adding `'az-nodiff'` to an element's attribute list marks it as a compile-time d
 
 `?each` compiles each item into a per-item template (`#{s, d, f}`) for fine-grained diffing
 (insert/move/update). So the callback's body must be an **element** (`{Tag, Attrs, Children}`),
-a list of elements, or a static/mixed fragment. A bare value, a runtime binary, an `?html(...)`
-call, a `?stateful`/`?stateless` descriptor, or a `case`/`if` compiles to one opaque value
+a list of elements, or a static/mixed fragment. A bare value, a runtime binary, a
+`?stateful`/`?stateless` descriptor, or a `case`/`if` compiles to one opaque value
 slot. A scalar value renders and diffs (keyed by content) but gets no per-item diffing -- a
 comprehension is the right tool; a template or descriptor value goes further and **crashes on
 the first diff** (`bad_template_value`, when `to_bin/1` hits the stored template/descriptor). A
@@ -157,6 +157,12 @@ transform rejects all of these at compile time (`each_body_not_element`). A 2-ar
 callback is rejected the same way but with `each_stream_body_not_element`: a stream/map keys
 each item for per-item diffing and has **no comprehension fallback**, so the body must be an
 element (wrap the value: `fun(Item, Key) -> {li, [], [Item]} end`).
+
+A whole-body `?html(...)` (or `?native`/`?terminal`) **is** accepted: it's unwrapped to the
+element it wraps and compiled identically to returning that element bare -- so a helper that
+returns `?html(...)` can be reused as an `?each` callback. Only a **whole-body** wrapper
+unwraps; a wrapper as a **list item** (`[?html(...)]`) stays rejected (it lands in the same
+fragile per-item value slot as a wrapped descriptor).
 
 The callback may be an inline fun **or a local single-clause function reference** (`fun row/1`,
 or `fun row/2` for a stream/map): the parse transform resolves the reference to the function's
@@ -178,12 +184,15 @@ and a **multi-clause** function (can't map to one shared per-item template,
   return a bare element tuple (see "Bare element tuples in conditional tails" below).
 
 ```erlang
-%% rejected (would crash on diff): a case / ?html body
+%% rejected (would crash on diff): a bare case body -- branches select different structures
 ?each(fun(U) -> case U of #{name := N} -> ?html({li,[],N}); _ -> ~"-" end end, ?get(users))
 %% ok: the conditional is a child of a stable element
 ?each(fun(U) -> {li, [], [case U of #{name := N} -> N; _ -> ~"-" end]} end, ?get(users))
 %% ok: a local single-clause named fun, resolved and inlined (same element-body rules)
 row(U) -> {li, [], [case U of #{name := N} -> N; _ -> ~"-" end]}.
+?each(fun row/1, ?get(users))
+%% ok: a whole-body ?html(...) is unwrapped to its element (inline or named single-clause)
+row(U) -> ?html({li, [], [case U of #{name := N} -> N; _ -> ~"-" end]}).
 ?each(fun row/1, ?get(users))
 %% plain values: a comprehension, not ?each
 {ul, [], [[<<"#", Tag/binary>> || Tag <- ?get(tags)]]}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -321,8 +321,8 @@ inside `?each` items.
 template (`#{s, d, f}`), the callback body must be an element (`{Tag, Attrs, Children}`),
 a list of elements, or a static/mixed fragment. `classify_body/1` in
 `arizona_parse_transform` buckets the body; the only non-template bucket, `text_dynamic`
-(a bare value, a runtime binary, an `?html(...)` template, a `?stateful`/`?stateless`
-descriptor, or a `case`/`if`), compiles to one opaque value slot. A scalar value renders at
+(a bare value, a runtime binary, a `?stateful`/`?stateless` descriptor, or a `case`/`if`),
+compiles to one opaque value slot. A scalar value renders at
 SSR and diffs (the per-item key is `arizona_template:to_bin/1` of its value), but gets no
 per-item template diffing -- pointless where a comprehension is the right tool; a template or
 descriptor value goes further and crashes on the first diff, when `to_bin/1` hits the stored
@@ -350,6 +350,17 @@ referenced as a bare `fun row/1` falls through to `each_named_fun_undefined` sin
 `FunDefs`) and a **multi-clause** function (`each_named_fun_multi_clause` -- clauses would select
 different per-item structures, but there is only one shared per-item template); collapse
 multiple clauses into a `case` inside the returned element.
+
+A whole-body backend wrapper -- `?html(...)` (or `?native`/`?terminal` matching the each's
+target) -- is **accepted**: `compile_each` unwraps it to the element it wraps and builds the
+same per-item template as the bare element (both go through `compile_body_parts/4` +
+`scope_az/4` with the same fingerprint, so the result is byte-identical). The two callback
+forms reach `compile_each` as different AST: a **named** ref resolves to its untransformed
+clause, so its body is a raw `arizona_template:html(...)` call, unwrapped to its argument; an
+**inline** fun's `?html` was already compiled bottom-up into a template-map literal, taken
+directly (re-wrapping its `d`-list into the per-item `fun`). A wrapper as a **list item**
+(`[?html(...)]`) is **not** unwrapped -- only a whole-body wrapper -- so it stays rejected like
+a wrapped descriptor.
 
 A per-item **component** (`{li, [], [?stateless(...)]}`) compiles and renders but currently
 **crashes on the first diff**: the list-each diff in `arizona_diff` (`diff_list_zip/4`) keys a

--- a/src/arizona_parse_transform.erl
+++ b/src/arizona_parse_transform.erl
@@ -1064,26 +1064,12 @@ maybe_target_opt(_Backend, Opts) ->
 compile_each(FunAST, SourceAST, Line, Module, Backend, FunDefs) ->
     case FunAST of
         {'fun', _, {clauses, [{clause, _, [ItemVar, KeyVar], Guards, Body}]}} ->
-            {Prefix, LastExpr} = split_fun_body(Body),
-            ok = validate_each_body(stream, classify_body(LastExpr), LastExpr),
-            {Statics, DynASTs, Fingerprint, Opts0} = compile_body_parts(
-                LastExpr, Module, false, Backend
-            ),
-            Opts = maybe_target_opt(Backend, Opts0),
-            {S1, D1} = scope_az(Backend, Fingerprint, Statics, DynASTs),
-            build_each_ast(
-                Line, SourceAST, [ItemVar, KeyVar], Guards, Prefix, S1, D1, Fingerprint, Opts
+            compile_each_clause(
+                stream, [ItemVar, KeyVar], Guards, Body, SourceAST, Line, Module, Backend
             );
         {'fun', _, {clauses, [{clause, _, [ItemVar], Guards, Body}]}} ->
-            {Prefix, LastExpr} = split_fun_body(Body),
-            ok = validate_each_body(list, classify_body(LastExpr), LastExpr),
-            {Statics, DynASTs, Fingerprint, Opts0} = compile_body_parts(
-                LastExpr, Module, false, Backend
-            ),
-            Opts = maybe_target_opt(Backend, Opts0),
-            {S1, D1} = scope_az(Backend, Fingerprint, Statics, DynASTs),
-            build_each_ast(
-                Line, SourceAST, [ItemVar], Guards, Prefix, S1, D1, Fingerprint, Opts
+            compile_each_clause(
+                list, [ItemVar], Guards, Body, SourceAST, Line, Module, Backend
             );
         %% Local `fun Name/1` or `fun Name/2` ref: resolve its single clause and compile
         %% it exactly like an inline fun, so the same element-body validation runs. The
@@ -1126,14 +1112,97 @@ compile_named_each(Name, Arity, SourceAST, Line, L, Module, Backend, FunDefs) ->
             parse_error(each_named_fun_undefined, L)
     end.
 
+%% Compile one inline `?each` callback clause (`Kind` = list | stream, from the arity) into
+%% the iteration AST. The body's last expr may be a bare element/fragment (the common case),
+%% or a whole-body backend wrapper (`?html`/`?native`/`?terminal`): raw (a named-fun ref
+%% resolves to its untransformed clause) or already compiled to a template map (an inline fun,
+%% compiled bottom-up before the enclosing each). Both wrapper forms reduce to the same
+%% per-item template the bare element would build -- `?html` and `?each` share
+%% `compile_body_parts`/`scope_az` with the same fingerprint. Anything else falls through to
+%% `validate_each_body` (element path or reject).
+compile_each_clause(Kind, Vars, Guards, Body, SourceAST, Line, Module, Backend) ->
+    {Prefix, LastExpr} = split_fun_body(Body),
+    case each_body_unwrap(LastExpr, Backend) of
+        {compiled, Map} ->
+            build_each_from_compiled(Line, SourceAST, Vars, Guards, Prefix, Map);
+        {element, ElemAST} ->
+            ok = validate_each_body(Kind, classify_body(ElemAST), ElemAST),
+            {Statics, DynASTs, Fingerprint, Opts0} = compile_body_parts(
+                ElemAST, Module, false, Backend
+            ),
+            Opts = maybe_target_opt(Backend, Opts0),
+            {S1, D1} = scope_az(Backend, Fingerprint, Statics, DynASTs),
+            build_each_ast(Line, SourceAST, Vars, Guards, Prefix, S1, D1, Fingerprint, Opts)
+    end.
+
+%% Classify an ?each callback's last expr. A whole-body backend wrapper call
+%% (`?html`/`?native`/`?terminal` matching this each's `Backend`) unwraps to the element it
+%% wraps, so the normal element path builds the per-item template. An already-compiled
+%% template map literal (an inline wrapper, compiled bottom-up) is taken as the per-item
+%% template directly. Anything else (a non-matching wrapper, a user map, a bare value) is
+%% handed back as-is for the normal validation, which compiles a bare element or rejects.
+each_body_unwrap(
+    {call, _, {remote, _, {atom, _, Mod}, {atom, _, Fn}}, [Inner]} = Call, Backend
+) when
+    Mod =:= arizona_template; Mod =:= az
+->
+    Wrapper = backend_template_fn(Backend),
+    case Fn of
+        Wrapper -> {element, Inner};
+        _ -> {element, Call}
+    end;
+each_body_unwrap({map, _, Fields} = Map, _Backend) ->
+    case is_compiled_template_map(Fields) of
+        true -> {compiled, Map};
+        false -> {element, Map}
+    end;
+each_body_unwrap(LastExpr, _Backend) ->
+    {element, LastExpr}.
+
+backend_template_fn(arizona_html) -> html;
+backend_template_fn(arizona_native) -> native;
+backend_template_fn(arizona_terminal) -> terminal.
+
+%% A compiled template map literal carries all three of the `s`/`d`/`f` assoc keys (from
+%% build_template_ast). A user map or a ?stateful/?stateless descriptor (a runtime call, not
+%% a map literal) does not, so they fall through to the normal reject.
+is_compiled_template_map(Fields) ->
+    Keys = [K || {map_field_assoc, _, {atom, _, K}, _} <:- Fields],
+    lists:all(fun(Key) -> lists:member(Key, Keys) end, [s, d, f]).
+
+%% Build the ?each iteration AST from an already-compiled template map (an inline
+%% `?html`/`?native`/`?terminal` body). Mirror build_each_ast but reuse the map's prebuilt
+%% assocs: keep `s`/`f`/opts verbatim, wrap the existing `d`-list (nullary closures capturing
+%% the item vars) in the per-item fun, and add `t => 0`. Scoping/fingerprint were already
+%% computed by compile_template from the same body the element path would use, so the result
+%% matches the bare-element form.
+build_each_from_compiled(Line, SourceAST, Vars, Guards, Prefix, {map, MapLine, Fields}) ->
+    DListAST = template_map_field(d, Fields),
+    DFunAST =
+        {'fun', Line, {clauses, [{clause, Line, Vars, Guards, Prefix ++ [DListAST]}]}},
+    TField = {map_field_assoc, MapLine, {atom, MapLine, t}, {integer, MapLine, 0}},
+    NewFields = [TField | [set_template_map_d_field(Field, DFunAST) || Field <- Fields]],
+    {call, Line, {remote, Line, {atom, Line, arizona_template}, {atom, Line, each}}, [
+        SourceAST, {map, MapLine, NewFields}
+    ]}.
+
+template_map_field(Key, Fields) ->
+    [Val] = [V || {map_field_assoc, _, {atom, _, K}, V} <:- Fields, K =:= Key],
+    Val.
+
+set_template_map_d_field({map_field_assoc, FL, {atom, AL, d}, _}, DFunAST) ->
+    {map_field_assoc, FL, {atom, AL, d}, DFunAST};
+set_template_map_d_field(Field, _DFunAST) ->
+    Field.
+
 %% An ?each callback must build a per-item template: its body must be an element, a list
-%% of elements, or a static/mixed fragment. A `text_dynamic` body (a bare value, a runtime
-%% binary, an ?html(...) template, a ?stateful/?stateless descriptor, or a case/if) compiles
-%% to one opaque value slot that renders at SSR but loses per-item diffing (and a template/
-%% descriptor value crashes on diff). Reject it at compile time. `Kind` (list | stream) is the
-%% source shape, inferred from the callback arity (1-arg = list, 2-arg = stream/map): the error
-%% it raises tailors the fix advice, since a list has a comprehension fallback and a stream
-%% does not.
+%% of elements, a static/mixed fragment, or a whole-body `?html`/`?native`/`?terminal`
+%% wrapper (unwrapped to its element before this check). A `text_dynamic` body (a bare value,
+%% a runtime binary, a ?stateful/?stateless descriptor, or a case/if) compiles to one opaque
+%% value slot that renders at SSR but loses per-item diffing (and a descriptor value crashes
+%% on diff). Reject it at compile time. `Kind` (list | stream) is the source shape, inferred
+%% from the callback arity (1-arg = list, 2-arg = stream/map): the error it raises tailors the
+%% fix advice, since a list has a comprehension fallback and a stream does not.
 validate_each_body(Kind, text_dynamic, LastExpr) ->
     parse_error(each_body_error(Kind), line(LastExpr));
 validate_each_body(Kind, list_ast, LastExpr) ->

--- a/test/arizona_parse_transform_SUITE.erl
+++ b/test/arizona_parse_transform_SUITE.erl
@@ -24,13 +24,16 @@
     each_named_fun_imported_rejected/1,
     each_named_fun_variable_module_rejected/1,
     each_named_fun_ref_native/1,
-    each_body_html_wrapped_rejected/1,
+    each_named_fun_ref_html_body_diffs/1,
+    each_named_fun_ref_native_html/1,
+    each_body_html_wrapped_diffs/1,
+    each_body_two_arg_html_diffs/1,
+    each_body_list_with_html_rejected/1,
     each_body_descriptor_rejected/1,
     each_body_case_rejected/1,
     each_body_if_rejected/1,
     each_body_runtime_binary_rejected/1,
     each_body_two_arg_value_rejected/1,
-    each_body_two_arg_html_rejected/1,
     each_body_list_with_descriptor_rejected/1,
     each_body_mixed_fragment_ok/1,
     each_body_conditional_child_diffs/1,
@@ -382,13 +385,16 @@ groups() ->
             each_named_fun_imported_rejected,
             each_named_fun_variable_module_rejected,
             each_named_fun_ref_native,
-            each_body_html_wrapped_rejected,
+            each_named_fun_ref_html_body_diffs,
+            each_named_fun_ref_native_html,
+            each_body_html_wrapped_diffs,
+            each_body_two_arg_html_diffs,
+            each_body_list_with_html_rejected,
             each_body_descriptor_rejected,
             each_body_case_rejected,
             each_body_if_rejected,
             each_body_runtime_binary_rejected,
             each_body_two_arg_value_rejected,
-            each_body_two_arg_html_rejected,
             each_body_list_with_descriptor_rejected,
             each_body_mixed_fragment_ok,
             each_body_conditional_child_diffs,
@@ -4119,18 +4125,67 @@ each_named_fun_ref_native(Config) when is_list(Config) ->
     ),
     ?assert(is_map(Mod:render(#{id => ~"c", items => #{1 => #{text => ~"a"}}}))).
 
-%% Wrapping the element in ?html(...) yields a template value (a text_dynamic slot that
-%% crashes on diff) -- rejected; return the element literal directly.
-each_body_html_wrapped_rejected(Config) when is_list(Config) ->
-    assert_parse_error(
+%% A named-ref callback whose body is ?html(...) is unwrapped and diffs per-item, exactly
+%% like the bare-element named-ref form (each_named_fun_ref_diffs).
+each_named_fun_ref_html_body_diffs(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_each_named_html). "
+        "-export([render/1, row/1]). "
+        "row(U) -> arizona_template:html({'li', [], "
+        "    [case U of #{name := N} -> N; _ -> ~\"-\" end]}). "
+        "render(Bindings) -> "
+        "    arizona_template:html({'ul', [], [arizona_template:each(fun row/1, "
+        "        arizona_template:get(users, Bindings))]}). "
+    ),
+    B0 = #{users => [#{name => ~"Ada"}]},
+    {_HTML, Snap0, V0} = arizona_render:render(Mod:render(B0), #{}),
+    B1 = #{users => [#{name => ~"Grace"}]},
+    Changed = compute_changed(B0, B1),
+    {Ops, _Snap1, _V1} = arizona_diff:diff(Mod:render(B1), Snap0, V0, Changed),
+    ?assertNotEqual([], Ops).
+
+%% A named-ref callback whose body is ?native(...) inside a ?native(...) view unwraps too
+%% (the private row/2 is covered by the injected nowarn_unused_function / ignore_xref).
+each_named_fun_ref_native_html(Config) when is_list(Config) ->
+    Mod = compile_module_strict(
+        "-module(pt_each_named_native_html). "
+        "-export([render/1]). "
+        "row(#{text := T}, Key) -> arizona_template:native({'Text', [{az_key, Key}], [T]}). "
+        "render(Bindings) -> "
+        "    arizona_template:native({'Column', [{id, arizona_template:get(id, Bindings)}], "
+        "        [arizona_template:each(fun row/2, arizona_template:get(items, Bindings))]}). "
+    ),
+    ?assert(is_map(Mod:render(#{id => ~"c", items => #{1 => #{text => ~"a"}}}))).
+
+%% A whole-body ?html(...) callback is unwrapped to its element and builds the SAME per-item
+%% template as returning the element bare -- it compiles, renders, and diffs per item (no
+%% crash on diff). The diff ops are byte-identical to the bare-element form.
+each_body_html_wrapped_diffs(Config) when is_list(Config) ->
+    Wrapped = compile_module(
         "-module(pt_each_html_wrapped). "
         "-export([render/1]). "
         "render(Bindings) -> "
-        "    arizona_template:html({'ul', [], [arizona_template:each(fun(X) -> "
-        "        arizona_template:html({'li', [], [X]}) "
-        "    end, arizona_template:get(xs, Bindings))]}). ",
-        fun(R) -> R =:= each_body_not_element end
-    ).
+        "    arizona_template:html({'ul', [], [arizona_template:each(fun(U) -> "
+        "        arizona_template:html({'li', [], [case U of #{name := N} -> N; _ -> ~\"-\" end]}) "
+        "    end, arizona_template:get(users, Bindings))]}). "
+    ),
+    Bare = compile_module(
+        "-module(pt_each_html_bare). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:html({'ul', [], [arizona_template:each(fun(U) -> "
+        "        {'li', [], [case U of #{name := N} -> N; _ -> ~\"-\" end]} "
+        "    end, arizona_template:get(users, Bindings))]}). "
+    ),
+    B0 = #{users => [#{name => ~"Ada"}]},
+    B1 = #{users => [#{name => ~"Grace"}]},
+    Changed = compute_changed(B0, B1),
+    {_HW, WSnap0, WV0} = arizona_render:render(Wrapped:render(B0), #{}),
+    {WOps, _, _} = arizona_diff:diff(Wrapped:render(B1), WSnap0, WV0, Changed),
+    {_HB, BSnap0, BV0} = arizona_render:render(Bare:render(B0), #{}),
+    {BOps, _, _} = arizona_diff:diff(Bare:render(B1), BSnap0, BV0, Changed),
+    ?assertNotEqual([], WOps),
+    ?assertEqual(BOps, WOps).
 
 %% A bare ?stateful/?stateless descriptor body is rejected -- wrap it in an element.
 each_body_descriptor_rejected(Config) when is_list(Config) ->
@@ -4197,16 +4252,30 @@ each_body_two_arg_value_rejected(Config) when is_list(Config) ->
         fun(R) -> R =:= each_stream_body_not_element end
     ).
 
-%% A 2-arg callback returning an ?html template is rejected with the stream error too.
-each_body_two_arg_html_rejected(Config) when is_list(Config) ->
-    assert_parse_error(
+%% A 2-arg (stream/map) callback whose whole body is ?html(...) is unwrapped the same way
+%% as the 1-arg form, building a per-item template that renders.
+each_body_two_arg_html_diffs(Config) when is_list(Config) ->
+    Mod = compile_module(
         "-module(pt_each_two_arg_html). "
         "-export([render/1]). "
         "render(Bindings) -> "
-        "    arizona_template:html({'ul', [], [arizona_template:each(fun(Item, _Key) -> "
-        "        arizona_template:html({'li', [], [Item]}) "
+        "    arizona_template:html({'ul', [], [arizona_template:each(fun(V, K) -> "
+        "        arizona_template:html({'li', [], [K, ~\": \", V]}) "
+        "    end, arizona_template:get(items, Bindings))]}). "
+    ),
+    ?assert(is_map(Mod:render(#{items => #{~"a" => ~"1"}}))).
+
+%% A ?html template as a *list item* ([?html(...)]) is still rejected -- only a WHOLE-body
+%% wrapper is unwrapped; a one-template list lands in the fragile per-item value slot.
+each_body_list_with_html_rejected(Config) when is_list(Config) ->
+    assert_parse_error(
+        "-module(pt_each_list_html). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:html({'ul', [], [arizona_template:each(fun(X) -> "
+        "        [arizona_template:html({'li', [], [X]})] "
         "    end, arizona_template:get(xs, Bindings))]}). ",
-        fun(R) -> R =:= each_stream_body_not_element end
+        fun(R) -> R =:= each_body_not_element end
     ).
 
 %% A bare list whose item is a descriptor (or template) is rejected: the item lands in a

--- a/test/support/arizona_each_html_fun.erl
+++ b/test/support/arizona_each_html_fun.erl
@@ -1,0 +1,35 @@
+-module(arizona_each_html_fun).
+-include("arizona_stateful.hrl").
+-export([mount/1, render/1]).
+
+%% Regression fixture: a PRIVATE `?each` callback whose body is a whole `?html(...)` wrapper.
+%% The parse transform unwraps the `?html` and inlines its element into the per-item template,
+%% orphaning `stat_row/1`. Mirrors `arizona_each_named_fun` but for the `?html`-body unwrap,
+%% exercising the injected `nowarn_unused_function` (compiler, test profile runs
+%% warnings_as_errors) and `-ignore_xref` (xref locals_not_used) suppressions under `make ci`.
+
+-spec mount(az:bindings()) -> az:mount_ret().
+mount(Props) ->
+    Bindings = #{
+        id => maps:get(id, Props, ~"stats_html"),
+        stats => maps:get(stats, Props, [{~"Users", ~"42"}, {~"Online", ~"7"}])
+    },
+    {Bindings, #{}}.
+
+-spec render(az:bindings()) -> az:template().
+render(Bindings) ->
+    ?html(
+        {'div', [{id, ?get(id)}], [
+            {ul, [], [
+                ?each(fun stat_row/1, ?get(stats))
+            ]}
+        ]}
+    ).
+
+stat_row({Label, Value}) ->
+    ?html(
+        {li, [], [
+            {span, [{class, ~"label"}], [Label]},
+            {span, [{class, ~"value"}], [Value]}
+        ]}
+    ).


### PR DESCRIPTION
# Description

`?each` rejected a callback whose body is `?html(...)` (or `?native`/`?terminal`), blocking the natural reuse of a template-returning helper -- `foo(X) -> ?html({li, [], [X]}).` used as `?each(fun foo/1, Items)`. A whole-body wrapper is now unwrapped to the element it wraps and compiled into the same per-item template as returning that element bare: both go through `compile_body_parts`/`scope_az` with the same fingerprint, so the diff ops are byte-identical -- a real diffable template, not the value slot that crashes on diff. It works for inline funs and local single-clause named (and `fun ?MODULE:name`) refs; a wrapper as a *list item* (`[?html(...)]`) stays rejected, and a backend mismatch (an `?html` body in a `?native` each) is still a compile error.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
