### PR TITLE
Extract arizona_crypto signed-value primitive from flash, with optional TTL

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -117,6 +117,7 @@
 {hank, [
     {ignore, [
         {"test/arizona_app_SUITE.erl", [unnecessary_function_arguments]},
+        {"test/arizona_crypto_SUITE.erl", [unnecessary_function_arguments]},
         {"test/arizona_flash_SUITE.erl", [unnecessary_function_arguments]},
         {"test/arizona_req_SUITE.erl", [unnecessary_function_arguments]},
         {"test/arizona_jsonrpc_SUITE.erl", [unnecessary_function_arguments]},
@@ -160,6 +161,7 @@
         {"test/support/arizona_fetch_push.erl", [unnecessary_function_arguments]},
         {"include/arizona_effect.hrl", [single_use_hrl_attrs]},
         {"include/arizona_common.hrl", [unused_macros, single_use_hrl_attrs]},
+        {"src/arizona_crypto.erl", [unnecessary_function_arguments]},
         {"src/arizona_template.erl", [unnecessary_function_arguments]},
         {"src/arizona_reloader.erl", [unnecessary_function_arguments]},
         {"src/arizona_renderer.erl", [unused_callbacks]},

--- a/src/arizona_crypto.erl
+++ b/src/arizona_crypto.erl
@@ -1,0 +1,179 @@
+-module(arizona_crypto).
+-moduledoc """
+Signed-value primitive: HMAC-SHA256 over arbitrary binaries.
+
+`sign/1` wraps a binary into a tamper-evident, URL-safe wire value
+`b64(tagged) "." b64(hmac)`; `sign/2` additionally bakes a signed expiry
+(`#{ttl => Seconds}`) so the value rejects after a deadline. `verify/1`
+constant-time-checks the HMAC, enforces any expiry, and returns the original
+payload as `{ok, Payload}` (or `error` on a tampered, malformed, or expired
+value -- the caller layers its own failure policy on top).
+
+The signing key is the `arizona` `secret_key` application env (a non-empty
+binary); `secret/0` reads it and errors loudly if unset. This module owns no
+domain shape: callers layer their own encoding (e.g. `arizona_flash` signs JSON).
+""".
+
+%% --------------------------------------------------------------------
+%% API function exports
+%% --------------------------------------------------------------------
+
+-export([sign/1]).
+-export([sign/2]).
+-export([verify/1]).
+-export([secret/0]).
+-export([format_error/2]).
+
+%% --------------------------------------------------------------------
+%% Ignore xref warnings
+%% --------------------------------------------------------------------
+
+%% Public primitive, exercised by arizona_flash (and future signed-token
+%% callers); no other internal callers by design.
+-ignore_xref([sign/1]).
+-ignore_xref([sign/2]).
+-ignore_xref([verify/1]).
+-ignore_xref([secret/0]).
+-ignore_xref([format_error/2]).
+
+%% --------------------------------------------------------------------
+%% Types exports
+%% --------------------------------------------------------------------
+
+-export_type([sign_opts/0]).
+
+%% --------------------------------------------------------------------
+%% Types definitions
+%% --------------------------------------------------------------------
+
+-nominal sign_opts() :: #{ttl := non_neg_integer()}.
+
+%% Envelope tag bytes -- signed alongside the payload so a flipped tag breaks the MAC.
+-define(TAG_RAW, 0).
+-define(TAG_TTL, 1).
+
+%% --------------------------------------------------------------------
+%% API Functions
+%% --------------------------------------------------------------------
+
+-doc """
+Signs `Payload` into the URL-safe `b64(tagged) "." b64(hmac)` wire value, never
+expiring. Errors if `secret_key` is unset (see `secret/0`).
+""".
+-spec sign(Payload) -> binary() when Payload :: binary().
+sign(Payload) when is_binary(Payload) ->
+    sign_envelope(<<?TAG_RAW, Payload/binary>>).
+
+-doc """
+Like `sign/1` but bakes a signed expiry: `#{ttl => Seconds}` makes the value
+verify only until `Seconds` from now (inclusive). Errors if `secret_key` is unset.
+""".
+-spec sign(Payload, Opts) -> binary() when
+    Payload :: binary(),
+    Opts :: sign_opts().
+sign(Payload, #{ttl := Secs}) when is_binary(Payload), is_integer(Secs), Secs >= 0 ->
+    ExpiresAt = erlang:system_time(second) + Secs,
+    sign_envelope(<<?TAG_TTL, ExpiresAt:64, Payload/binary>>).
+
+-doc """
+Verifies a signed value, returning `{ok, Payload}` when the HMAC matches and the
+value is unexpired, and `error` when it is malformed, tampered, or expired. The
+HMAC compare is constant-time. Errors if `secret_key` is unset.
+""".
+-spec verify(Signed) -> {ok, binary()} | error when
+    Signed :: binary().
+verify(Signed) when is_binary(Signed) ->
+    do_verify(Signed, erlang:system_time(second)).
+
+-doc """
+Returns the configured signing secret from the `arizona` `secret_key` application
+env, erroring if it is unset or empty.
+""".
+-spec secret() -> binary().
+secret() ->
+    case application:get_env(arizona, secret_key) of
+        {ok, Secret} when is_binary(Secret), Secret =/= <<>> ->
+            Secret;
+        _ ->
+            erlang:error(secret_key_not_configured, [], [
+                {error_info, #{module => ?MODULE}}
+            ])
+    end.
+
+%% --------------------------------------------------------------------
+%% Format error
+%% --------------------------------------------------------------------
+
+-doc """
+Formats `arizona_crypto` runtime errors into a human-readable message. Picked up
+by `erl_error:format_exception/3` via the `error_info` annotation attached at the
+raise site.
+""".
+-spec format_error(Reason, Stacktrace) -> ErrorInfo when
+    Reason :: term(),
+    Stacktrace :: [tuple()],
+    ErrorInfo :: #{general := iolist()}.
+format_error(secret_key_not_configured, _ST) ->
+    #{
+        general =>
+            "signing requires a secret: set the arizona `secret_key` "
+            "application env to a random non-empty binary"
+    }.
+
+%% --------------------------------------------------------------------
+%% Internal functions
+%% --------------------------------------------------------------------
+
+sign_envelope(Tagged) ->
+    Sig = crypto:mac(hmac, sha256, secret(), Tagged),
+    <<(b64(Tagged))/binary, ".", (b64(Sig))/binary>>.
+
+%% The clock is injected so the expiry boundary is deterministically testable.
+do_verify(Signed, Now) ->
+    try
+        [B64Tagged, B64Sig] = binary:split(Signed, ~"."),
+        Tagged = unb64(B64Tagged),
+        Expected = crypto:mac(hmac, sha256, secret(), Tagged),
+        true = crypto:hash_equals(unb64(B64Sig), Expected),
+        unwrap(Tagged, Now)
+    catch
+        _:_ -> error
+    end.
+
+unwrap(<<?TAG_RAW, Payload/binary>>, _Now) ->
+    {ok, Payload};
+unwrap(<<?TAG_TTL, ExpiresAt:64, Payload/binary>>, Now) when Now =< ExpiresAt ->
+    {ok, Payload};
+unwrap(<<?TAG_TTL, _ExpiresAt:64, _Payload/binary>>, _Now) ->
+    error.
+
+b64(Bin) ->
+    base64:encode(Bin, #{mode => urlsafe, padding => false}).
+
+unb64(Bin) ->
+    base64:decode(Bin, #{mode => urlsafe, padding => false}).
+
+%% --------------------------------------------------------------------
+%% EUnit tests
+%% --------------------------------------------------------------------
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+ttl_expiry_boundary_test() ->
+    application:set_env(arizona, secret_key, ~"eunit-secret-key"),
+    %% A signed envelope with a fixed absolute expiry, verified against an
+    %% injected clock -- no wall-clock, no sleep.
+    Signed = sign_envelope(<<?TAG_TTL, 1000:64, "payload">>),
+    ?assertEqual({ok, ~"payload"}, do_verify(Signed, 999)),
+    ?assertEqual({ok, ~"payload"}, do_verify(Signed, 1000)),
+    ?assertEqual(error, do_verify(Signed, 1001)),
+    application:unset_env(arizona, secret_key).
+
+raw_ignores_clock_test() ->
+    application:set_env(arizona, secret_key, ~"eunit-secret-key"),
+    Signed = sign(~"payload"),
+    ?assertEqual({ok, ~"payload"}, do_verify(Signed, 1 bsl 40)),
+    application:unset_env(arizona, secret_key).
+
+-endif.

--- a/src/arizona_flash.erl
+++ b/src/arizona_flash.erl
@@ -3,17 +3,19 @@
 Signed, one-time flash cookie codec.
 
 A flash is a small map of short-lived display messages carried across a single
-redirect (the Post/Redirect/Get pattern). It rides a dedicated cookie that is
-signed (HMAC-SHA256) with the `arizona` `secret_key` application env, so a client
-cannot forge one, and is consumed on the next request that reads it.
+redirect (the Post/Redirect/Get pattern). It rides a dedicated cookie whose JSON
+payload is signed by `arizona_crypto` (HMAC-SHA256 with the `arizona` `secret_key`
+application env), so a client cannot forge one, and is consumed on the next
+request that reads it.
 
-This module owns the wire format: encode/decode the payload and build the
+This module owns the flash domain: JSON-encode/decode the payload and build the
 `Set-Cookie` tuples. `arizona_req` integrates it into the request/response stash
 (`put_flash/3`, `flash/1`, `read_flash/1`), and the `arizona_middleware:fetch_flash/2`
 step reads it into the `flash` binding.
 
-The cookie value is `payload "." signature`, both URL-safe base64 without padding;
-`payload` is the JSON of the flash map and `signature` is its HMAC.
+The cookie value is the flash JSON signed by `arizona_crypto:sign/1`
+(`b64(payload) "." b64(signature)`, URL-safe base64 without padding);
+`decode/1` returns `#{}` when the signature does not verify.
 """.
 
 %% --------------------------------------------------------------------
@@ -63,9 +65,7 @@ Encodes a flash map into a signed cookie value. Errors if `secret_key` is unset.
 -spec encode(Flash) -> binary() when
     Flash :: arizona_req:flash().
 encode(Flash) ->
-    Payload = iolist_to_binary(json:encode(Flash)),
-    Sig = crypto:mac(hmac, sha256, secret(), Payload),
-    <<(b64(Payload))/binary, ".", (b64(Sig))/binary>>.
+    arizona_crypto:sign(iolist_to_binary(json:encode(Flash))).
 
 -doc """
 Decodes and verifies a cookie value into a flash map, returning `#{}` when the
@@ -74,17 +74,21 @@ signature does not match or the value is malformed.
 -spec decode(Value) -> arizona_req:flash() when
     Value :: binary().
 decode(Value) ->
-    try
-        [B64Payload, B64Sig] = binary:split(Value, ~"."),
-        Payload = unb64(B64Payload),
-        Expected = crypto:mac(hmac, sha256, secret(), Payload),
-        true = crypto:hash_equals(unb64(B64Sig), Expected),
-        case json:decode(Payload) of
-            Flash when is_map(Flash) -> Flash;
-            _ -> #{}
-        end
-    catch
-        _:_ -> #{}
+    case arizona_crypto:verify(Value) of
+        {ok, Payload} ->
+            %% `verify` owns the tamper check; the remaining failure is a
+            %% verified-but-non-JSON payload (possible now that arizona_crypto
+            %% is shared -- another consumer could sign non-JSON under the same
+            %% secret), which `decode/1`'s total `#{}`-on-anything contract
+            %% must still swallow rather than crash on.
+            try json:decode(Payload) of
+                Flash when is_map(Flash) -> Flash;
+                _ -> #{}
+            catch
+                _:_ -> #{}
+            end;
+        error ->
+            #{}
     end.
 
 -doc "The `Set-Cookie` tuple that carries `Flash` to the next request.".
@@ -121,29 +125,12 @@ key(Key) when is_atom(Key) -> atom_to_binary(Key, utf8);
 key(Key) when is_binary(Key) -> Key.
 
 -doc """
-Returns the configured flash signing secret from the `arizona` `secret_key`
-application env, erroring if it is unset or empty.
+Returns the configured flash signing secret. Delegates to `arizona_crypto:secret/0`
+(the flash cookie is signed by `arizona_crypto`); erroring if it is unset or empty.
 """.
 -spec secret() -> binary().
 secret() ->
-    case application:get_env(arizona, secret_key) of
-        {ok, Secret} when is_binary(Secret), Secret =/= <<>> ->
-            Secret;
-        _ ->
-            error(
-                {arizona_flash, secret_key_not_configured},
-                none,
-                [
-                    {error_info, #{
-                        cause =>
-                            <<
-                                "flash requires a signing key: set the arizona "
-                                "`secret_key` application env to a random binary"
-                            >>
-                    }}
-                ]
-            )
-    end.
+    arizona_crypto:secret().
 
 %% --------------------------------------------------------------------
 %% Internal functions
@@ -157,9 +144,3 @@ cookie_opts(MaxAge) ->
         max_age => MaxAge,
         secure => application:get_env(arizona, flash_secure, false)
     }.
-
-b64(Bin) ->
-    base64:encode(Bin, #{mode => urlsafe, padding => false}).
-
-unb64(Bin) ->
-    base64:decode(Bin, #{mode => urlsafe, padding => false}).

--- a/test/arizona_crypto_SUITE.erl
+++ b/test/arizona_crypto_SUITE.erl
@@ -1,0 +1,132 @@
+-module(arizona_crypto_SUITE).
+-include_lib("stdlib/include/assert.hrl").
+
+-export([all/0]).
+-export([init_per_suite/1]).
+-export([end_per_suite/1]).
+
+-export([sign_verify_round_trips/1]).
+-export([sign_verify_round_trips_empty/1]).
+-export([sign_verify_round_trips_payload_with_dot/1]).
+-export([sign_ttl_verifies_before_expiry/1]).
+-export([verify_rejects_tampered_payload/1]).
+-export([verify_rejects_tampered_signature/1]).
+-export([verify_rejects_malformed_no_dot/1]).
+-export([verify_rejects_extra_dots/1]).
+-export([verify_rejects_wrong_secret/1]).
+-export([secret_returns_configured/1]).
+-export([secret_errors_when_unset/1]).
+-export([sign_errors_when_secret_unset/1]).
+-export([format_error_renders_secret_message/1]).
+
+-define(SECRET, ~"test-secret-key-0123456789abcdef").
+
+%% Sequential (not parallel): the cases share the `secret_key` application env,
+%% and the secret-toggling cases mutate it.
+all() ->
+    [
+        sign_verify_round_trips,
+        sign_verify_round_trips_empty,
+        sign_verify_round_trips_payload_with_dot,
+        sign_ttl_verifies_before_expiry,
+        verify_rejects_tampered_payload,
+        verify_rejects_tampered_signature,
+        verify_rejects_malformed_no_dot,
+        verify_rejects_extra_dots,
+        verify_rejects_wrong_secret,
+        secret_returns_configured,
+        secret_errors_when_unset,
+        sign_errors_when_secret_unset,
+        format_error_renders_secret_message
+    ].
+
+init_per_suite(Config) ->
+    application:set_env(arizona, secret_key, ?SECRET),
+    Config.
+
+end_per_suite(_Config) ->
+    application:unset_env(arizona, secret_key),
+    ok.
+
+sign_verify_round_trips(Config) when is_list(Config) ->
+    Payload = ~"hello, world",
+    ?assertMatch({ok, Payload}, arizona_crypto:verify(arizona_crypto:sign(Payload))).
+
+sign_verify_round_trips_empty(Config) when is_list(Config) ->
+    ?assertMatch({ok, <<>>}, arizona_crypto:verify(arizona_crypto:sign(<<>>))).
+
+sign_verify_round_trips_payload_with_dot(Config) when is_list(Config) ->
+    %% A payload full of `.` round-trips: the split delimiter is the single `.`
+    %% the wire format inserts, and base64 halves never contain `.`.
+    Payload = ~"a.b.c.d",
+    ?assertMatch({ok, Payload}, arizona_crypto:verify(arizona_crypto:sign(Payload))).
+
+sign_ttl_verifies_before_expiry(Config) when is_list(Config) ->
+    %% A far-future TTL verifies now without sleeping; the expiry boundary itself
+    %% is covered deterministically by the inline EUnit tests in arizona_crypto.
+    Payload = ~"fresh",
+    ?assertMatch(
+        {ok, Payload}, arizona_crypto:verify(arizona_crypto:sign(Payload, #{ttl => 3600}))
+    ).
+
+verify_rejects_tampered_payload(Config) when is_list(Config) ->
+    Signed = arizona_crypto:sign(~"boom"),
+    [B64Payload, B64Sig] = binary:split(Signed, ~"."),
+    %% Flip a byte in the payload half; the recomputed HMAC must no longer match.
+    Tampered = <<(flip_first_byte(B64Payload))/binary, ".", B64Sig/binary>>,
+    ?assertEqual(error, arizona_crypto:verify(Tampered)).
+
+verify_rejects_tampered_signature(Config) when is_list(Config) ->
+    Signed = arizona_crypto:sign(~"boom"),
+    %% Corrupt the trailing signature byte; the HMAC check must fail closed.
+    ?assertEqual(error, arizona_crypto:verify(<<Signed/binary, "x">>)).
+
+verify_rejects_malformed_no_dot(Config) when is_list(Config) ->
+    ?assertEqual(error, arizona_crypto:verify(~"nodothere")),
+    ?assertEqual(error, arizona_crypto:verify(<<>>)).
+
+verify_rejects_extra_dots(Config) when is_list(Config) ->
+    %% Split takes the first `.`; the right half is not valid base64 -> error.
+    ?assertEqual(error, arizona_crypto:verify(~"a.b.c")).
+
+verify_rejects_wrong_secret(Config) when is_list(Config) ->
+    Signed = arizona_crypto:sign(~"secret-data"),
+    application:set_env(arizona, secret_key, ~"a-totally-different-secret-key-99"),
+    try
+        ?assertEqual(error, arizona_crypto:verify(Signed))
+    after
+        application:set_env(arizona, secret_key, ?SECRET)
+    end.
+
+secret_returns_configured(Config) when is_list(Config) ->
+    ?assertEqual(?SECRET, arizona_crypto:secret()).
+
+secret_errors_when_unset(Config) when is_list(Config) ->
+    application:unset_env(arizona, secret_key),
+    try
+        ?assertError(secret_key_not_configured, arizona_crypto:secret())
+    after
+        application:set_env(arizona, secret_key, ?SECRET)
+    end.
+
+sign_errors_when_secret_unset(Config) when is_list(Config) ->
+    application:unset_env(arizona, secret_key),
+    try
+        ?assertError(secret_key_not_configured, arizona_crypto:sign(~"x"))
+    after
+        application:set_env(arizona, secret_key, ?SECRET)
+    end.
+
+format_error_renders_secret_message(Config) when is_list(Config) ->
+    #{general := Msg} = arizona_crypto:format_error(secret_key_not_configured, []),
+    ?assertNotEqual(nomatch, binary:match(iolist_to_binary(Msg), ~"secret_key")).
+
+%% Flip the first byte to a guaranteed-different value, keeping it in the
+%% URL-safe base64 alphabet so only the HMAC (not the decode) rejects it.
+flip_first_byte(<<First, Rest/binary>>) ->
+    Flipped =
+        case First of
+            $A -> $B;
+            _ -> $A
+        end,
+    <<Flipped, Rest/binary>>.

--- a/test/arizona_flash_SUITE.erl
+++ b/test/arizona_flash_SUITE.erl
@@ -77,7 +77,7 @@ resp_cookie_none_when_idle(Config) when is_list(Config) ->
 secret_errors_when_unset(Config) when is_list(Config) ->
     application:unset_env(arizona, secret_key),
     try
-        ?assertError({arizona_flash, secret_key_not_configured}, arizona_flash:secret())
+        ?assertError(secret_key_not_configured, arizona_flash:secret())
     after
         application:set_env(arizona, secret_key, ~"test-secret-key-0123456789abcdef")
     end.


### PR DESCRIPTION
# Description

Generalizes the HMAC-SHA256 cookie signing that lived in `arizona_flash` into a standalone `arizona_crypto` primitive over arbitrary binaries: `sign/1`, `sign/2` with `#{ttl => Secs}` signed expiry, and `verify/1 -> {ok, Payload} | error`.

`arizona_flash` now consumes it as a thin JSON layer, so there is a single signing path, and the primitive is ready for the future signed-value consumers (CSRF token, password-reset links, remember-me) that the CSRF notes point at.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
