### PR TITLE
Accept rotated-out keys on verify/decrypt for zero-downtime key rotation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,6 +159,5 @@ arizona_static:generate(~"_site", [
 
 - **CSRF double-submit token** -- now unblocked: a signed token (from `arizona_crypto`) can bind to the session, closing the missing-Origin gap the Origin check leaves open.
 - **Server-side session store** -- a pluggable `get/put/delete` store behaviour (ETS/Redis/DB) behind an opaque session-id cookie, for instant revocation and large/secret state the cookie store can't hold.
-- **Key rotation grace** -- the encrypt/sign wire format carries no key version, so rotating `secret_key` invalidates every existing cookie (logs everyone out). Add a multi-key decrypt path (accept the previous key) for zero-downtime rotation.
 - **Sliding-window expiry** -- the session TTL is fixed per write; optionally renew it on read.
 - **Auth / `current_user` helpers** -- a login/identity layer built on top of `get_session`.

--- a/src/arizona_crypto.erl
+++ b/src/arizona_crypto.erl
@@ -21,6 +21,14 @@ The key is the `arizona` `secret_key` application env (a non-empty binary);
 domain-separated from the raw secret used for HMAC, so the two uses never share key
 material. This module owns no domain shape: callers layer their own encoding (e.g.
 both `arizona_flash` and `arizona_session` carry JSON).
+
+**Key rotation.** `sign`/`encrypt` always use the primary `secret_key`, but
+`verify`/`decrypt` also accept any key listed in the optional `secret_key_previous`
+application env (`[binary()]`, default `[]`). Rotate with zero downtime and no forced
+re-issue: move the old `secret_key` into `secret_key_previous`, set a fresh
+`secret_key`, then drop the old key once the grace window (your longest cookie TTL)
+has passed. There is no key-version byte in the wire format -- verify/decrypt simply
+try each candidate key in turn.
 """.
 
 %% --------------------------------------------------------------------
@@ -182,7 +190,7 @@ sign_envelope(Tagged) ->
 encrypt_envelope(Plaintext) ->
     IV = crypto:strong_rand_bytes(?IV_SIZE),
     {Cipher, Tag} = crypto:crypto_one_time_aead(
-        aes_256_gcm, aead_key(), IV, Plaintext, <<>>, true
+        aes_256_gcm, aead_key(secret()), IV, Plaintext, <<>>, true
     ),
     b64(<<IV/binary, Tag/binary, Cipher/binary>>).
 
@@ -190,29 +198,59 @@ encrypt_envelope(Plaintext) ->
 do_decrypt(Encrypted, Now) ->
     try
         <<IV:?IV_SIZE/binary, Tag:?TAG_SIZE/binary, Cipher/binary>> = unb64(Encrypted),
-        case crypto:crypto_one_time_aead(aes_256_gcm, aead_key(), IV, Cipher, <<>>, Tag, false) of
+        case decrypt_candidates(candidate_keys(), IV, Cipher, Tag) of
             error -> error;
-            Plaintext when is_binary(Plaintext) -> unwrap(Plaintext, Now)
+            Plaintext -> unwrap(Plaintext, Now)
         end
     catch
         _:_ -> error
     end.
 
-%% Derive a 32-byte AES-256 key from secret_key, domain-separated from the raw
-%% secret used for HMAC signing so the encrypt and sign uses never share key material.
-aead_key() ->
-    crypto:hash(sha256, <<"arizona.aead.v1:", (secret())/binary>>).
+%% Try each candidate key (primary first, then rotated-out previous keys) until one
+%% authenticates the ciphertext; `error` when none do.
+decrypt_candidates([], _IV, _Cipher, _Tag) ->
+    error;
+decrypt_candidates([Key | Rest], IV, Cipher, Tag) ->
+    case crypto:crypto_one_time_aead(aes_256_gcm, aead_key(Key), IV, Cipher, <<>>, Tag, false) of
+        error -> decrypt_candidates(Rest, IV, Cipher, Tag);
+        Plaintext when is_binary(Plaintext) -> Plaintext
+    end.
+
+%% Derive a 32-byte AES-256 key from a signing key, domain-separated from its raw
+%% form (used for HMAC) so the encrypt and sign uses never share key material.
+aead_key(Key) ->
+    crypto:hash(sha256, <<"arizona.aead.v1:", Key/binary>>).
+
+%% The keys to try when verifying/decrypting: the primary (`secret_key`) first, then
+%% any `secret_key_previous` rotated-out keys. Signing/encryption always use the
+%% primary. Rotate by moving the old primary into `secret_key_previous` and setting a
+%% new `secret_key`: existing values keep verifying under the old key for the grace
+%% window -- no forced re-issue, no wire-format change.
+candidate_keys() ->
+    [secret() | application:get_env(arizona, secret_key_previous, [])].
 
 %% The clock is injected so the expiry boundary is deterministically testable.
 do_verify(Signed, Now) ->
     try
         [B64Tagged, B64Sig] = binary:split(Signed, ~"."),
         Tagged = unb64(B64Tagged),
-        Expected = crypto:mac(hmac, sha256, secret(), Tagged),
-        true = crypto:hash_equals(unb64(B64Sig), Expected),
-        unwrap(Tagged, Now)
+        Sig = unb64(B64Sig),
+        case verify_candidates(candidate_keys(), Tagged, Sig) of
+            true -> unwrap(Tagged, Now);
+            false -> error
+        end
     catch
         _:_ -> error
+    end.
+
+%% Constant-time HMAC compare against each candidate key (primary first, then
+%% rotated-out previous keys); `true` when any matches.
+verify_candidates([], _Tagged, _Sig) ->
+    false;
+verify_candidates([Key | Rest], Tagged, Sig) ->
+    case crypto:hash_equals(Sig, crypto:mac(hmac, sha256, Key, Tagged)) of
+        true -> true;
+        false -> verify_candidates(Rest, Tagged, Sig)
     end.
 
 unwrap(<<?TAG_RAW, Payload/binary>>, _Now) ->

--- a/test/arizona_crypto_SUITE.erl
+++ b/test/arizona_crypto_SUITE.erl
@@ -21,6 +21,10 @@
 -export([decrypt_rejects_truncated/1]).
 -export([decrypt_rejects_wrong_secret/1]).
 -export([encrypt_ttl_verifies_before_expiry/1]).
+-export([verify_accepts_previous_key/1]).
+-export([decrypt_accepts_previous_key/1]).
+-export([verify_rejects_fully_rotated_key/1]).
+-export([decrypt_rejects_fully_rotated_key/1]).
 -export([secret_returns_configured/1]).
 -export([secret_errors_when_unset/1]).
 -export([sign_errors_when_secret_unset/1]).
@@ -49,6 +53,10 @@ all() ->
         decrypt_rejects_truncated,
         decrypt_rejects_wrong_secret,
         encrypt_ttl_verifies_before_expiry,
+        verify_accepts_previous_key,
+        decrypt_accepts_previous_key,
+        verify_rejects_fully_rotated_key,
+        decrypt_rejects_fully_rotated_key,
         secret_returns_configured,
         secret_errors_when_unset,
         sign_errors_when_secret_unset,
@@ -156,6 +164,49 @@ encrypt_ttl_verifies_before_expiry(Config) when is_list(Config) ->
     ?assertMatch(
         {ok, Payload}, arizona_crypto:decrypt(arizona_crypto:encrypt(Payload, #{ttl => 3600}))
     ).
+
+verify_accepts_previous_key(Config) when is_list(Config) ->
+    %% Sign under the current key, then rotate it into secret_key_previous behind a
+    %% fresh primary -- the old value still verifies during the grace window.
+    Signed = arizona_crypto:sign(~"payload"),
+    application:set_env(arizona, secret_key, ~"a-fresh-primary-key-after-rotation"),
+    application:set_env(arizona, secret_key_previous, [?SECRET]),
+    try
+        ?assertMatch({ok, ~"payload"}, arizona_crypto:verify(Signed))
+    after
+        application:set_env(arizona, secret_key, ?SECRET),
+        application:unset_env(arizona, secret_key_previous)
+    end.
+
+decrypt_accepts_previous_key(Config) when is_list(Config) ->
+    Blob = arizona_crypto:encrypt(~"payload"),
+    application:set_env(arizona, secret_key, ~"a-fresh-primary-key-after-rotation"),
+    application:set_env(arizona, secret_key_previous, [?SECRET]),
+    try
+        ?assertMatch({ok, ~"payload"}, arizona_crypto:decrypt(Blob))
+    after
+        application:set_env(arizona, secret_key, ?SECRET),
+        application:unset_env(arizona, secret_key_previous)
+    end.
+
+verify_rejects_fully_rotated_key(Config) when is_list(Config) ->
+    %% Once the old key is dropped from secret_key_previous, its values stop verifying.
+    Signed = arizona_crypto:sign(~"payload"),
+    application:set_env(arizona, secret_key, ~"a-fresh-primary-key-after-rotation"),
+    try
+        ?assertEqual(error, arizona_crypto:verify(Signed))
+    after
+        application:set_env(arizona, secret_key, ?SECRET)
+    end.
+
+decrypt_rejects_fully_rotated_key(Config) when is_list(Config) ->
+    Blob = arizona_crypto:encrypt(~"payload"),
+    application:set_env(arizona, secret_key, ~"a-fresh-primary-key-after-rotation"),
+    try
+        ?assertEqual(error, arizona_crypto:decrypt(Blob))
+    after
+        application:set_env(arizona, secret_key, ?SECRET)
+    end.
 
 secret_returns_configured(Config) when is_list(Config) ->
     ?assertEqual(?SECRET, arizona_crypto:secret()).


### PR DESCRIPTION
# Description

Adds zero-downtime key rotation to `arizona_crypto`: `sign`/`encrypt` still use the primary `secret_key`, but `verify`/`decrypt` now also accept any key in an optional `secret_key_previous` list (default `[]`), trying each in turn. Rotate by moving the old key into `secret_key_previous`, setting a fresh `secret_key`, and dropping the old one after the grace window -- no forced re-issue and no wire-format change, so existing flash/session cookies keep verifying across the rotation.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
