### PR TITLE
Treat atomic-rename saves as reload-worthy file events

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -648,7 +648,9 @@ callback, broadcasts changed files via `arizona_pubsub`.
 - `start_link(Dir, Opts)` -- starts a linked gen_server that subscribes to `fs` events for `Dir`.
   Options: `patterns` (list of regex strings, default `[".*"]`), `callback` (fun receiving list of
   changed file paths), `debounce` (ms, default 100). On debounce fire: calls callback, then
-  `broadcast/1`
+  `broadcast/1`. Relevant file events are `created`, `modified`, `deleted`, and `renamed`
+  (MOVED_TO) -- the last covers atomic-rename saves (vim, `sed -i`, agent file-writers); directory
+  renames (`isdir`) and files moved out of the dir (`removed`) are ignored
 - `broadcast(Files)` -- broadcasts `{arizona_watcher, Files}` via `arizona_pubsub` on channel
   `arizona_watcher`
 

--- a/src/arizona_watcher.erl
+++ b/src/arizona_watcher.erl
@@ -29,6 +29,11 @@ topic named `arizona_watcher`.
 - `debounce` -- milliseconds to wait after the last event before flushing
   (default `100`); coalesces editor-save bursts into a single event
 
+Both in-place saves (`modified`) and atomic-rename saves (`renamed`, the
+write-temp-then-`rename()` pattern used by vim, `sed -i`, and most editors and
+agent file-writers) trigger a reload. Directory renames (`isdir`) and files
+moved out of the watched directory (`removed`) do not.
+
 ## Lifecycle and shutdown
 
 The `fs` library spawns an OS process (`sh` + `inotifywait`) with the
@@ -217,7 +222,21 @@ watcher_name(AbsDir) ->
 is_relevant_event(Events) ->
     lists:member(created, Events) orelse
         lists:member(modified, Events) orelse
-        lists:member(deleted, Events).
+        lists:member(deleted, Events) orelse
+        is_file_rename(Events).
+
+%% Atomic-rename saves -- write to a temp file then rename() over the target --
+%% are what vim (default), `sed -i`, and most editors/agent file-writers do.
+%% The `fs` inotify backend maps the resulting MOVED_TO to `renamed`, so treat
+%% it as a real edit or those saves would silently skip hot reload.
+%%
+%% Two deliberate exclusions:
+%%   - `isdir`: a directory being renamed is not a source-file edit; skip it.
+%%   - `removed` (MOVED_FROM): a file moving *out* of the watched dir is
+%%     delete-like; the path is now absent, so forcing a recompile of a
+%%     vanished path is pointless. Real deletes already emit `deleted`.
+is_file_rename(Events) ->
+    lists:member(renamed, Events) andalso not lists:member(isdir, Events).
 
 file_matches(FilePath, #state{abs_dir = AbsDir, compiled = Compiled}) ->
     in_directory(FilePath, AbsDir) andalso matches_pattern(FilePath, Compiled).

--- a/test/arizona_watcher_SUITE.erl
+++ b/test/arizona_watcher_SUITE.erl
@@ -18,6 +18,8 @@
     event_irrelevant/1,
     event_created/1,
     event_deleted/1,
+    event_renamed/1,
+    event_removed/1,
     debounce_accumulates/1,
     debounce_resets_timer/1,
     debounce_deduplicates/1,
@@ -46,6 +48,8 @@ groups() ->
             event_irrelevant,
             event_created,
             event_deleted,
+            event_renamed,
+            event_removed,
             debounce_accumulates,
             debounce_resets_timer,
             debounce_deduplicates,
@@ -132,6 +136,9 @@ event_outside_dir(Config) when is_list(Config) ->
 event_irrelevant(Config) when is_list(Config) ->
     W = proplists:get_value(watcher, Config),
     Dir = proplists:get_value(tmp_dir, Config),
+    %% A directory rename (`isdir` + `renamed`) is not a source-file edit, so
+    %% it must not reload -- distinct from a plain file `renamed` (see
+    %% event_renamed), which is an atomic-rename save and does reload.
     send_fs_event(W, Dir ++ "/file.erl", [isdir, renamed]),
     timer:sleep(100),
     assert_no_messages().
@@ -153,6 +160,29 @@ event_deleted(Config) when is_list(Config) ->
         {cb, _} -> ok
     after 500 -> ct:fail(no_callback)
     end.
+
+%% Atomic-rename saves (vim, `sed -i`, agent file-writers) write a temp file
+%% then rename() over the target; the `fs` inotify backend reports MOVED_TO as
+%% `renamed`. This must reload like an in-place save.
+event_renamed(Config) when is_list(Config) ->
+    W = proplists:get_value(watcher, Config),
+    Dir = proplists:get_value(tmp_dir, Config),
+    File = Dir ++ "/atomic.erl",
+    send_fs_event(W, File, [renamed]),
+    receive
+        {cb, Files} -> ?assert(lists:member(File, Files))
+    after 500 -> ct:fail(no_callback)
+    end.
+
+%% A file moved *out* of the watched dir reports MOVED_FROM as `removed`. The
+%% path is now absent, so it is delete-like and must not force a reload (real
+%% deletes already emit `deleted`).
+event_removed(Config) when is_list(Config) ->
+    W = proplists:get_value(watcher, Config),
+    Dir = proplists:get_value(tmp_dir, Config),
+    send_fs_event(W, Dir ++ "/gone.erl", [removed]),
+    timer:sleep(100),
+    assert_no_messages().
 
 debounce_accumulates(Config) when is_list(Config) ->
     W = proplists:get_value(watcher, Config),


### PR DESCRIPTION
# Description

The dev-mode file watcher only treated `created`/`modified`/`deleted` as reload-worthy, so atomic-rename saves -- write a temp file then `rename()` over the target, the default for vim, `sed -i`, and most editors and agent file-writers -- were silently ignored and never triggered a hot reload. Treat a file `renamed` event (inotify MOVED_TO) as a real edit too, while excluding directory renames (`isdir`) and files moved out of the watched directory (`removed`, MOVED_FROM, which are delete-like with an absent path).

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
