### PR TITLE
Stop escaping the dev error page's live-reload script tag

### DIFF
--- a/.claude/rules/erlang.md
+++ b/.claude/rules/erlang.md
@@ -152,6 +152,7 @@ Adding `'az-nodiff'` to an element's attribute list marks it as a compile-time d
 | `?stateless(Fun, Props)` | `arizona_template:stateless(fun Fun/1, Props)` |
 | `?stateless(Mod, Fun, Props)` | `arizona_template:stateless(Mod, Fun, Props)` |
 | `?local(Key, Init)` | `arizona_template:local(Key, Init)` -- client-owned slot: server renders `Init` once and never diffs it; the browser owns/updates the value via `Key` (a binary or atom literal; content -- one or many per element, mixed with static text -- or an attribute value, whole or interpolated with one local + static prefix/suffix) |
+| `?raw(Value)` | `arizona_template:raw(Value)` -- escape opt-out: splices a trusted, already-safe HTML fragment verbatim into a content slot or attribute value instead of HTML-escaping it. The parse transform only recognizes the opt-out when the `raw` call is **literal at the template site**, so wrap values here, never inside a helper. Never for user-controlled data |
 | `?connected` | `arizona_live:connected()` -- true inside a connected live process, false during SSR |
 | `?send(Msg)` | `arizona_live:send(?get(id), Msg)` -- send to current view (stateful only) |
 | `?send(ViewId, Msg)` | `arizona_live:send(ViewId, Msg)` -- send to specific view (stateful only) |

--- a/include/arizona_common.hrl
+++ b/include/arizona_common.hrl
@@ -15,6 +15,12 @@
 -define(terminal(Elems), arizona_template:terminal(Elems)).
 -define(each(Fun, Source), arizona_template:each(Fun, Source)).
 
+%% Escape opt-out -- splices a trusted, already-safe HTML fragment verbatim into a
+%% content slot or attribute value instead of HTML-escaping it. The parse transform
+%% only recognizes the opt-out when the `raw` call is literal at the template site,
+%% so wrap values here, never inside a helper. Never use for user-controlled data.
+-define(raw(Value), arizona_template:raw(Value)).
+
 %% Descriptor constructors
 -define(stateful(Handler, Props), arizona_template:stateful(Handler, Props)).
 -define(stateless(Fun, Props), arizona_template:stateless(Fun, Props)).

--- a/src/arizona_error_page.erl
+++ b/src/arizona_error_page.erl
@@ -96,7 +96,7 @@ render(Bindings) ->
                         Stacktrace
                     )
                 ]},
-                reload_script(ReloadUrl)
+                ?raw(reload_script(ReloadUrl))
             ]}
         ]}
     ).
@@ -327,6 +327,10 @@ relative_path(File) ->
             File
     end.
 
+%% Trusted, framework-built markup -- the caller wraps it in `?raw` so the
+%% content slot splices it verbatim and the browser sees a real <script> tag
+%% rather than escaped text (`?raw` must be the literal call at the template
+%% site for the parse transform to recognize the escape opt-out).
 reload_script(undefined) ->
     <<>>;
 reload_script(Url) ->
@@ -367,7 +371,9 @@ render_with_reload_url_test() ->
     },
     Tmpl = render(#{error_info => ErrorInfo}),
     HTML = iolist_to_binary(arizona_render:render_to_iolist(Tmpl)),
-    ?assertNotEqual(nomatch, binary:match(HTML, <<"EventSource">>)),
-    ?assertNotEqual(nomatch, binary:match(HTML, <<"/reload">>)).
+    %% Must be a real <script> tag, not escaped text -- assert the literal
+    %% opening tag is present and that no escaped form (&lt;script&gt;) leaked.
+    ?assertNotEqual(nomatch, binary:match(HTML, <<"<script>new EventSource('/reload')">>)),
+    ?assertEqual(nomatch, binary:match(HTML, <<"&lt;script&gt;">>)).
 
 -endif.


### PR DESCRIPTION
# Description

The dev-mode error page rendered the live-reload `<script>` as escaped text instead of a real tag, so auto-reload never armed once a page failed to compile. Adds a `?raw` macro for the template escape opt-out and uses it to splice the reload script verbatim.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
