### PR TITLE
Auto-track binding reads used in template guards

### DIFF
--- a/.claude/rules/erlang.md
+++ b/.claude/rules/erlang.md
@@ -301,9 +301,20 @@ case ?get(mode) of dark -> X = ?get(a); _ -> X = ?get(b) end, ?html({p, [], [X]}
 
 Exceptions that stay un-tracked (slot frozen after SSR): a binding destructured
 in the head (`render(#{foo := Foo})`) or through any non-bare-var pattern
-(`{ok, V} = ?get(...)` -- use `?get(foo)` then plain destructuring), a read
-reachable only through a guard, a variable bound inside an `if` or a `case`
-branch whose clause head binds a variable, and a rebound variable.
+(`{ok, V} = ?get(...)` -- use `?get(foo)` then plain destructuring), a variable
+bound inside a `case` branch whose clause head binds a variable, and a rebound
+variable.
+
+A tracked read used in a **guard** inside a template (`case Status of active when
+Confirming -> ...`, an `if`, a fun-clause guard) is a compile error
+(`tracked_read_in_guard`), not a silent freeze. A guard cannot hold the `get/2`
+call (Erlang rejects it as an illegal guard expression), so the read can never
+re-run inside the slot's dependency bracket -- the dependency would be dropped and
+the slot would stop updating when that binding changes. The transform rejects it:
+move the test into the `case` scrutinee or clause body so the read is tracked
+(`case {?get(status), ?get(confirming)} of {active, true} -> ...`), or replace the
+guard with a pattern match. Only a tracked read reaches this -- a non-tracked local
+or a pattern-bound variable in a guard is fine.
 
 `?get`/`get_lazy`/`with` are for the **view bindings**, not sub-maps: they call
 `track/1` regardless of which map they read, so reading a nested map records the

--- a/.claude/rules/erlang.md
+++ b/.claude/rules/erlang.md
@@ -306,15 +306,14 @@ bound inside a `case` branch whose clause head binds a variable, and a rebound
 variable.
 
 A tracked read used in a **guard** inside a template (`case Status of active when
-Confirming -> ...`, an `if`, a fun-clause guard) is a compile error
-(`tracked_read_in_guard`), not a silent freeze. A guard cannot hold the `get/2`
-call (Erlang rejects it as an illegal guard expression), so the read can never
-re-run inside the slot's dependency bracket -- the dependency would be dropped and
-the slot would stop updating when that binding changes. The transform rejects it:
-move the test into the `case` scrutinee or clause body so the read is tracked
-(`case {?get(status), ?get(confirming)} of {active, true} -> ...`), or replace the
-guard with a pattern match. Only a tracked read reaches this -- a non-tracked local
-or a pattern-bound variable in a guard is fine.
+Confirming -> ...`, an `if`, a nested fun) is **auto-tracked**, so the slot stays
+reactive. A guard cannot hold the `get/2` call (Erlang rejects it as an illegal guard
+expression), so the read can't run inside the slot's dependency bracket on its own; the
+transform wraps the guard-bearing expression so it first reads (for the `track/1` side
+effect) each binding the guards reference, recording them as slot dependencies. The guard
+keeps using the captured value, which each diff cycle rebuilds from current bindings, so a
+change to a guard binding re-renders the slot. A non-tracked local or a pattern-bound
+variable in a guard needs nothing -- there is no binding dependency to record.
 
 `?get`/`get_lazy`/`with` are for the **view bindings**, not sub-maps: they call
 `track/1` regardless of which map they read, so reading a nested map records the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -274,12 +274,26 @@ and idiomatic templates (reads written inside `?html`) are unaffected.
 destructured in the function head (`render(#{foo := Foo})`) or through any
 non-bare-var pattern (`{ok, V} = ?get(...)`) -- a pattern match is an untracked
 read; read the whole value with `?get(foo)` and destructure with plain Erlang.
-Also: a read reachable only through a guard (`when N > 5` -- a guard cannot hold
-a `get`), a variable bound inside an `if` or a `case` branch whose clause head
-itself binds a variable, and a rebound variable. Use `?get` for the top-level
-binding and plain `maps:get/2` for sub-structures (only the `?get` records a dep,
-which is the correct grain). In all these cases the read is left captured and the
-slot keeps its SSR value; the transform never makes valid code uncompilable.
+Also: a variable bound inside a `case` branch whose clause head itself binds a
+variable, and a rebound variable. Use `?get` for the top-level binding and plain
+`maps:get/2` for sub-structures (only the `?get` records a dep, which is the
+correct grain). In these cases the read is left captured and the slot keeps its
+SSR value.
+
+**The one read that is rejected, not frozen:** a tracked read used in a **guard**
+(`case Status of active when Confirming -> ...`, an `if`, a fun-clause guard) is a
+compile error (`tracked_read_in_guard`). A guard cannot hold the `get/2` call
+(Erlang itself rejects that as an illegal guard expression), so `inline_vars`
+leaves guards untouched -- the read then never re-runs inside the slot's dependency
+bracket, the dep is dropped, and the slot would silently stop updating when that
+binding changes. Because the only way a tracked read reaches a guard is a pre-bound
+variable, scanning each clause's guards for an inline-map variable is the whole
+check (`iv_clause` / `iv_fun_clause`). This is the one place the transform makes
+otherwise-compilable code fail to compile, deliberately: the alternative is a silent
+freeze. The fix is to move the test into the `case` scrutinee or clause body
+(`case {?get(status), ?get(confirming)} of {active, true} -> ...`) so the read is
+tracked, or to pattern-match instead of guarding. A non-tracked local or a
+pattern-bound variable in a guard is unaffected.
 
 ## Tracked accessors, the sub-map diagnostic, and `with/2`
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -280,20 +280,24 @@ variable, and a rebound variable. Use `?get` for the top-level binding and plain
 correct grain). In these cases the read is left captured and the slot keeps its
 SSR value.
 
-**The one read that is rejected, not frozen:** a tracked read used in a **guard**
-(`case Status of active when Confirming -> ...`, an `if`, a fun-clause guard) is a
-compile error (`tracked_read_in_guard`). A guard cannot hold the `get/2` call
-(Erlang itself rejects that as an illegal guard expression), so `inline_vars`
-leaves guards untouched -- the read then never re-runs inside the slot's dependency
-bracket, the dep is dropped, and the slot would silently stop updating when that
-binding changes. Because the only way a tracked read reaches a guard is a pre-bound
-variable, scanning each clause's guards for an inline-map variable is the whole
-check (`iv_clause` / `iv_fun_clause`). This is the one place the transform makes
-otherwise-compilable code fail to compile, deliberately: the alternative is a silent
-freeze. The fix is to move the test into the `case` scrutinee or clause body
-(`case {?get(status), ?get(confirming)} of {active, true} -> ...`) so the read is
-tracked, or to pattern-match instead of guarding. A non-tracked local or a
-pattern-bound variable in a guard is unaffected.
+**A tracked read used in a guard is auto-tracked, not frozen:** a binding read in a
+**guard** (`case Status of active when Confirming -> ...`, an `if`) can't run inside the
+slot's dependency bracket on its own -- a guard cannot hold the `get/2` call (Erlang
+rejects that as an illegal guard expression), so `inline_vars` leaves guards as bound
+variables. Left alone the read would run once in the function body, outside the bracket,
+and the slot would silently freeze on that binding. Instead, the guard-bearing `iv` node
+(`{'case',...}` / `{'if',...}` / `{'receive',...}` / `{'try',...}` / `{'maybe',...}`, and
+a nested `fun`) wraps itself in a block that first reads each tracked binding its clause
+guards reference -- `begin _ = arizona_template:get(K, Bindings), ..., <expr> end` -- for
+the `track/1` side effect, recording those bindings as slot dependencies
+(`wrap_guard_touches/4`, collecting via `guard_tracked_vars/2` with per-clause shadow
+handling). The guard keeps using the captured value, which each diff cycle rebuilds from
+current bindings, so a change to a guard binding re-renders the slot. Reusing the inline
+expansion as the touch (`iv({var,L,V}, Inline)`) handles `get`/`get_lazy`/`with` and
+transitively-derived vars uniformly. A non-tracked local or a pattern-bound variable in a
+guard needs no touch (no binding dependency). The one fun NOT wrapped is a top-level
+`?each` callback (handled in `inline_vars/2`): `compile_each` needs a single-clause fun,
+and its guards are over the item param, not outer tracked vars.
 
 ## Tracked accessors, the sub-map diagnostic, and `with/2`
 

--- a/src/arizona_parse_transform.erl
+++ b/src/arizona_parse_transform.erl
@@ -377,22 +377,7 @@ format_error(tracked_get_on_non_bindings_map) ->
     "direct alias (`B = Bindings`). This local is not provably the bindings. If it is a "
     "nested map, read it with maps:get/2 (`User = arizona_template:get(user, Bindings), "
     "Name = maps:get(name, User)`); if it is a bindings value reached through a "
-    "case/merge the transform cannot see into, alias it directly with `B = Bindings` first";
-format_error({tracked_read_in_guard, Var}) ->
-    lists:flatten(
-        io_lib:format(
-            "'~s' holds a value read from the view bindings "
-            "(arizona_template:get/get_lazy/with) and is then used in a guard inside a template. "
-            "A guard cannot re-run that read -- Erlang rejects a function call in a guard -- so it "
-            "never executes inside the slot's dependency bracket: the slot records no dependency "
-            "on that binding and freezes at its SSR value, no longer updating when the binding "
-            "changes. Move the test out of the guard so the read is tracked -- read it in the case "
-            "scrutinee or the clause body, e.g. `case {arizona_template:get(status, Bindings), "
-            "arizona_template:get(confirming, Bindings)} of {active, true} -> ... end`, or replace "
-            "the guard with a pattern match.",
-            [Var]
-        )
-    ).
+    "case/merge the transform cannot see into, alias it directly with `B = Bindings` first".
 
 %% --------------------------------------------------------------------
 %% Internal functions
@@ -913,6 +898,14 @@ strip_tail_bind({clause, L, Patterns, Guards, [{match, _, {var, _, _V}, E}]}) ->
 %% substitution can never produce an illegal pattern.
 inline_vars(Expr, Inline) when map_size(Inline) =:= 0 ->
     Expr;
+%% A bare top-level fun is an ?each callback (compile_each is the only caller that passes a
+%% fun straight to inline_vars); inline its clauses but DON'T wrap it -- compile_each needs a
+%% fun literal, not a block. A fun NESTED in a content slot is wrapped by iv/2 below.
+inline_vars({'fun', L, {clauses, Cs}}, Inline) ->
+    {'fun', L, {clauses, [iv_fun_clause(C, Inline) || C <- Cs]}};
+inline_vars({named_fun, L, Name, Cs}, Inline) ->
+    Inline1 = maps:remove(Name, Inline),
+    {named_fun, L, Name, [iv_fun_clause(C, Inline1) || C <- Cs]};
 inline_vars(Expr, Inline) ->
     iv(Expr, Inline).
 
@@ -922,25 +915,33 @@ iv({var, _, V} = Var, Inline) ->
         #{} -> Var
     end;
 iv({'fun', L, {clauses, Cs}}, Inline) ->
-    {'fun', L, {clauses, [iv_fun_clause(C, Inline) || C <- Cs]}};
+    Node = {'fun', L, {clauses, [iv_fun_clause(C, Inline) || C <- Cs]}},
+    wrap_guard_touches(Node, L, Cs, Inline);
 iv({named_fun, L, Name, Cs}, Inline) ->
     Inline1 = maps:remove(Name, Inline),
-    {named_fun, L, Name, [iv_fun_clause(C, Inline1) || C <- Cs]};
+    Node = {named_fun, L, Name, [iv_fun_clause(C, Inline1) || C <- Cs]},
+    wrap_guard_touches(Node, L, Cs, Inline1);
 iv({'case', L, E, Cs}, Inline) ->
-    {'case', L, iv(E, Inline), [iv_clause(C, Inline) || C <- Cs]};
+    Node = {'case', L, iv(E, Inline), [iv_clause(C, Inline) || C <- Cs]},
+    wrap_guard_touches(Node, L, Cs, Inline);
 iv({'if', L, Cs}, Inline) ->
-    {'if', L, [iv_clause(C, Inline) || C <- Cs]};
+    Node = {'if', L, [iv_clause(C, Inline) || C <- Cs]},
+    wrap_guard_touches(Node, L, Cs, Inline);
 iv({'receive', L, Cs}, Inline) ->
-    {'receive', L, [iv_clause(C, Inline) || C <- Cs]};
+    Node = {'receive', L, [iv_clause(C, Inline) || C <- Cs]},
+    wrap_guard_touches(Node, L, Cs, Inline);
 iv({'receive', L, Cs, AE, AB}, Inline) ->
-    {'receive', L, [iv_clause(C, Inline) || C <- Cs], iv(AE, Inline), iv_body(AB, Inline)};
+    Node = {'receive', L, [iv_clause(C, Inline) || C <- Cs], iv(AE, Inline), iv_body(AB, Inline)},
+    wrap_guard_touches(Node, L, Cs, Inline);
 iv({'try', L, B, OfCs, CatchCs, Aft}, Inline) ->
-    {'try', L, iv_body(B, Inline), [iv_clause(C, Inline) || C <- OfCs],
-        [
-            iv_clause(C, Inline)
-         || C <- CatchCs
-        ],
-        iv_body(Aft, Inline)};
+    Node =
+        {'try', L, iv_body(B, Inline), [iv_clause(C, Inline) || C <- OfCs],
+            [
+                iv_clause(C, Inline)
+             || C <- CatchCs
+            ],
+            iv_body(Aft, Inline)},
+    wrap_guard_touches(Node, L, OfCs ++ CatchCs, Inline);
 iv({'catch', L, E}, Inline) ->
     {'catch', L, iv(E, Inline)};
 iv({Comp, L, T, Qs}, Inline) when Comp =:= lc; Comp =:= bc; Comp =:= mc ->
@@ -953,7 +954,8 @@ iv({match, L, P, E}, Inline) ->
 iv({'maybe', L, B}, Inline) ->
     {'maybe', L, iv_body(B, Inline)};
 iv({'maybe', L, B, {'else', L2, Cs}}, Inline) ->
-    {'maybe', L, iv_body(B, Inline), {'else', L2, [iv_clause(C, Inline) || C <- Cs]}};
+    Node = {'maybe', L, iv_body(B, Inline), {'else', L2, [iv_clause(C, Inline) || C <- Cs]}},
+    wrap_guard_touches(Node, L, Cs, Inline);
 iv({maybe_match, L, P, E}, Inline) ->
     {maybe_match, L, P, iv(E, Inline)};
 iv(T, Inline) when is_tuple(T) ->
@@ -963,55 +965,73 @@ iv(L, Inline) when is_list(L) ->
 iv(Other, _Inline) ->
     Other.
 
-%% Fun clause: parameters bind and shadow; drop them from the map for the body.
+%% Fun clause: parameters bind and shadow; drop them from the map for the body. Guards
+%% stay untouched (a binding read can't live in a guard); a tracked binding read in a
+%% nested fun's guard is auto-tracked by the enclosing fun node (wrap_guard_touches/4 in
+%% iv/2). A top-level ?each callback fun is inlined through here too but not wrapped (see
+%% inline_vars/2: compile_each needs a single-clause fun, whose guards are over the item
+%% param, not outer tracked vars).
 iv_fun_clause({clause, L, Params, Guards, Body}, Inline) ->
     Inline1 = maps:without(pattern_vars(Params), Inline),
-    reject_tracked_guard(Guards, Inline1),
     {clause, L, Params, Guards, iv_body(Body, Inline1)}.
 
 %% case/receive/try-of/catch clause: patterns match the (already inlined) scrutinee,
 %% so patterns and guards are left untouched. Any name a pattern binds is dropped from
-%% the map for the body as a conservative shadow guard.
+%% the map for the body as a conservative shadow guard. A tracked binding read in a guard
+%% is handled by the enclosing node via wrap_guard_touches/4, not here.
 iv_clause({clause, L, Patterns, Guards, Body}, Inline) ->
     Inline1 = maps:without(pattern_vars(Patterns), Inline),
-    reject_tracked_guard(Guards, Inline1),
     {clause, L, Patterns, Guards, iv_body(Body, Inline1)}.
 
-%% A tracked (`?get`/`get_lazy`/`with`-derived) variable used in a guard inside a
-%% template freezes the slot silently. inline_vars leaves guards untouched -- it has
-%% to, since Erlang forbids the get/2 call in a guard -- so the read never re-runs
-%% inside the slot's dependency bracket: the dependency is dropped and the slot stops
-%% updating when that binding changes. Erlang accepts the guard (a bound variable is
-%% legal), so nothing complains. The only path a tracked read can reach a guard is a
-%% pre-bound variable (a literal `?get` there is already an "illegal guard expression"),
-%% so scanning the guards for an inline-map variable is the whole detection. Reject it
-%% so the freeze is a loud compile error instead.
-reject_tracked_guard(_Guards, Inline) when map_size(Inline) =:= 0 ->
-    ok;
-reject_tracked_guard(Guards, Inline) ->
-    case tracked_guard_var(Guards, Inline) of
-        none -> ok;
-        {V, L} -> parse_error({tracked_read_in_guard, V}, L)
+%% A binding read (`?get`/`get_lazy`/`with`-derived, hence in the inline map) cannot live
+%% in a guard -- Erlang forbids a function call there -- so guards are left as bound
+%% variables. The read then never re-runs inside the slot's dependency bracket, and the
+%% slot would silently freeze on that binding. To keep the slot reactive, wrap the
+%% guard-bearing expression in a block that first reads (for the `track/1` side effect)
+%% each tracked binding its guards reference, recording them as slot dependencies. The
+%% guard keeps using the captured value, which each diff cycle rebuilds from the current
+%% bindings, so a change to a guard binding re-renders the slot. No tracked guard var ->
+%% node returned unchanged.
+wrap_guard_touches(Node, L, Clauses, Inline) ->
+    case guard_tracked_vars(Clauses, Inline) of
+        [] -> Node;
+        Vars -> {block, L, [guard_touch(V, L, Inline) || V <- Vars] ++ [Node]}
     end.
 
-%% First reference, depth-first, to an inline-map variable anywhere in the guards
-%% (it may be nested in `andalso`/`is_binary(...)`/comparisons); `none` if there is
-%% none. The `{var, _, _}` clause is matched ahead of the generic tuple walk so a var
-%% node is never decomposed.
-tracked_guard_var({var, L, V}, Inline) ->
-    case is_map_key(V, Inline) of
-        true -> {V, L};
-        false -> none
+%% Read V's inlined definition (its get/get_lazy/with call) for the track side effect,
+%% discarding the value. Reusing the inline expansion handles get/get_lazy/with and
+%% transitively-derived vars uniformly without extracting the binding key.
+guard_touch(V, L, Inline) ->
+    {match, L, {var, L, '_'}, iv({var, L, V}, Inline)}.
+
+%% Union (first-seen order) of inline-map variables referenced in any clause guard,
+%% respecting each clause's own pattern/parameter shadowing.
+guard_tracked_vars(Clauses, Inline) ->
+    lists:reverse(
+        lists:foldl(
+            fun({clause, _, Patterns, Guards, _}, Acc) ->
+                ClauseInline = maps:without(pattern_vars(Patterns), Inline),
+                collect_guard_vars(Guards, ClauseInline, Acc)
+            end,
+            [],
+            Clauses
+        )
+    ).
+
+%% Depth-first collect of inline-map variable names in a guard AST (they may be nested in
+%% `andalso`/`is_binary(...)`/comparisons). The `{var, _, _}` clause is matched ahead of
+%% the generic tuple walk so a var node is never decomposed.
+collect_guard_vars({var, _, V}, Inline, Acc) ->
+    case is_map_key(V, Inline) andalso not lists:member(V, Acc) of
+        true -> [V | Acc];
+        false -> Acc
     end;
-tracked_guard_var(T, Inline) when is_tuple(T) ->
-    tracked_guard_var(tuple_to_list(T), Inline);
-tracked_guard_var([H | T], Inline) ->
-    case tracked_guard_var(H, Inline) of
-        none -> tracked_guard_var(T, Inline);
-        Found -> Found
-    end;
-tracked_guard_var(_Other, _Inline) ->
-    none.
+collect_guard_vars(T, Inline, Acc) when is_tuple(T) ->
+    collect_guard_vars(tuple_to_list(T), Inline, Acc);
+collect_guard_vars([H | T], Inline, Acc) ->
+    collect_guard_vars(T, Inline, collect_guard_vars(H, Inline, Acc));
+collect_guard_vars(_Other, _Inline, Acc) ->
+    Acc.
 
 %% A body is a sequence; a `Var = RHS` match binds Var (shadowing) for later exprs.
 iv_body(Exprs, Inline) ->

--- a/src/arizona_parse_transform.erl
+++ b/src/arizona_parse_transform.erl
@@ -915,33 +915,19 @@ iv({var, _, V} = Var, Inline) ->
         #{} -> Var
     end;
 iv({'fun', L, {clauses, Cs}}, Inline) ->
-    Node = {'fun', L, {clauses, [iv_fun_clause(C, Inline) || C <- Cs]}},
-    wrap_guard_touches(Node, L, Cs, Inline);
+    iv_fun(L, Cs, Inline);
 iv({named_fun, L, Name, Cs}, Inline) ->
-    Inline1 = maps:remove(Name, Inline),
-    Node = {named_fun, L, Name, [iv_fun_clause(C, Inline1) || C <- Cs]},
-    wrap_guard_touches(Node, L, Cs, Inline1);
+    iv_named_fun(L, Name, Cs, Inline);
 iv({'case', L, E, Cs}, Inline) ->
-    Node = {'case', L, iv(E, Inline), [iv_clause(C, Inline) || C <- Cs]},
-    wrap_guard_touches(Node, L, Cs, Inline);
+    iv_case(L, E, Cs, Inline);
 iv({'if', L, Cs}, Inline) ->
-    Node = {'if', L, [iv_clause(C, Inline) || C <- Cs]},
-    wrap_guard_touches(Node, L, Cs, Inline);
+    iv_if(L, Cs, Inline);
 iv({'receive', L, Cs}, Inline) ->
-    Node = {'receive', L, [iv_clause(C, Inline) || C <- Cs]},
-    wrap_guard_touches(Node, L, Cs, Inline);
+    iv_receive(L, Cs, Inline);
 iv({'receive', L, Cs, AE, AB}, Inline) ->
-    Node = {'receive', L, [iv_clause(C, Inline) || C <- Cs], iv(AE, Inline), iv_body(AB, Inline)},
-    wrap_guard_touches(Node, L, Cs, Inline);
+    iv_receive(L, Cs, AE, AB, Inline);
 iv({'try', L, B, OfCs, CatchCs, Aft}, Inline) ->
-    Node =
-        {'try', L, iv_body(B, Inline), [iv_clause(C, Inline) || C <- OfCs],
-            [
-                iv_clause(C, Inline)
-             || C <- CatchCs
-            ],
-            iv_body(Aft, Inline)},
-    wrap_guard_touches(Node, L, OfCs ++ CatchCs, Inline);
+    iv_try(L, B, OfCs, CatchCs, Aft, Inline);
 iv({'catch', L, E}, Inline) ->
     {'catch', L, iv(E, Inline)};
 iv({Comp, L, T, Qs}, Inline) when Comp =:= lc; Comp =:= bc; Comp =:= mc ->
@@ -954,8 +940,7 @@ iv({match, L, P, E}, Inline) ->
 iv({'maybe', L, B}, Inline) ->
     {'maybe', L, iv_body(B, Inline)};
 iv({'maybe', L, B, {'else', L2, Cs}}, Inline) ->
-    Node = {'maybe', L, iv_body(B, Inline), {'else', L2, [iv_clause(C, Inline) || C <- Cs]}},
-    wrap_guard_touches(Node, L, Cs, Inline);
+    iv_maybe_else(L, B, L2, Cs, Inline);
 iv({maybe_match, L, P, E}, Inline) ->
     {maybe_match, L, P, iv(E, Inline)};
 iv(T, Inline) when is_tuple(T) ->
@@ -964,6 +949,45 @@ iv(L, Inline) when is_list(L) ->
     [iv(E, Inline) || E <- L];
 iv(Other, _Inline) ->
     Other.
+
+iv_clauses(Cs, Inline) ->
+    [iv_clause(C, Inline) || C <- Cs].
+
+iv_fun_clauses(Cs, Inline) ->
+    [iv_fun_clause(C, Inline) || C <- Cs].
+
+%% Guard-bearing forms build their node and wrap it (wrap_guard_touches/4) so a tracked
+%% binding read in a clause guard is recorded as a slot dependency. Kept as separate
+%% helpers so iv/2 stays a thin dispatcher.
+iv_fun(L, Cs, Inline) ->
+    wrap_guard_touches({'fun', L, {clauses, iv_fun_clauses(Cs, Inline)}}, L, Cs, Inline).
+
+iv_named_fun(L, Name, Cs, Inline) ->
+    Inline1 = maps:remove(Name, Inline),
+    wrap_guard_touches({named_fun, L, Name, iv_fun_clauses(Cs, Inline1)}, L, Cs, Inline1).
+
+iv_case(L, E, Cs, Inline) ->
+    wrap_guard_touches({'case', L, iv(E, Inline), iv_clauses(Cs, Inline)}, L, Cs, Inline).
+
+iv_if(L, Cs, Inline) ->
+    wrap_guard_touches({'if', L, iv_clauses(Cs, Inline)}, L, Cs, Inline).
+
+iv_receive(L, Cs, Inline) ->
+    wrap_guard_touches({'receive', L, iv_clauses(Cs, Inline)}, L, Cs, Inline).
+
+iv_receive(L, Cs, AE, AB, Inline) ->
+    Node = {'receive', L, iv_clauses(Cs, Inline), iv(AE, Inline), iv_body(AB, Inline)},
+    wrap_guard_touches(Node, L, Cs, Inline).
+
+iv_try(L, B, OfCs, CatchCs, Aft, Inline) ->
+    Node =
+        {'try', L, iv_body(B, Inline), iv_clauses(OfCs, Inline), iv_clauses(CatchCs, Inline),
+            iv_body(Aft, Inline)},
+    wrap_guard_touches(Node, L, OfCs ++ CatchCs, Inline).
+
+iv_maybe_else(L, B, L2, Cs, Inline) ->
+    Node = {'maybe', L, iv_body(B, Inline), {'else', L2, iv_clauses(Cs, Inline)}},
+    wrap_guard_touches(Node, L, Cs, Inline).
 
 %% Fun clause: parameters bind and shadow; drop them from the map for the body. Guards
 %% stay untouched (a binding read can't live in a guard); a tracked binding read in a

--- a/src/arizona_parse_transform.erl
+++ b/src/arizona_parse_transform.erl
@@ -377,7 +377,22 @@ format_error(tracked_get_on_non_bindings_map) ->
     "direct alias (`B = Bindings`). This local is not provably the bindings. If it is a "
     "nested map, read it with maps:get/2 (`User = arizona_template:get(user, Bindings), "
     "Name = maps:get(name, User)`); if it is a bindings value reached through a "
-    "case/merge the transform cannot see into, alias it directly with `B = Bindings` first".
+    "case/merge the transform cannot see into, alias it directly with `B = Bindings` first";
+format_error({tracked_read_in_guard, Var}) ->
+    lists:flatten(
+        io_lib:format(
+            "'~s' holds a value read from the view bindings "
+            "(arizona_template:get/get_lazy/with) and is then used in a guard inside a template. "
+            "A guard cannot re-run that read -- Erlang rejects a function call in a guard -- so it "
+            "never executes inside the slot's dependency bracket: the slot records no dependency "
+            "on that binding and freezes at its SSR value, no longer updating when the binding "
+            "changes. Move the test out of the guard so the read is tracked -- read it in the case "
+            "scrutinee or the clause body, e.g. `case {arizona_template:get(status, Bindings), "
+            "arizona_template:get(confirming, Bindings)} of {active, true} -> ... end`, or replace "
+            "the guard with a pattern match.",
+            [Var]
+        )
+    ).
 
 %% --------------------------------------------------------------------
 %% Internal functions
@@ -951,6 +966,7 @@ iv(Other, _Inline) ->
 %% Fun clause: parameters bind and shadow; drop them from the map for the body.
 iv_fun_clause({clause, L, Params, Guards, Body}, Inline) ->
     Inline1 = maps:without(pattern_vars(Params), Inline),
+    reject_tracked_guard(Guards, Inline1),
     {clause, L, Params, Guards, iv_body(Body, Inline1)}.
 
 %% case/receive/try-of/catch clause: patterns match the (already inlined) scrutinee,
@@ -958,7 +974,44 @@ iv_fun_clause({clause, L, Params, Guards, Body}, Inline) ->
 %% the map for the body as a conservative shadow guard.
 iv_clause({clause, L, Patterns, Guards, Body}, Inline) ->
     Inline1 = maps:without(pattern_vars(Patterns), Inline),
+    reject_tracked_guard(Guards, Inline1),
     {clause, L, Patterns, Guards, iv_body(Body, Inline1)}.
+
+%% A tracked (`?get`/`get_lazy`/`with`-derived) variable used in a guard inside a
+%% template freezes the slot silently. inline_vars leaves guards untouched -- it has
+%% to, since Erlang forbids the get/2 call in a guard -- so the read never re-runs
+%% inside the slot's dependency bracket: the dependency is dropped and the slot stops
+%% updating when that binding changes. Erlang accepts the guard (a bound variable is
+%% legal), so nothing complains. The only path a tracked read can reach a guard is a
+%% pre-bound variable (a literal `?get` there is already an "illegal guard expression"),
+%% so scanning the guards for an inline-map variable is the whole detection. Reject it
+%% so the freeze is a loud compile error instead.
+reject_tracked_guard(_Guards, Inline) when map_size(Inline) =:= 0 ->
+    ok;
+reject_tracked_guard(Guards, Inline) ->
+    case tracked_guard_var(Guards, Inline) of
+        none -> ok;
+        {V, L} -> parse_error({tracked_read_in_guard, V}, L)
+    end.
+
+%% First reference, depth-first, to an inline-map variable anywhere in the guards
+%% (it may be nested in `andalso`/`is_binary(...)`/comparisons); `none` if there is
+%% none. The `{var, _, _}` clause is matched ahead of the generic tuple walk so a var
+%% node is never decomposed.
+tracked_guard_var({var, L, V}, Inline) ->
+    case is_map_key(V, Inline) of
+        true -> {V, L};
+        false -> none
+    end;
+tracked_guard_var(T, Inline) when is_tuple(T) ->
+    tracked_guard_var(tuple_to_list(T), Inline);
+tracked_guard_var([H | T], Inline) ->
+    case tracked_guard_var(H, Inline) of
+        none -> tracked_guard_var(T, Inline);
+        Found -> Found
+    end;
+tracked_guard_var(_Other, _Inline) ->
+    none.
 
 %% A body is a sequence; a `Var = RHS` match binds Var (shadowing) for later exprs.
 iv_body(Exprs, Inline) ->

--- a/test/arizona_parse_transform_SUITE.erl
+++ b/test/arizona_parse_transform_SUITE.erl
@@ -205,14 +205,19 @@
     with_handoff_freezes_without_tracking/1,
     with_handoff_tracks_outer_slot/1,
     with_handoff_hoisted_tracks_outer_slot/1,
-    guard_case_tracked_read_rejected/1,
-    guard_if_tracked_read_rejected/1,
-    guard_buried_tracked_read_rejected/1,
-    guard_hoisted_case_result_rejected/1,
-    guard_fun_clause_tracked_read_rejected/1,
+    guard_case_tracked_read_tracks/1,
+    guard_if_tracked_read_tracks/1,
+    guard_buried_tracked_read_tracks/1,
+    guard_hoisted_case_result_tracks/1,
+    guard_tracked_read_also_in_body_tracks/1,
+    guard_transitively_derived_read_tracks/1,
+    guard_fun_clause_tracked_read_tracks/1,
+    guard_attr_value_tracks/1,
+    guard_nodiff_compiles/1,
     guard_pattern_var_ok/1,
     guard_untracked_local_ok/1,
     guard_tracked_read_in_scrutinee_ok/1,
+    guard_pattern_bound_from_tracked_case_ok/1,
     void_element/1,
     void_in_each_with_children/1,
     void_nested_child_with_children/1,
@@ -518,16 +523,22 @@ groups() ->
             with_handoff_tracks_outer_slot,
             with_handoff_hoisted_tracks_outer_slot
         ]},
-        %% Reject a tracked read used in a template guard (it silently freezes the slot)
+        %% Auto-track a binding read used in a template guard (the read can't live in the
+        %% guard, so the transform injects a tracking touch so the slot stays reactive)
         {tracked_guard, [parallel], [
-            guard_case_tracked_read_rejected,
-            guard_if_tracked_read_rejected,
-            guard_buried_tracked_read_rejected,
-            guard_hoisted_case_result_rejected,
-            guard_fun_clause_tracked_read_rejected,
+            guard_case_tracked_read_tracks,
+            guard_if_tracked_read_tracks,
+            guard_buried_tracked_read_tracks,
+            guard_hoisted_case_result_tracks,
+            guard_tracked_read_also_in_body_tracks,
+            guard_transitively_derived_read_tracks,
+            guard_fun_clause_tracked_read_tracks,
+            guard_attr_value_tracks,
+            guard_nodiff_compiles,
             guard_pattern_var_ok,
             guard_untracked_local_ok,
-            guard_tracked_read_in_scrutinee_ok
+            guard_tracked_read_in_scrutinee_ok,
+            guard_pattern_bound_from_tracked_case_ok
         ]},
         %% Tests 68-77c: layout tests
         {layout, [parallel], [
@@ -1635,18 +1646,16 @@ cond_case_bare_matches_html(Config) when is_list(Config) ->
     {WrapHTML, _} = arizona_render:render(Wrap:render(B)),
     ?assertEqual(iolist_to_binary(WrapHTML), iolist_to_binary(BareHTML)).
 
-%% An `if` branch returning a bare element is expanded the same way (this guards
-%% the `if` clause of map_tail_exprs). An `if` condition is a guard, so it cannot
-%% react to a binding: a tracked `?get` there is rejected (tracked_read_in_guard),
-%% and an untracked read freezes the slot. `Show` is destructured in the head (an
-%% untracked read), so the slot renders correctly at SSR but records NO dependency
-%% -- it never updates when `show` changes. To react to a binding, use `case` with
-%% a tracked scrutinee, not `if`. This test asserts both halves honestly.
+%% An `if` branch returning a bare element is expanded the same way (this guards the
+%% `if` clause of map_tail_exprs). The condition reads a tracked binding (`?get(show)`):
+%% the read can't live in the guard, so the transform injects a tracking touch and the
+%% slot tracks `show` and stays reactive (not frozen).
 cond_if_bare_element(Config) when is_list(Config) ->
     Mod = compile_module(
         "-module(pt_cond_if_bare). "
         "-export([render/1]). "
-        "render(#{show := Show}) -> "
+        "render(Bindings) -> "
+        "    Show = arizona_template:get(show, Bindings), "
         "    arizona_template:html({'div', [], ["
         "        if "
         "            Show -> {'p', [], [<<\"yes\">>]}; "
@@ -1654,16 +1663,14 @@ cond_if_bare_element(Config) when is_list(Config) ->
         "        end "
         "    ]}). "
     ),
-    %% Bare element in the `if` tail compiles to a nested template; both branches
-    %% render at SSR.
+    %% Bare element in the `if` tail compiles to a nested template; both branches render.
     {Shown, _} = arizona_render:render(Mod:render(#{show => true})),
     ?assertNotEqual(nomatch, binary:match(iolist_to_binary(Shown), <<"<p>yes</p>">>)),
     {Hidden, _} = arizona_render:render(Mod:render(#{show => false})),
     ?assertEqual(nomatch, binary:match(iolist_to_binary(Hidden), <<"<p">>)),
-    %% But the slot is frozen: the if-condition is a guard over an untracked read,
-    %% so it records no dependency and a `show` change would emit no diff.
+    %% the if-condition's binding is auto-tracked, so the slot is reactive.
     {_HTML, Snap, _Views} = arizona_render:render(Mod:render(#{show => true}), #{}),
-    ?assertEqual([#{}], maps:get(deps, Snap)).
+    ?assertEqual([#{show => true}], maps:get(deps, Snap)).
 
 %% A bare element in the tail of a nested `case`-of-`case` is reached by the
 %% recursive tail walk.
@@ -5846,10 +5853,12 @@ with_handoff_hoisted_tracks_outer_slot(Config) when is_list(Config) ->
     {Ops, _Snap1, _V1} = arizona_diff:diff(Mod:render(B1), Snap0, V0, Changed),
     ?assertNotEqual([], Ops).
 
-%% A tracked read used in a `case` clause guard freezes the slot silently (the
-%% read can't re-run in the guard, so the dep is dropped); reject it instead.
-guard_case_tracked_read_rejected(Config) when is_list(Config) ->
-    assert_parse_error(
+%% A tracked read used in a `case` clause guard auto-tracks: the transform records the
+%% guard's bindings as slot dependencies (it can't put the read in the guard, so it
+%% injects a tracking touch), keeping the slot reactive. Both reads are tracked, and
+%% flipping only `confirming` re-renders the slot (no freeze).
+guard_case_tracked_read_tracks(Config) when is_list(Config) ->
+    Mod = compile_module_strict(
         "-module(pt_guard_case). "
         "-export([render/1]). "
         "render(Bindings) -> "
@@ -5859,26 +5868,32 @@ guard_case_tracked_read_rejected(Config) when is_list(Config) ->
         "        case Status of "
         "            active when Confirming -> <<\"y\">>; "
         "            _ -> <<>> "
-        "        end]}). ",
-        fun(R) -> R =:= {tracked_read_in_guard, 'Confirming'} end
-    ).
+        "        end]}). "
+    ),
+    B0 = #{status => active, confirming => false},
+    {_HTML, Snap, _Views} = arizona_render:render(Mod:render(B0), #{}),
+    ?assertEqual([#{status => true, confirming => true}], maps:get(deps, Snap)),
+    {Ops, _Snap1, _Views1} = arizona_diff:diff(
+        Mod:render(#{status => active, confirming => true}), Snap, #{}, #{confirming => true}
+    ),
+    ?assertNotEqual([], Ops).
 
-%% Same freeze through an `if` (its condition is a guard); rejected too.
-guard_if_tracked_read_rejected(Config) when is_list(Config) ->
-    assert_parse_error(
+%% Same auto-tracking through an `if` (its condition is a guard).
+guard_if_tracked_read_tracks(Config) when is_list(Config) ->
+    Mod = compile_module_strict(
         "-module(pt_guard_if). "
         "-export([render/1]). "
         "render(Bindings) -> "
         "    Confirming = arizona_template:get(confirming, Bindings), "
         "    arizona_template:html({'p', [], ["
-        "        if Confirming -> <<\"y\">>; true -> <<>> end]}). ",
-        fun(R) -> R =:= {tracked_read_in_guard, 'Confirming'} end
-    ).
+        "        if Confirming -> <<\"y\">>; true -> <<>> end]}). "
+    ),
+    {_HTML, Snap, _Views} = arizona_render:render(Mod:render(#{confirming => false}), #{}),
+    ?assertEqual([#{confirming => true}], maps:get(deps, Snap)).
 
-%% The tracked var can be buried inside a guard BIF / boolean combination and is
-%% still detected (the scan finds the variable node wherever it sits).
-guard_buried_tracked_read_rejected(Config) when is_list(Config) ->
-    assert_parse_error(
+%% A tracked var buried in a guard BIF / boolean combination is still tracked.
+guard_buried_tracked_read_tracks(Config) when is_list(Config) ->
+    Mod = compile_module_strict(
         "-module(pt_guard_buried). "
         "-export([render/1]). "
         "render(Bindings) -> "
@@ -5887,37 +5902,102 @@ guard_buried_tracked_read_rejected(Config) when is_list(Config) ->
         "        case ok of "
         "            _ when is_integer(N) andalso N > 5 -> <<\"y\">>; "
         "            _ -> <<>> "
-        "        end]}). ",
-        fun(R) -> R =:= {tracked_read_in_guard, 'N'} end
-    ).
+        "        end]}). "
+    ),
+    {_HTML, Snap, _Views} = arizona_render:render(Mod:render(#{n => 10}), #{}),
+    ?assertEqual([#{n => true}], maps:get(deps, Snap)).
 
-%% A guarded `case` whose result is hoisted into a slot is inlined into that slot
-%% (its result reaches a tracked read), so its guard lands in the slot and is
-%% rejected -- the case `inline_guard_get_stays_captured` used to document as a
-%% silent freeze.
-guard_hoisted_case_result_rejected(Config) when is_list(Config) ->
-    assert_parse_error(
+%% A guarded `case` whose result is hoisted into a slot is inlined into that slot, so its
+%% guard lands in the slot and auto-tracks -- the case `inline_guard_get_stays_captured`
+%% used to document as a silent freeze.
+guard_hoisted_case_result_tracks(Config) when is_list(Config) ->
+    Mod = compile_module_strict(
         "-module(pt_guard_hoist). "
         "-export([render/1]). "
         "render(Bindings) -> "
         "    N = arizona_template:get(n, Bindings), "
-        "    Label = case x of _ when N > 5 -> big; _ -> small end, "
-        "    arizona_template:html({'p', [], [Label]}). ",
-        fun(R) -> R =:= {tracked_read_in_guard, 'N'} end
-    ).
+        "    Label = case x of _ when N > 5 -> <<\"big\">>; _ -> <<\"small\">> end, "
+        "    arizona_template:html({'p', [], [Label]}). "
+    ),
+    {_HTML, Snap, _Views} = arizona_render:render(Mod:render(#{n => 10}), #{}),
+    ?assertEqual([#{n => true}], maps:get(deps, Snap)).
 
-%% A fun clause guard inside a slot is scanned the same way (iv_fun_clause path):
-%% the fun parameter is shadowed, but an outer tracked var in the guard is rejected.
-guard_fun_clause_tracked_read_rejected(Config) when is_list(Config) ->
-    assert_parse_error(
+%% Auto-tracked even when the var is ALSO read in the body. The touch is unconditional,
+%% so the dep is recorded even when SSR takes the branch that does NOT read it (here N=3
+%% fails the guard, so `integer_to_binary(N)` never runs -- yet `n` is still tracked).
+guard_tracked_read_also_in_body_tracks(Config) when is_list(Config) ->
+    Mod = compile_module_strict(
+        "-module(pt_guard_body). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    N = arizona_template:get(n, Bindings), "
+        "    arizona_template:html({'p', [], ["
+        "        case ok of "
+        "            _ when N > 5 -> integer_to_binary(N); "
+        "            _ -> <<>> "
+        "        end]}). "
+    ),
+    {_HTML, Snap, _Views} = arizona_render:render(Mod:render(#{n => 3}), #{}),
+    ?assertEqual([#{n => true}], maps:get(deps, Snap)).
+
+%% The guard variable need not be the direct ?get: a variable transitively derived from a
+%% tracked read (M = N, N = ?get(n)) auto-tracks the underlying binding `n`.
+guard_transitively_derived_read_tracks(Config) when is_list(Config) ->
+    Mod = compile_module_strict(
+        "-module(pt_guard_trans). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    N = arizona_template:get(n, Bindings), "
+        "    M = N, "
+        "    arizona_template:html({'p', [], ["
+        "        case x of _ when M > 5 -> <<\"big\">>; _ -> <<\"small\">> end]}). "
+    ),
+    {_HTML, Snap, _Views} = arizona_render:render(Mod:render(#{n => 10}), #{}),
+    ?assertEqual([#{n => true}], maps:get(deps, Snap)).
+
+%% A guard in a content-slot fun (a fun literal applied inline) over an outer tracked var
+%% is auto-tracked: the nested fun node is wrapped. (A top-level ?each callback is not
+%% wrapped -- its guards are over the item param; see inline_vars/2 / compile_each.)
+guard_fun_clause_tracked_read_tracks(Config) when is_list(Config) ->
+    Mod = compile_module_strict(
         "-module(pt_guard_fun). "
         "-export([render/1]). "
         "render(Bindings) -> "
         "    N = arizona_template:get(n, Bindings), "
         "    arizona_template:html({'p', [], ["
-        "        (fun (X) when N > 5 -> X; (_) -> <<>> end)(<<\"y\">>)]}). ",
-        fun(R) -> R =:= {tracked_read_in_guard, 'N'} end
-    ).
+        "        (fun (X) when N > 5 -> X; (_) -> <<>> end)(<<\"y\">>)]}). "
+    ),
+    {_HTML, Snap, _Views} = arizona_render:render(Mod:render(#{n => 10}), #{}),
+    ?assertEqual([#{n => true}], maps:get(deps, Snap)).
+
+%% A guard inside an ATTRIBUTE-value expression (a different compile path than a content
+%% slot) is auto-tracked the same way.
+guard_attr_value_tracks(Config) when is_list(Config) ->
+    Mod = compile_module_strict(
+        "-module(pt_guard_attr). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    Dark = arizona_template:get(dark, Bindings), "
+        "    arizona_template:html({'div', "
+        "        [{class, case x of _ when Dark -> <<\"d\">>; _ -> <<\"l\">> end}], [<<\"hi\">>]}). "
+    ),
+    {HTML, Snap, _Views} = arizona_render:render(Mod:render(#{dark => true}), #{}),
+    ?assertNotEqual(nomatch, binary:match(iolist_to_binary(HTML), <<"class=\"d\"">>)),
+    ?assertEqual([#{dark => true}], maps:get(deps, Snap)).
+
+%% az-nodiff + a guard over a tracked read compiles (no error) and renders: the slot is
+%% intentionally frozen, and the injected touch is a harmless no-op under nodiff.
+guard_nodiff_compiles(Config) when is_list(Config) ->
+    Mod = compile_module_strict(
+        "-module(pt_guard_nodiff). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    Show = arizona_template:get(show, Bindings), "
+        "    arizona_template:html({'div', ['az-nodiff'], ["
+        "        if Show -> {'p', [], [<<\"yes\">>]}; true -> <<\"\">> end]}). "
+    ),
+    {HTML, _Snap} = arizona_render:render(Mod:render(#{show => true})),
+    ?assertNotEqual(nomatch, binary:match(iolist_to_binary(HTML), <<"<p>yes</p>">>)).
 
 %% Negative: a variable bound by the clause PATTERN (not a tracked outer read) is
 %% not flagged. The slot compiles and tracks the scrutinee read.
@@ -5971,6 +6051,24 @@ guard_tracked_read_in_scrutinee_ok(Config) when is_list(Config) ->
     [{_Az, {esc, Fun}, _Loc}] = maps:get(d, Mod:render(#{status => active, confirming => true})),
     ?assertEqual(<<"Confirm">>, Fun()),
     ?assertEqual(#{status => true, confirming => true}, slot_deps(Fun)).
+
+%% Negative + the one reactive `if`: a variable bound by a tracked `case` scrutinee's
+%% pattern is not a tracked read, so an `if` over it is not flagged. The scrutinee
+%% read is tracked, so the slot stays reactive -- this is how `if` is used reactively
+%% in a template (the bare standalone `if` over a binding cannot be, see
+%% cond_if_bare_element).
+guard_pattern_bound_from_tracked_case_ok(Config) when is_list(Config) ->
+    Mod = compile_module_strict(
+        "-module(pt_guard_pbcase). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:html({'div', [], ["
+        "        case arizona_template:get(show, Bindings) of "
+        "            Show -> if Show -> {'p', [], [<<\"yes\">>]}; true -> <<\"\">> end "
+        "        end]}). "
+    ),
+    {_HTML, Snap, _Views} = arizona_render:render(Mod:render(#{show => true}), #{}),
+    ?assertEqual([#{show => true}], maps:get(deps, Snap)).
 
 %% Like compile_module/1 but compiles with warnings_as_errors, matching the
 %% project's real erl_opts. Needed because unused-variable / match_underscore_var

--- a/test/arizona_parse_transform_SUITE.erl
+++ b/test/arizona_parse_transform_SUITE.erl
@@ -190,7 +190,6 @@
     inline_same_var_two_slots/1,
     inline_non_bindings_var_name/1,
     inline_destructuring_not_inlined/1,
-    inline_guard_get_stays_captured/1,
     inline_comprehension_source/1,
     tracked_get_submap_errors/1,
     tracked_get_submap_az_errors/1,
@@ -206,6 +205,14 @@
     with_handoff_freezes_without_tracking/1,
     with_handoff_tracks_outer_slot/1,
     with_handoff_hoisted_tracks_outer_slot/1,
+    guard_case_tracked_read_rejected/1,
+    guard_if_tracked_read_rejected/1,
+    guard_buried_tracked_read_rejected/1,
+    guard_hoisted_case_result_rejected/1,
+    guard_fun_clause_tracked_read_rejected/1,
+    guard_pattern_var_ok/1,
+    guard_untracked_local_ok/1,
+    guard_tracked_read_in_scrutinee_ok/1,
     void_element/1,
     void_in_each_with_children/1,
     void_nested_child_with_children/1,
@@ -288,6 +295,7 @@ all() ->
         {group, conditional_elements},
         {group, inline},
         {group, tracked_get},
+        {group, tracked_guard},
         {group, layout},
         {group, utf8},
         {group, errors},
@@ -491,7 +499,6 @@ groups() ->
             inline_same_var_two_slots,
             inline_non_bindings_var_name,
             inline_destructuring_not_inlined,
-            inline_guard_get_stays_captured,
             inline_comprehension_source
         ]},
         %% Reject the tracked accessor reading a non-bindings (sub-)map
@@ -510,6 +517,17 @@ groups() ->
             with_handoff_freezes_without_tracking,
             with_handoff_tracks_outer_slot,
             with_handoff_hoisted_tracks_outer_slot
+        ]},
+        %% Reject a tracked read used in a template guard (it silently freezes the slot)
+        {tracked_guard, [parallel], [
+            guard_case_tracked_read_rejected,
+            guard_if_tracked_read_rejected,
+            guard_buried_tracked_read_rejected,
+            guard_hoisted_case_result_rejected,
+            guard_fun_clause_tracked_read_rejected,
+            guard_pattern_var_ok,
+            guard_untracked_local_ok,
+            guard_tracked_read_in_scrutinee_ok
         ]},
         %% Tests 68-77c: layout tests
         {layout, [parallel], [
@@ -1617,13 +1635,18 @@ cond_case_bare_matches_html(Config) when is_list(Config) ->
     {WrapHTML, _} = arizona_render:render(Wrap:render(B)),
     ?assertEqual(iolist_to_binary(WrapHTML), iolist_to_binary(BareHTML)).
 
-%% An `if` branch returning a bare element is expanded the same way.
+%% An `if` branch returning a bare element is expanded the same way (this guards
+%% the `if` clause of map_tail_exprs). An `if` condition is a guard, so it cannot
+%% react to a binding: a tracked `?get` there is rejected (tracked_read_in_guard),
+%% and an untracked read freezes the slot. `Show` is destructured in the head (an
+%% untracked read), so the slot renders correctly at SSR but records NO dependency
+%% -- it never updates when `show` changes. To react to a binding, use `case` with
+%% a tracked scrutinee, not `if`. This test asserts both halves honestly.
 cond_if_bare_element(Config) when is_list(Config) ->
     Mod = compile_module(
         "-module(pt_cond_if_bare). "
         "-export([render/1]). "
-        "render(Bindings) -> "
-        "    Show = arizona_template:get(show, Bindings), "
+        "render(#{show := Show}) -> "
         "    arizona_template:html({'div', [], ["
         "        if "
         "            Show -> {'p', [], [<<\"yes\">>]}; "
@@ -1631,10 +1654,16 @@ cond_if_bare_element(Config) when is_list(Config) ->
         "        end "
         "    ]}). "
     ),
+    %% Bare element in the `if` tail compiles to a nested template; both branches
+    %% render at SSR.
     {Shown, _} = arizona_render:render(Mod:render(#{show => true})),
     ?assertNotEqual(nomatch, binary:match(iolist_to_binary(Shown), <<"<p>yes</p>">>)),
     {Hidden, _} = arizona_render:render(Mod:render(#{show => false})),
-    ?assertEqual(nomatch, binary:match(iolist_to_binary(Hidden), <<"<p">>)).
+    ?assertEqual(nomatch, binary:match(iolist_to_binary(Hidden), <<"<p">>)),
+    %% But the slot is frozen: the if-condition is a guard over an untracked read,
+    %% so it records no dependency and a `show` change would emit no diff.
+    {_HTML, Snap, _Views} = arizona_render:render(Mod:render(#{show => true}), #{}),
+    ?assertEqual([#{}], maps:get(deps, Snap)).
 
 %% A bare element in the tail of a nested `case`-of-`case` is reached by the
 %% recursive tail walk.
@@ -5591,22 +5620,6 @@ inline_destructuring_not_inlined(Config) when is_list(Config) ->
     ?assertEqual(~"Ada", Fun()),
     ?assertEqual(#{}, slot_deps(Fun)).
 
-%% Residue: a read reachable only through a clause GUARD stays captured (a guard
-%% cannot hold a get), so the slot records no dep and freezes. Documents the limit.
-inline_guard_get_stays_captured(Config) when is_list(Config) ->
-    Mod = compile_module_strict(
-        "-module(pt_inline_guardget). "
-        "-export([render/1]). "
-        "render(Bindings) -> "
-        "    N = arizona_template:get(n, Bindings), "
-        "    Label = case x of _ when N > 5 -> big; _ -> small end, "
-        "    arizona_template:html({'p', [], [Label]}). "
-    ),
-    T = Mod:render(#{n => 10}),
-    [{_Az, {esc, Fun}, _Loc}] = maps:get(d, T),
-    ?assertEqual(big, Fun()),
-    ?assertEqual(#{}, slot_deps(Fun)).
-
 %% A hoisted read used as a comprehension generator SOURCE is inlined (the
 %% collapsed lc/bc/mc clause of iv/2 must preserve the comprehension tag -- this
 %% uses a *binary* comprehension so a tag-hardcoding bug would be caught). The
@@ -5832,6 +5845,132 @@ with_handoff_hoisted_tracks_outer_slot(Config) when is_list(Config) ->
     Changed = compute_changed(B0, B1),
     {Ops, _Snap1, _V1} = arizona_diff:diff(Mod:render(B1), Snap0, V0, Changed),
     ?assertNotEqual([], Ops).
+
+%% A tracked read used in a `case` clause guard freezes the slot silently (the
+%% read can't re-run in the guard, so the dep is dropped); reject it instead.
+guard_case_tracked_read_rejected(Config) when is_list(Config) ->
+    assert_parse_error(
+        "-module(pt_guard_case). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    Status = arizona_template:get(status, Bindings), "
+        "    Confirming = arizona_template:get(confirming, Bindings), "
+        "    arizona_template:html({'p', [], ["
+        "        case Status of "
+        "            active when Confirming -> <<\"y\">>; "
+        "            _ -> <<>> "
+        "        end]}). ",
+        fun(R) -> R =:= {tracked_read_in_guard, 'Confirming'} end
+    ).
+
+%% Same freeze through an `if` (its condition is a guard); rejected too.
+guard_if_tracked_read_rejected(Config) when is_list(Config) ->
+    assert_parse_error(
+        "-module(pt_guard_if). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    Confirming = arizona_template:get(confirming, Bindings), "
+        "    arizona_template:html({'p', [], ["
+        "        if Confirming -> <<\"y\">>; true -> <<>> end]}). ",
+        fun(R) -> R =:= {tracked_read_in_guard, 'Confirming'} end
+    ).
+
+%% The tracked var can be buried inside a guard BIF / boolean combination and is
+%% still detected (the scan finds the variable node wherever it sits).
+guard_buried_tracked_read_rejected(Config) when is_list(Config) ->
+    assert_parse_error(
+        "-module(pt_guard_buried). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    N = arizona_template:get(n, Bindings), "
+        "    arizona_template:html({'p', [], ["
+        "        case ok of "
+        "            _ when is_integer(N) andalso N > 5 -> <<\"y\">>; "
+        "            _ -> <<>> "
+        "        end]}). ",
+        fun(R) -> R =:= {tracked_read_in_guard, 'N'} end
+    ).
+
+%% A guarded `case` whose result is hoisted into a slot is inlined into that slot
+%% (its result reaches a tracked read), so its guard lands in the slot and is
+%% rejected -- the case `inline_guard_get_stays_captured` used to document as a
+%% silent freeze.
+guard_hoisted_case_result_rejected(Config) when is_list(Config) ->
+    assert_parse_error(
+        "-module(pt_guard_hoist). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    N = arizona_template:get(n, Bindings), "
+        "    Label = case x of _ when N > 5 -> big; _ -> small end, "
+        "    arizona_template:html({'p', [], [Label]}). ",
+        fun(R) -> R =:= {tracked_read_in_guard, 'N'} end
+    ).
+
+%% A fun clause guard inside a slot is scanned the same way (iv_fun_clause path):
+%% the fun parameter is shadowed, but an outer tracked var in the guard is rejected.
+guard_fun_clause_tracked_read_rejected(Config) when is_list(Config) ->
+    assert_parse_error(
+        "-module(pt_guard_fun). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    N = arizona_template:get(n, Bindings), "
+        "    arizona_template:html({'p', [], ["
+        "        (fun (X) when N > 5 -> X; (_) -> <<>> end)(<<\"y\">>)]}). ",
+        fun(R) -> R =:= {tracked_read_in_guard, 'N'} end
+    ).
+
+%% Negative: a variable bound by the clause PATTERN (not a tracked outer read) is
+%% not flagged. The slot compiles and tracks the scrutinee read.
+guard_pattern_var_ok(Config) when is_list(Config) ->
+    Mod = compile_module_strict(
+        "-module(pt_guard_patvar). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:html({'p', [], ["
+        "        case arizona_template:get(count, Bindings) of "
+        "            V when V > 0 -> <<\"some\">>; "
+        "            _ -> <<\"none\">> "
+        "        end]}). "
+    ),
+    [{_Az, {esc, Fun}, _Loc}] = maps:get(d, Mod:render(#{count => 3})),
+    ?assertEqual(<<"some">>, Fun()),
+    ?assertEqual(#{count => true}, slot_deps(Fun)).
+
+%% Negative: a non-tracked local (no ?get behind it) in a guard is fine -- there is
+%% no dependency to lose. Compiles and tracks only the scrutinee read.
+guard_untracked_local_ok(Config) when is_list(Config) ->
+    Mod = compile_module_strict(
+        "-module(pt_guard_local). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    Limit = 10, "
+        "    arizona_template:html({'p', [], ["
+        "        case arizona_template:get(count, Bindings) of "
+        "            V when V > Limit -> <<\"over\">>; "
+        "            _ -> <<\"ok\">> "
+        "        end]}). "
+    ),
+    [{_Az, {esc, Fun}, _Loc}] = maps:get(d, Mod:render(#{count => 5})),
+    ?assertEqual(<<"ok">>, Fun()),
+    ?assertEqual(#{count => true}, slot_deps(Fun)).
+
+%% Negative + idiomatic fix: moving both reads into the case scrutinee (pattern
+%% match instead of guard) compiles and tracks BOTH dependencies.
+guard_tracked_read_in_scrutinee_ok(Config) when is_list(Config) ->
+    Mod = compile_module_strict(
+        "-module(pt_guard_scrut). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:html({'p', [], ["
+        "        case {arizona_template:get(status, Bindings), "
+        "              arizona_template:get(confirming, Bindings)} of "
+        "            {active, true} -> <<\"Confirm\">>; "
+        "            _ -> <<>> "
+        "        end]}). "
+    ),
+    [{_Az, {esc, Fun}, _Loc}] = maps:get(d, Mod:render(#{status => active, confirming => true})),
+    ?assertEqual(<<"Confirm">>, Fun()),
+    ?assertEqual(#{status => true, confirming => true}, slot_deps(Fun)).
 
 %% Like compile_module/1 but compiles with warnings_as_errors, matching the
 %% project's real erl_opts. Needed because unused-variable / match_underscore_var

--- a/test/arizona_parse_transform_SUITE.erl
+++ b/test/arizona_parse_transform_SUITE.erl
@@ -5978,8 +5978,9 @@ guard_attr_value_tracks(Config) when is_list(Config) ->
         "-export([render/1]). "
         "render(Bindings) -> "
         "    Dark = arizona_template:get(dark, Bindings), "
-        "    arizona_template:html({'div', "
-        "        [{class, case x of _ when Dark -> <<\"d\">>; _ -> <<\"l\">> end}], [<<\"hi\">>]}). "
+        "    arizona_template:html({'div', [{class, "
+        "        case x of _ when Dark -> <<\"d\">>; _ -> <<\"l\">> end"
+        "    }], [<<\"hi\">>]}). "
     ),
     {HTML, Snap, _Views} = arizona_render:render(Mod:render(#{dark => true}), #{}),
     ?assertNotEqual(nomatch, binary:match(iolist_to_binary(HTML), <<"class=\"d\"">>)),


### PR DESCRIPTION
# Description

A binding read used in a template guard (`case ... when V`, `if V ->`, a nested fun) now auto-tracks: the read can't live in a guard, so the parse transform records the guard's bindings as slot dependencies, keeping the slot reactive instead of silently freezing.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
