### PR TITLE
Drop malformed JSON instead of crashing on the WS and session-cookie paths

### DIFF
--- a/src/arizona_session.erl
+++ b/src/arizona_session.erl
@@ -126,9 +126,16 @@ the value is tampered, malformed, or its baked-in expiry has passed.
 decode(Value) ->
     case arizona_crypto:decrypt(Value) of
         {ok, Payload} ->
-            case json:decode(Payload) of
+            %% `decrypt` owns the tamper check; the remaining failure is a
+            %% decrypted-but-non-JSON payload (possible now that arizona_crypto
+            %% is shared -- another consumer could encrypt non-JSON under the
+            %% same secret), which `decode/1`'s total `#{}`-on-anything contract
+            %% must still swallow rather than crash on.
+            try json:decode(Payload) of
                 Session when is_map(Session) -> Session;
                 _ -> #{}
+            catch
+                _:_ -> #{}
             end;
         error ->
             #{}

--- a/src/arizona_socket.erl
+++ b/src/arizona_socket.erl
@@ -148,7 +148,8 @@ Recognized payloads:
 - `[~"navigate", #{~"path" := Path, ~"qs" := Qs}]` -- SPA navigation
 - `[ViewId, Event, Payload]` -- UI event dispatch
 
-Unrecognized payloads are silently dropped.
+Unrecognized payloads, and frames whose body is not valid JSON, are
+silently dropped (a single bad frame must not crash the socket).
 """.
 -spec handle_in(Frame, Socket) -> result() when
     Frame :: binary(),
@@ -156,7 +157,10 @@ Unrecognized payloads are silently dropped.
 handle_in(?SYS_PING, Socket) ->
     {reply, ?SYS_PONG, Socket};
 handle_in(JSON, #socket{pid = Pid} = Socket) ->
-    case json:decode(JSON) of
+    %% `try ... of` so the catch fires ONLY on a malformed decode -- exceptions
+    %% raised inside the matched clause bodies (the inner navigate/dispatch
+    %% trys) are not caught here, so a genuine handler crash still closes 4500.
+    try json:decode(JSON) of
         [~"cached_fps", FpList] when is_list(FpList) ->
             arizona_live:seed_fps(Pid, FpList),
             {ok, Socket};
@@ -180,6 +184,14 @@ handle_in(JSON, #socket{pid = Pid} = Socket) ->
                     close_crash(Socket)
             end;
         _ ->
+            {ok, Socket}
+    catch
+        %% Malformed JSON (e.g. a scanner/probe, a corrupted or fragmented
+        %% frame, a stale client). `json:decode/1` raises `error:{invalid_byte,
+        %% _}` / `error:unexpected_end` / `error:{unexpected_sequence, _}`. Drop
+        %% the frame like an unrecognized payload rather than crashing the
+        %% socket -- one bad frame must not tear down a live session.
+        error:_ ->
             {ok, Socket}
     end.
 

--- a/test/arizona_session_SUITE.erl
+++ b/test/arizona_session_SUITE.erl
@@ -9,6 +9,7 @@
 -export([encode_decode_round_trips/1]).
 -export([decode_rejects_tampered/1]).
 -export([decode_rejects_malformed/1]).
+-export([decode_swallows_decrypted_non_json/1]).
 -export([key_normalizes_atom/1]).
 -export([resp_cookie_sets_when_dirty_and_present/1]).
 -export([resp_cookie_clears_when_dirty_and_empty/1]).
@@ -24,6 +25,7 @@ all() ->
         encode_decode_round_trips,
         decode_rejects_tampered,
         decode_rejects_malformed,
+        decode_swallows_decrypted_non_json,
         key_normalizes_atom,
         resp_cookie_sets_when_dirty_and_present,
         resp_cookie_clears_when_dirty_and_empty,
@@ -56,6 +58,16 @@ decode_rejects_tampered(Config) when is_list(Config) ->
 decode_rejects_malformed(Config) when is_list(Config) ->
     ?assertEqual(#{}, arizona_session:decode(~"not-a-session")),
     ?assertEqual(#{}, arizona_session:decode(~"")).
+
+decode_swallows_decrypted_non_json(Config) when is_list(Config) ->
+    Ttl = arizona_session:max_age(),
+    %% A payload that decrypts cleanly (encrypted under the same secret, e.g. by
+    %% another arizona_crypto consumer) but is not JSON -- json:decode raises.
+    NonJson = arizona_crypto:encrypt(~"not json {{{", #{ttl => Ttl}),
+    ?assertEqual(#{}, arizona_session:decode(NonJson)),
+    %% Decrypts to valid JSON that is not a map -- the non-map clause.
+    NotMap = arizona_crypto:encrypt(iolist_to_binary(json:encode(42)), #{ttl => Ttl}),
+    ?assertEqual(#{}, arizona_session:decode(NotMap)).
 
 key_normalizes_atom(Config) when is_list(Config) ->
     ?assertEqual(~"user_id", arizona_session:key(user_id)),

--- a/test/arizona_ws_SUITE.erl
+++ b/test/arizona_ws_SUITE.erl
@@ -12,6 +12,7 @@
     event_no_change/1,
     unknown_json/1,
     unknown_frame/1,
+    malformed_json/1,
     reconnect_init/1,
     connect_with_params/1,
     http_query_params/1,
@@ -77,6 +78,7 @@ groups() ->
         event_no_change,
         unknown_json,
         unknown_frame,
+        malformed_json,
         reconnect_init,
         connect_with_params,
         http_query_params,
@@ -378,6 +380,18 @@ unknown_frame(Config) ->
     %% Send a binary frame (opcode 2) -- should be ignored
     ok = ws_send_binary_frame(Sock, <<"binary data">>),
     %% Verify connection alive
+    ok = ws_send(Sock, <<"0">>),
+    {text, <<"1">>} = ws_recv(Sock),
+    ws_close(Sock).
+
+malformed_json(Config) ->
+    {ok, Sock} = ws_connect(Config, <<"/">>),
+    %% A text frame whose body is not valid JSON (json:decode raises
+    %% error:{invalid_byte, _}). Must be dropped, not crash the socket.
+    ok = ws_send(Sock, <<"{bad json">>),
+    %% A truncated frame (json:decode raises error:unexpected_end).
+    ok = ws_send(Sock, <<"[\"crashable\",">>),
+    %% Connection survived both -- ping/pong still works.
     ok = ws_send(Sock, <<"0">>),
     {text, <<"1">>} = ws_recv(Sock),
     ws_close(Sock).


### PR DESCRIPTION
# Description

Two uncaught `json:decode/1` paths could crash on malformed input: a malformed WebSocket text frame in `arizona_socket:handle_in/2` (reachable by any sender), and a decrypted-but-non-JSON `az_session` payload in `arizona_session:decode/1` (reachable now that `arizona_crypto` is shared). Both now degrade gracefully (dropped frame / empty session), matching the already-guarded `arizona_flash` and `arizona_jsonrpc` decoders.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
