### PR TITLE
Unwrap on_error command tuples in arizona_js:fetch/2

### DIFF
--- a/e2e/parallel/arizona_fetch_error.spec.js
+++ b/e2e/parallel/arizona_fetch_error.spec.js
@@ -1,0 +1,32 @@
+import { expect, test } from '@playwright/test';
+
+const wsReady = (page) =>
+    page.waitForFunction(() => document.documentElement.classList.contains('az-connected'));
+
+test('fetch runs on_error commands and fires arizona:fetch-error when the response has no effects body', async ({
+    page,
+}) => {
+    await page.goto('/fetch-error');
+    await wsReady(page);
+
+    // Capture the arizona:fetch-error DOM event the failure path dispatches.
+    await page.evaluate(() => {
+        window.__fetchError = false;
+        document.addEventListener('arizona:fetch-error', () => {
+            window.__fetchError = true;
+        });
+    });
+
+    await expect(page.locator('#fetch-status')).not.toHaveClass(/errored/);
+
+    // Submit -> arizona_js:fetch. The controller replies 500 with no effects body, so the
+    // client takes the failure path and runs the on_error list (add a class + set an attr).
+    await page.locator('#error-form button[type="submit"]').click();
+
+    // Both on_error commands ran -- the list-unwrap reached the client.
+    await expect(page.locator('#fetch-status')).toHaveClass(/errored/);
+    await expect(page.locator('#fetch-status')).toHaveAttribute('data-errored', 'yes');
+
+    // The failure path also dispatched arizona:fetch-error on document.
+    await expect.poll(() => page.evaluate(() => window.__fetchError)).toBe(true);
+});

--- a/rebar.lock
+++ b/rebar.lock
@@ -2,7 +2,7 @@
 [{<<"fs">>,{pkg,<<"fs">>,<<"11.4.1">>},0},
  {<<"roadrunner">>,
   {git,"https://github.com/arizona-framework/roadrunner.git",
-       {ref,"dc33e68e1b180f5e94298420ecfc376be06588b3"}},
+       {ref,"bff6fc759e1b6cfe2174e783cc9e5131c4d0aa14"}},
   0},
  {<<"telemetry">>,{pkg,<<"telemetry">>,<<"1.4.2">>},1}]}.
 [

--- a/src/arizona_js.erl
+++ b/src/arizona_js.erl
@@ -278,7 +278,7 @@ controller (e.g. via `arizona_controller:reply_redirect/1`) rather than an HTTP
         credentials => same_origin | include | omit,
         on_error => arizona_effect:cmd() | [arizona_effect:cmd()]
     }.
-fetch(Url, Opts) -> {arizona_effect, [?EFFECT_FETCH, Url, Opts]}.
+fetch(Url, Opts) -> {arizona_effect, [?EFFECT_FETCH, Url, unwrap_on_error(Opts)]}.
 
 -doc "Focuses the first element matching the selector.".
 -spec focus(Selector) -> arizona_effect:cmd() when
@@ -321,10 +321,8 @@ list of atoms (matches any), or a regex pattern as a binary.
 -spec on_key(Key, Cmd) -> arizona_effect:cmd() when
     Key :: atom() | [atom()] | binary(),
     Cmd :: arizona_effect:cmd() | [arizona_effect:cmd()].
-on_key(Key, {arizona_effect, Inner}) ->
-    {arizona_effect, [?EFFECT_ON_KEY, encode_key(Key), Inner]};
-on_key(Key, [_ | _] = Cmds) ->
-    {arizona_effect, [?EFFECT_ON_KEY, encode_key(Key), [C || {arizona_effect, C} <:- Cmds]]}.
+on_key(Key, Cmds) ->
+    {arizona_effect, [?EFFECT_ON_KEY, encode_key(Key), unwrap_cmds(Cmds)]}.
 
 -doc """
 Sets a client-owned slot (`?local`) to `Value` in the **closest view** of the
@@ -401,10 +399,8 @@ CSS), letting one stylesheet pick a different animation per call.
 -spec transition(Cmd, Opts) -> arizona_effect:cmd() when
     Cmd :: arizona_effect:cmd() | [arizona_effect:cmd()],
     Opts :: #{types => [binary()]}.
-transition({arizona_effect, Inner}, Opts) ->
-    {arizona_effect, [?EFFECT_TRANSITION, Opts, Inner]};
-transition([_ | _] = Cmds, Opts) ->
-    {arizona_effect, [?EFFECT_TRANSITION, Opts, [C || {arizona_effect, C} <:- Cmds]]}.
+transition(Cmds, Opts) ->
+    {arizona_effect, [?EFFECT_TRANSITION, Opts, unwrap_cmds(Cmds)]}.
 
 %% --------------------------------------------------------------------
 %% Internal functions
@@ -413,6 +409,18 @@ transition([_ | _] = Cmds, Opts) ->
 encode_key(Key) when is_atom(Key) -> [Key];
 encode_key(Keys) when is_list(Keys) -> Keys;
 encode_key(Pattern) when is_binary(Pattern) -> Pattern.
+
+%% Unwrap nested cmd tuple(s) to bare op-array(s) so the result is JSON-encodable.
+%% A single `{arizona_effect, Inner}` yields its bare `Inner`; a list of cmd tuples
+%% yields a list of bare op-arrays. Shared by on_key/2, transition/2, and
+%% unwrap_on_error/1.
+unwrap_cmds({arizona_effect, Inner}) -> Inner;
+unwrap_cmds([_ | _] = Cmds) -> [C || {arizona_effect, C} <:- Cmds].
+
+%% fetch/2's on_error carries cmd tuple(s) inside the Opts map; arizona_effect:encode/1
+%% does not recurse into map values, so unwrap them here before embedding Opts.
+unwrap_on_error(#{on_error := Cmds} = Opts) -> Opts#{on_error => unwrap_cmds(Cmds)};
+unwrap_on_error(Opts) -> Opts.
 
 -ifdef(TEST).
 

--- a/test/arizona_js_SUITE.erl
+++ b/test/arizona_js_SUITE.erl
@@ -1,0 +1,79 @@
+-module(arizona_js_SUITE).
+-include_lib("stdlib/include/assert.hrl").
+-include_lib("arizona/include/arizona_effect.hrl").
+
+-export([all/0]).
+-export([groups/0]).
+
+-export([fetch_unwraps_single_on_error_cmd/1]).
+-export([fetch_unwraps_on_error_cmd_list/1]).
+-export([fetch_without_on_error_unchanged/1]).
+
+all() ->
+    [{group, fetch_on_error}].
+
+groups() ->
+    [
+        {fetch_on_error, [parallel], [
+            fetch_unwraps_single_on_error_cmd,
+            fetch_unwraps_on_error_cmd_list,
+            fetch_without_on_error_unchanged
+        ]}
+    ].
+
+%% --------------------------------------------------------------------
+%% fetch/2 on_error unwrapping
+%% --------------------------------------------------------------------
+
+%% A single on_error cmd is unwrapped to its bare op-array so the Opts map is
+%% JSON-encodable. Before the fix the wrapped {arizona_effect, ...} tuple reached
+%% json:encode/1 (arizona_effect:encode/1 does not recurse into map values) and
+%% crashed with {unsupported_type, ...}.
+fetch_unwraps_single_on_error_cmd(Config) when is_list(Config) ->
+    Cmd = arizona_js:fetch(~"/x", #{
+        method => post,
+        on_error => arizona_js:remove_attr(~"#f", ~"disabled")
+    }),
+    ?assertMatch(
+        {arizona_effect, [
+            ?EFFECT_FETCH,
+            ~"/x",
+            #{on_error := [?EFFECT_REMOVE_ATTR, ~"#f", ~"disabled"]}
+        ]},
+        Cmd
+    ),
+    Bin = arizona_effect:encode(Cmd),
+    ?assert(is_binary(Bin)),
+    ?assertNotEqual(nomatch, binary:match(Bin, ~"on_error")).
+
+%% A list of on_error cmds is unwrapped to a list of bare op-arrays (the
+%% comprehension clause), mirroring on_key/2 and transition/2.
+fetch_unwraps_on_error_cmd_list(Config) when is_list(Config) ->
+    Cmd = arizona_js:fetch(~"/x", #{
+        method => post,
+        on_error => [
+            arizona_js:add_class(~"#f", ~"err"),
+            arizona_js:remove_attr(~"#f", ~"disabled")
+        ]
+    }),
+    ?assertMatch(
+        {arizona_effect, [
+            ?EFFECT_FETCH,
+            ~"/x",
+            #{
+                on_error := [
+                    [?EFFECT_ADD_CLASS, ~"#f", ~"err"],
+                    [?EFFECT_REMOVE_ATTR, ~"#f", ~"disabled"]
+                ]
+            }
+        ]},
+        Cmd
+    ),
+    ?assert(is_binary(arizona_effect:encode(Cmd))).
+
+%% Opts without on_error pass through untouched (the catch-all clause).
+fetch_without_on_error_unchanged(Config) when is_list(Config) ->
+    ?assertMatch(
+        {arizona_effect, [?EFFECT_FETCH, ~"/x", #{method := post}]},
+        arizona_js:fetch(~"/x", #{method => post})
+    ).

--- a/test/support/arizona_fetch_error.erl
+++ b/test/support/arizona_fetch_error.erl
@@ -1,0 +1,47 @@
+-module(arizona_fetch_error).
+-moduledoc """
+**TEST FIXTURE.** Exercises `arizona_js:fetch/2`'s `on_error` option end to end
+(`e2e/parallel/arizona_fetch_error.spec.js`).
+
+The form submits via fetch to a controller that replies `500` with no effects body, so
+the client takes the failure path: it runs the `on_error` commands (a list, to exercise
+the list-unwrap clause) and dispatches an `arizona:fetch-error` event. The commands mutate
+`#fetch-status` (add a class + set an attribute), proving the previously-crashing
+`on_error` cmds now reach the client and run.
+""".
+-include("arizona_stateful.hrl").
+-export([mount/1, render/1]).
+
+-spec mount(az:bindings()) -> az:mount_ret().
+mount(Bindings) ->
+    {
+        #{
+            id => ~"page",
+            title => maps:get(title, Bindings, ~"Error")
+        },
+        #{}
+    }.
+
+-spec render(az:bindings()) -> az:template().
+render(Bindings) ->
+    ?html(
+        {main, [{id, ?get(id)}], [
+            {h1, [], [?get(title)]},
+            {p, [{id, ~"fetch-status"}], [~"idle"]},
+            {form,
+                [
+                    {id, ~"error-form"},
+                    {az_submit,
+                        arizona_js:fetch(~"/fetch-error/submit", #{
+                            method => post,
+                            on_error => [
+                                arizona_js:add_class(~"#fetch-status", ~"errored"),
+                                arizona_js:set_attr(~"#fetch-status", ~"data-errored", ~"yes")
+                            ]
+                        })}
+                ],
+                [
+                    {button, [{type, ~"submit"}], [~"Save"]}
+                ]}
+        ]}
+    ).

--- a/test/support/arizona_fetch_error_controller.erl
+++ b/test/support/arizona_fetch_error_controller.erl
@@ -1,0 +1,17 @@
+-module(arizona_fetch_error_controller).
+-moduledoc """
+**TEST FIXTURE.** The controller `arizona_fetch_error` posts to via `arizona_js:fetch/2`.
+It replies `500` with an empty body -- no usable effects body -- so the client runs the
+fetch's `on_error` commands and dispatches `arizona:fetch-error`. Drives
+`e2e/parallel/arizona_fetch_error.spec.js`.
+""".
+
+-behaviour(roadrunner_handler).
+
+-export([handle/1]).
+
+-spec handle(Req) -> {Response, Req} when
+    Req :: roadrunner_req:request(),
+    Response :: roadrunner_handler:response().
+handle(Req) ->
+    {roadrunner_resp:internal_error(), Req}.

--- a/test/support/arizona_test_server.erl
+++ b/test/support/arizona_test_server.erl
@@ -102,6 +102,13 @@ routes() ->
             layouts => Layouts
         }},
         {post, <<"/fetch-push/submit">>, arizona_fetch_push_controller, #{}},
+        %% arizona_js:fetch on_error -- the controller replies 500 with no effects body, so
+        %% the client runs the fetch's on_error commands and fires arizona:fetch-error.
+        {live, <<"/fetch-error">>, arizona_fetch_error, #{
+            bindings => #{title => <<"Error">>},
+            layouts => Layouts
+        }},
+        {post, <<"/fetch-error/submit">>, arizona_fetch_error_controller, #{}},
         %% arizona_session write loop -- a fetch posts to the controller, which rotates
         %% the encrypted az_session cookie and push_events the new name; fetch_session on
         %% the page route reads the persisted name back from the cookie on the next load.


### PR DESCRIPTION
# Description

`arizona_js:fetch/2` crashed at render whenever `on_error` was set, because its command tuples weren't unwrapped to bare op-arrays before JSON encoding the way `on_key` and `transition` do. Fixed with a shared `unwrap_cmds/1` helper plus encode and e2e coverage, and bumps roadrunner to the latest main.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
