### PR TITLE
Render raw-text element content slots markerless and render-once

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1192,7 +1192,22 @@ map appears in the `Changed` map (via `maps:intersect`). If none do, the dynamic
 A content-slot dynamic -- a value, a nested template, *or a plain-list `?each`* -- is anchored
 by `<!--az:X-->...<!--/az-->` comment markers in SSR (no wrapper element carries the slot `az`),
 so its diff patch is the marker-aware `OP_TEXT`: it replaces only the span between the markers,
-leaving the slot's static siblings and the enclosing element intact. `OP_UPDATE` (innerHTML on
+leaving the slot's static siblings and the enclosing element intact.
+
+**Exception -- raw-text elements (`script`/`style`/`textarea`/`title`).** The browser does not
+parse HTML comments inside these, so a comment marker becomes literal content and corrupts it (an
+inline module script's `<!--` is even a `SyntaxError`). A dynamic content slot inside a raw-text
+element is therefore emitted **markerless and render-once**: the value renders at SSR with `Az =
+undefined`, and the diff engine skips any `undefined`-`Az` dynamic (`arizona_diff:diff_dynamics/3`
+and `diff_dynamics_v/5`), so no `OP_TEXT` is ever produced (there would be no marker to target).
+The backend classifies the tag via `arizona_renderer:raw_text_kind/1`: `raw` (`script`/`style`)
+renders the value **verbatim** (the browser decodes no character references there, so HTML-escaping
+would corrupt it -- this is what makes a `?raw` JSON-LD blob or a computed inline boot-script URL
+correct); `escapable` (`textarea`/`title`) HTML-escapes a scalar (references *are* decoded there)
+but is still markerless. A dynamic *attribute* on a raw-text element stays fully diffable -- only
+the content slot is markerless. Limitation: the slot will not update after the initial render, and
+`?local` is unsupported inside a raw-text element (no marker to address); a live `?get` there
+silently freezes at its first value. `OP_UPDATE` (innerHTML on
 the resolved element) is reserved for the **stream** `?each` container full render, where the
 container is the addressable element and items carry `az-key` for incremental ops. Emitting
 `OP_UPDATE` for a marker-anchored slot is a bug: the client's `resolveEl` finds no element for

--- a/src/arizona_diff.erl
+++ b/src/arizona_diff.erl
@@ -49,6 +49,12 @@ Templates compiled with `az-nodiff` carry `diff => false` and dynamics
 with `Az = undefined`. The diff functions short-circuit on `diff => false`
 before ever inspecting individual dynamics, so `undefined` Az values
 never reach op-code targets.
+
+A diffable template can also carry an individual `Az = undefined` dynamic:
+a content slot inside a raw-text element (`script`/`style`/`textarea`/`title`),
+where HTML comment markers would become literal content. Such a slot is
+render-once -- `diff_dynamics/3` and `diff_dynamics_v/5` skip any `undefined`
+Az dynamic, so it is never re-evaluated and never produces an op.
 """.
 
 -include("arizona.hrl").
@@ -185,6 +191,10 @@ diff_dynamics(NewEvals, OldEvals) ->
 %% nesting level. `Tail` is the ops that follow these dynamics; order is preserved.
 diff_dynamics([], [], Tail) ->
     Tail;
+diff_dynamics([{undefined, _} | NR], [{undefined, _} | OR], Tail) ->
+    %% Markerless render-once slot (raw-text element content, or az-nodiff): no
+    %% comment marker to target, so never emit an op -- carry it forward as-is.
+    diff_dynamics(NR, OR, Tail);
 diff_dynamics([{Az, _} | NR], [{Az, #{diff := false}} | OR], Tail) ->
     diff_dynamics(NR, OR, Tail);
 diff_dynamics([{Az, Same} | NR], [{Az, Same} | OR], Tail) ->
@@ -194,6 +204,16 @@ diff_dynamics([{Az, New} | NR], [{Az, Old} | OR], Tail) ->
 
 diff_dynamics_v([], [], [], _Changed, Views) ->
     {[], [], [], Views};
+diff_dynamics_v(
+    [_Def | DR],
+    [{undefined, Old} | OR],
+    [ODeps | DepsR],
+    Changed,
+    Views0
+) ->
+    %% Markerless render-once slot (raw-text element content, or az-nodiff): no
+    %% comment marker to target, so skip it -- never re-evaluate, never emit an op.
+    skip_dynamic(undefined, Old, ODeps, DR, OR, DepsR, Changed, Views0);
 diff_dynamics_v(
     [_Def | DR],
     [{Az, #{diff := false} = Old} | OR],

--- a/src/arizona_html.erl
+++ b/src/arizona_html.erl
@@ -25,6 +25,7 @@ identical to the previous inlined emission.
 -export([text_slot_open/1]).
 -export([text_slot_close/0]).
 -export([is_void/1]).
+-export([raw_text_kind/1]).
 -export([scope_static/2]).
 
 -spec name(atom()) -> binary().
@@ -109,6 +110,17 @@ is_void(source) -> true;
 is_void(track) -> true;
 is_void(wbr) -> true;
 is_void(_) -> false.
+
+-spec raw_text_kind(atom()) -> none | raw | escapable.
+%% Raw-text elements: content is never parsed for comments or character
+%% references, so a dynamic slot must render verbatim and markerless.
+raw_text_kind(script) -> raw;
+raw_text_kind(style) -> raw;
+%% Escapable-raw-text elements: character references are decoded, so a scalar
+%% slot is HTML-escaped, but comments are still literal -- so still markerless.
+raw_text_kind(textarea) -> escapable;
+raw_text_kind(title) -> escapable;
+raw_text_kind(_) -> none.
 
 -spec scope_static(binary(), binary()) -> binary().
 scope_static(Fp, S0) ->

--- a/src/arizona_native.erl
+++ b/src/arizona_native.erl
@@ -36,6 +36,7 @@ form valid JSON.
 -export([text_slot_open/1]).
 -export([text_slot_close/0]).
 -export([is_void/1]).
+-export([raw_text_kind/1]).
 -export([scope_static/2]).
 
 -spec name(atom()) -> binary().
@@ -113,6 +114,12 @@ text_slot_close() ->
 -spec is_void(atom()) -> boolean().
 is_void(_Tag) ->
     false.
+
+-spec raw_text_kind(atom()) -> none | raw | escapable.
+raw_text_kind(_Tag) ->
+    %% The native wire is JSON, not HTML -- dynamic slots are `#slot` objects,
+    %% not comment markers, so the raw-text corruption does not apply.
+    none.
 
 -spec scope_static(binary(), binary()) -> binary().
 scope_static(Fp, S0) ->

--- a/src/arizona_parse_transform.erl
+++ b/src/arizona_parse_transform.erl
@@ -110,6 +110,11 @@ render(Bindings) ->
     dynamics = [] :: [dynamic()],
     az = 0 :: az(),
     nodiff = false :: boolean(),
+    %% Raw-text context of the enclosing element while compiling its children
+    %% (Backend:raw_text_kind/1). `raw`/`escapable` mean a dynamic content slot
+    %% must be emitted markerless and render-once -- HTML comment markers would
+    %% become literal content there (script/style/textarea/title).
+    raw_text_kind = none :: none | raw | escapable,
     module = undefined :: module() | undefined,
     live_render = false :: boolean(),
     root = false :: boolean(),
@@ -1448,8 +1453,13 @@ compile_element(Tag, Attrs0, Children, Line, State0) ->
     Backend = State0#state.backend,
     Attrs1 = maybe_inject_or_raise_az_view(Attrs0, Line, State0),
     Attrs = maybe_inject_local_descriptor(Backend, Attrs1, Children, Line, State0),
+    RawKind = Backend:raw_text_kind(Tag),
     State1 = State0#state{root = false},
-    HasDyn = has_dynamic_attr(Attrs) orelse has_dynamic_child(Children),
+    %% A dynamic content slot inside a raw-text element is markerless/render-once
+    %% (see emit_child_dynamic/4), so it never needs an element-level `az` target.
+    %% Only dynamic *attributes* (still diffable) force one there.
+    HasDyn =
+        has_dynamic_attr(Attrs) orelse (RawKind =:= none andalso has_dynamic_child(Children)),
     {ElemAz, State2} =
         case HasDyn andalso (not State1#state.nodiff) of
             true -> {State1#state.az, State1#state{az = State1#state.az + 1}};
@@ -1475,8 +1485,11 @@ compile_element(Tag, Attrs0, Children, Line, State0) ->
             buf_append(State5, Backend:element_void_close());
         false ->
             State6 = buf_append(State5, Backend:element_open_end()),
-            State7 = compile_children(Children, ElemAz, State6),
-            buf_append(State7, Backend:element_close(TagBin))
+            %% Scope the raw-text context to this element's children, then restore
+            %% the parent's so a following sibling is not treated as raw text.
+            State7 = compile_children(Children, ElemAz, State6#state{raw_text_kind = RawKind}),
+            State8 = buf_append(State7, Backend:element_close(TagBin)),
+            State8#state{raw_text_kind = State0#state.raw_text_kind}
     end.
 
 compile_attrs([], _ElemAz, State, _ElemLine) ->
@@ -1838,6 +1851,29 @@ emit_child_dynamic(
 ) ->
     DynAST = make_nodiff_dynamic_ast(Child, Module, line(Child), Backend),
     {flush(State0, DynAST), Slot};
+emit_child_dynamic(
+    Child, _ElemAz, #state{raw_text_kind = raw, module = Module, backend = Backend} = State0, Slot
+) ->
+    %% script/style: raw text, the browser decodes neither character references
+    %% nor HTML comments here, so the value is emitted verbatim, markerless and
+    %% render-once. Comment markers would become literal bytes and corrupt the
+    %% script/CSS (and a module script's HTML-comment tokens are a SyntaxError).
+    %% Diffing is impossible by construction (no marker to patch), so the slot
+    %% renders once -- the diff engine skips its `undefined` az.
+    DynAST = make_raw_text_dynamic_ast(Child, Module, line(Child), Backend),
+    {flush(State0, DynAST), Slot};
+emit_child_dynamic(
+    Child,
+    _ElemAz,
+    #state{raw_text_kind = escapable, module = Module, backend = Backend} = State0,
+    Slot
+) ->
+    %% textarea/title: escapable raw text, the browser DOES decode character
+    %% references, so a scalar is HTML-escaped (make_nodiff_dynamic_ast's
+    %% esc_spec), but comments are still literal -- so the slot is markerless and
+    %% render-once, exactly like the layout/nodiff value path.
+    DynAST = make_nodiff_dynamic_ast(Child, Module, line(Child), Backend),
+    {flush(State0, DynAST), Slot};
 emit_child_dynamic(Child, ElemAz, #state{module = Module, backend = Backend} = State0, Slot) ->
     ElemAzBin = integer_to_binary(ElemAz),
     MarkerAz = Backend:text_az(ElemAzBin, Slot),
@@ -2105,6 +2141,17 @@ make_nodiff_dynamic_ast(ExprAST0, Module, ExprLine, Backend) ->
     LocAST = loc_ast(Module, ExprLine),
     FunAST = {'fun', 0, {clauses, [{clause, 0, [], [], [ExprAST]}]}},
     {tuple, 0, [{atom, 0, undefined}, esc_spec(Backend, ExprAST, FunAST), LocAST]}.
+
+%% Markerless render-once for a `raw` raw-text element (script/style). Unlike
+%% make_nodiff_dynamic_ast/4 the value is left bare (never `{esc, Fun}`): the
+%% browser does not decode character references inside these, so HTML-escaping a
+%% scalar would corrupt it (`&` -> `&amp;`). `undefined` az makes it non-diffable
+%% -- there is no comment marker to patch.
+make_raw_text_dynamic_ast(ExprAST0, Module, ExprLine, Backend) ->
+    ExprAST = expand_block_element_tails(ExprAST0, Module, Backend),
+    LocAST = loc_ast(Module, ExprLine),
+    FunAST = {'fun', 0, {clauses, [{clause, 0, [], [], [ExprAST]}]}},
+    {tuple, 0, [{atom, 0, undefined}, FunAST, LocAST]}.
 
 make_nodiff_attr_dynamic_ast(AttrNameBin, ExprAST, Module, ExprLine) ->
     LocAST = loc_ast(Module, ExprLine),

--- a/src/arizona_renderer.erl
+++ b/src/arizona_renderer.erl
@@ -78,6 +78,22 @@ shares one flat registry.
 -callback is_void(Tag :: atom()) -> boolean().
 
 -doc """
+Raw-text classification of a tag, governing how a dynamic content slot inside it
+is emitted.
+
+`none` for ordinary elements: a content slot gets the usual comment-marker diff
+target (`<!--az:X-->...<!--/az-->`) and is fully diffable. `raw` for raw-text
+elements (`script`/`style`): the browser never decodes character references or
+HTML comments there, so the slot is emitted verbatim, markerless and render-once
+(comment markers would become literal bytes and corrupt the script/CSS).
+`escapable` for escapable-raw-text elements (`textarea`/`title`): character
+references ARE decoded, so a scalar slot is HTML-escaped, but it is still
+markerless and render-once. Non-HTML backends return `none` -- their wire format
+does not use HTML comment markers.
+""".
+-callback raw_text_kind(Tag :: atom()) -> none | raw | escapable.
+
+-doc """
 Prefix a static's embedded `az` references with the fingerprint, so a child
 template inlined into a parent does not collide on `az` targets.
 """.

--- a/src/arizona_terminal.erl
+++ b/src/arizona_terminal.erl
@@ -50,6 +50,7 @@ than silently dropped.
 -export([text_slot_open/1]).
 -export([text_slot_close/0]).
 -export([is_void/1]).
+-export([raw_text_kind/1]).
 -export([scope_static/2]).
 
 %% Full SGR reset (clears colour and every text style at once); io_ansi has no
@@ -162,6 +163,12 @@ text_slot_close() ->
 -spec is_void(atom()) -> boolean().
 is_void(br) -> true;
 is_void(_) -> false.
+
+-spec raw_text_kind(atom()) -> none | raw | escapable.
+raw_text_kind(_Tag) ->
+    %% Terminal output is plain styled text, not HTML -- no comment markers, so
+    %% the raw-text corruption does not apply.
+    none.
 
 -spec scope_static(binary(), binary()) -> binary().
 scope_static(_Fp, S0) ->

--- a/test/arizona_parse_transform_SUITE.erl
+++ b/test/arizona_parse_transform_SUITE.erl
@@ -276,6 +276,17 @@
     native_backend_not_escaped/1
 ]).
 -export([
+    raw_text_script_markerless/1,
+    raw_text_script_not_escaped/1,
+    raw_text_style_markerless/1,
+    raw_text_json_ld_raw_verbatim/1,
+    raw_text_title_escaped_markerless/1,
+    raw_text_textarea_markerless/1,
+    raw_text_render_once_no_diff/1,
+    raw_text_dynamic_attr_still_diffable/1,
+    normal_element_keeps_markers/1
+]).
+-export([
     cond_case_bare_element_renders/1,
     cond_case_bare_matches_html/1,
     cond_if_bare_element/1,
@@ -297,6 +308,7 @@ all() ->
         {group, each},
         {group, integration},
         {group, escaping},
+        {group, raw_text},
         {group, conditional_elements},
         {group, inline},
         {group, tracked_get},
@@ -462,6 +474,20 @@ groups() ->
             diff_value_stays_raw,
             fingerprint_escapes_value,
             native_backend_not_escaped
+        ]},
+        %% Raw-text elements (script/style/textarea/title): a dynamic content
+        %% slot is markerless/render-once -- HTML comment diff markers would
+        %% become literal content and corrupt the script/CSS/JSON-LD/title.
+        {raw_text, [parallel], [
+            raw_text_script_markerless,
+            raw_text_script_not_escaped,
+            raw_text_style_markerless,
+            raw_text_json_ld_raw_verbatim,
+            raw_text_title_escaped_markerless,
+            raw_text_textarea_markerless,
+            raw_text_render_once_no_diff,
+            raw_text_dynamic_attr_still_diffable,
+            normal_element_keeps_markers
         ]},
         %% Bare element tuples as case/if/begin branch results -- compiled into
         %% nested templates (no ?html wrap), inheriting the enclosing target.
@@ -1592,6 +1618,161 @@ native_backend_not_escaped(Config) when is_list(Config) ->
     [{_Az, Fun, _Loc}] = maps:get(d, T),
     ?assert(is_function(Fun, 0)),
     ?assertEqual(<<"<not-escaped>">>, Fun()).
+
+%% A dynamic content slot inside <script> renders WITHOUT comment markers: the
+%% browser would treat <!--az:...--> as literal script bytes (a module script's
+%% HTML-comment tokens are a SyntaxError), so the slot must be markerless.
+raw_text_script_markerless(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_rt_script). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:html({'script', [{type, <<\"module\">>}], ["
+        "        arizona_template:get(boot, Bindings)"
+        "    ]}). "
+    ),
+    {HTML0, _Snap} = arizona_render:render(Mod:render(#{boot => <<"import x from \"/c\"">>})),
+    HTML = iolist_to_binary(HTML0),
+    ?assertEqual(nomatch, binary:match(HTML, ~"<!--az:")),
+    ?assertEqual(nomatch, binary:match(HTML, ~"<!--/az-->")),
+    ?assertNotEqual(nomatch, binary:match(HTML, ~"import x from \"/c\"")),
+    ?assertEqual(<<"<script type=\"module\">import x from \"/c\"</script>">>, HTML).
+
+%% A scalar inside <script> is emitted verbatim (NOT HTML-escaped): the parser
+%% never decodes character references in raw text, so escaping `&`/`<` would
+%% corrupt the JavaScript (`b=1&c=2` must not become `b=1&amp;c=2`).
+raw_text_script_not_escaped(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_rt_script_esc). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:html({'script', [], [arizona_template:get(js, Bindings)]}). "
+    ),
+    {HTML0, _Snap} = arizona_render:render(Mod:render(#{js => <<"a < b && c > d">>})),
+    HTML = iolist_to_binary(HTML0),
+    ?assertNotEqual(nomatch, binary:match(HTML, ~"a < b && c > d")),
+    ?assertEqual(nomatch, binary:match(HTML, ~"&lt;")),
+    ?assertEqual(nomatch, binary:match(HTML, ~"&amp;")).
+
+%% A dynamic content slot inside <style> is markerless (markers would be invalid
+%% CSS) and verbatim.
+raw_text_style_markerless(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_rt_style). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:html({'style', [], [arizona_template:get(css, Bindings)]}). "
+    ),
+    {HTML0, _Snap} = arizona_render:render(Mod:render(#{css => <<".a > .b { color: red }">>})),
+    HTML = iolist_to_binary(HTML0),
+    ?assertEqual(nomatch, binary:match(HTML, ~"<!--az:")),
+    ?assertNotEqual(nomatch, binary:match(HTML, ~".a > .b { color: red }")),
+    ?assertEqual(nomatch, binary:match(HTML, ~"&gt;")).
+
+%% The real JSON-LD use case: a ?raw value as <script type="application/ld+json">
+%% content renders verbatim and markerless, so crawlers get valid JSON.
+raw_text_json_ld_raw_verbatim(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_rt_jsonld). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:html("
+        "        {'script', [{type, <<\"application/ld+json\">>}], ["
+        "            arizona_template:raw(arizona_template:get(jsonld, Bindings))"
+        "        ]}"
+        "    ). "
+    ),
+    JsonLd = <<"[{\"@type\":\"Product\",\"name\":\"x & y\"}]">>,
+    {HTML0, _Snap} = arizona_render:render(Mod:render(#{jsonld => JsonLd})),
+    HTML = iolist_to_binary(HTML0),
+    ?assertEqual(nomatch, binary:match(HTML, ~"<!--az:")),
+    ?assertNotEqual(nomatch, binary:match(HTML, JsonLd)),
+    ?assertEqual(nomatch, binary:match(HTML, ~"&quot;")).
+
+%% <title> is escapable raw text: comment markers would still be literal text, so
+%% the slot is markerless, but a scalar IS HTML-escaped (the parser decodes
+%% character references there, so `&`/`<` must be escaped to render correctly).
+raw_text_title_escaped_markerless(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_rt_title). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:html({'title', [], [arizona_template:get(t, Bindings)]}). "
+    ),
+    {HTML0, _Snap} = arizona_render:render(Mod:render(#{t => <<"A & B < C">>})),
+    HTML = iolist_to_binary(HTML0),
+    ?assertEqual(nomatch, binary:match(HTML, ~"<!--az:")),
+    ?assertNotEqual(nomatch, binary:match(HTML, ~"&amp;")),
+    ?assertNotEqual(nomatch, binary:match(HTML, ~"&lt;")).
+
+%% <textarea> is also escapable raw text: markerless slot.
+raw_text_textarea_markerless(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_rt_textarea). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:html({'textarea', [], [arizona_template:get(v, Bindings)]}). "
+    ),
+    {HTML0, _Snap} = arizona_render:render(Mod:render(#{v => <<"hello">>})),
+    HTML = iolist_to_binary(HTML0),
+    ?assertEqual(nomatch, binary:match(HTML, ~"<!--az:")),
+    ?assertNotEqual(nomatch, binary:match(HTML, ~"hello")).
+
+%% Render-once: the raw-text slot is non-diffable (Az = undefined). Even when its
+%% binding changes between renders, the diff emits no op -- there is no comment
+%% marker for the client to patch. Covers both the bare diff/2 (child-view path)
+%% and the production deps-aware diff/4, where the slot's binding is in `Changed`.
+raw_text_render_once_no_diff(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_rt_once). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:html({'script', [], [arizona_template:get(boot, Bindings)]}). "
+    ),
+    T1 = Mod:render(#{boot => <<"a">>}),
+    {_HTML, Snap0} = arizona_render:render(T1),
+    T2 = Mod:render(#{boot => <<"b">>}),
+    {Ops, _Snap2} = arizona_diff:diff(T2, Snap0),
+    ?assertEqual([], Ops),
+    %% Production path: build a deps-carrying snapshot (as the live process does on
+    %% mount), then diff/4 with the slot's binding explicitly marked changed.
+    {_Ops0, DepsSnap, _V0} = arizona_diff:diff(T1, Snap0, #{}),
+    {Ops4, _Snap4, _V1} = arizona_diff:diff(T2, DepsSnap, #{}, #{boot => true}),
+    ?assertEqual([], Ops4).
+
+%% A dynamic *attribute* on a raw-text element stays fully diffable -- attribute
+%% values are not raw-text content, so they keep the element az and emit an op
+%% when changed. Only the element's content slot is markerless.
+raw_text_dynamic_attr_still_diffable(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_rt_attr). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:html("
+        "        {'script', [{src, arizona_template:get(src, Bindings)}], []}"
+        "    ). "
+    ),
+    T1 = Mod:render(#{src => <<"/a.js">>}),
+    {HTML0, Snap} = arizona_render:render(T1),
+    HTML = iolist_to_binary(HTML0),
+    ?assertNotEqual(nomatch, binary:match(HTML, ~" az=\"")),
+    T2 = Mod:render(#{src => <<"/b.js">>}),
+    {Ops, _Snap2} = arizona_diff:diff(T2, Snap),
+    ?assertNotEqual([], Ops).
+
+%% Regression guard: a content slot in an ORDINARY element still gets its
+%% comment-marker diff target.
+normal_element_keeps_markers(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_rt_normal). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:html({'span', [], [arizona_template:get(x, Bindings)]}). "
+    ),
+    {HTML0, _Snap} = arizona_render:render(Mod:render(#{x => <<"hi">>})),
+    HTML = iolist_to_binary(HTML0),
+    ?assertNotEqual(nomatch, binary:match(HTML, ~"<!--az:")),
+    ?assertNotEqual(nomatch, binary:match(HTML, ~"<!--/az-->")).
 
 %% A bare element tuple as a `case` branch result is compiled into a nested
 %% template (no ?html wrap needed): the block renders structurally, a value

--- a/test/arizona_parse_transform_SUITE.erl
+++ b/test/arizona_parse_transform_SUITE.erl
@@ -284,7 +284,17 @@
     raw_text_textarea_markerless/1,
     raw_text_render_once_no_diff/1,
     raw_text_dynamic_attr_still_diffable/1,
-    normal_element_keeps_markers/1
+    normal_element_keeps_markers/1,
+    raw_text_sibling_after_restores_markers/1,
+    raw_text_sibling_before_keeps_markers/1,
+    raw_text_between_normal_siblings_markers/1,
+    raw_text_mixed_az_numbering_diffs/1,
+    raw_text_two_content_slots/1,
+    raw_text_static_text_around_slot/1,
+    raw_text_conditional_value_markerless/1,
+    raw_text_attr_diffs_content_render_once/1,
+    raw_text_escapable_adjacent_to_raw/1,
+    native_script_tag_unaffected/1
 ]).
 -export([
     cond_case_bare_element_renders/1,
@@ -487,7 +497,17 @@ groups() ->
             raw_text_textarea_markerless,
             raw_text_render_once_no_diff,
             raw_text_dynamic_attr_still_diffable,
-            normal_element_keeps_markers
+            normal_element_keeps_markers,
+            raw_text_sibling_after_restores_markers,
+            raw_text_sibling_before_keeps_markers,
+            raw_text_between_normal_siblings_markers,
+            raw_text_mixed_az_numbering_diffs,
+            raw_text_two_content_slots,
+            raw_text_static_text_around_slot,
+            raw_text_conditional_value_markerless,
+            raw_text_attr_diffs_content_render_once,
+            raw_text_escapable_adjacent_to_raw,
+            native_script_tag_unaffected
         ]},
         %% Bare element tuples as case/if/begin branch results -- compiled into
         %% nested templates (no ?html wrap), inheriting the enclosing target.
@@ -1773,6 +1793,219 @@ normal_element_keeps_markers(Config) when is_list(Config) ->
     HTML = iolist_to_binary(HTML0),
     ?assertNotEqual(nomatch, binary:match(HTML, ~"<!--az:")),
     ?assertNotEqual(nomatch, binary:match(HTML, ~"<!--/az-->")).
+
+%% Sibling restore: a normal element FOLLOWING a raw-text sibling must still get
+%% its markers -- the raw-text context is scoped to the script's own children and
+%% restored before the span compiles. Guards the `raw_text_kind` save/restore.
+raw_text_sibling_after_restores_markers(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_rt_sib_after). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:html({'div', [], ["
+        "        {'script', [], [arizona_template:get(boot, Bindings)]}, "
+        "        {'span', [], [arizona_template:get(x, Bindings)]}"
+        "    ]}). "
+    ),
+    {HTML0, _Snap} = arizona_render:render(Mod:render(#{boot => <<"BOOT">>, x => <<"XV">>})),
+    HTML = iolist_to_binary(HTML0),
+    %% The script content is markerless; the span (after it) keeps its markers.
+    ?assertNotEqual(nomatch, binary:match(HTML, ~"<script>BOOT</script>")),
+    ?assertEqual(1, length(binary:matches(HTML, ~"<!--az:"))),
+    ?assertNotEqual(nomatch, binary:match(HTML, ~"-->XV<!--/az-->")).
+
+%% Sibling restore (reverse order): a normal element BEFORE a raw-text sibling is
+%% unaffected -- it keeps markers, the trailing script is markerless.
+raw_text_sibling_before_keeps_markers(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_rt_sib_before). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:html({'div', [], ["
+        "        {'span', [], [arizona_template:get(x, Bindings)]}, "
+        "        {'script', [], [arizona_template:get(boot, Bindings)]}"
+        "    ]}). "
+    ),
+    {HTML0, _Snap} = arizona_render:render(Mod:render(#{boot => <<"BOOT">>, x => <<"XV">>})),
+    HTML = iolist_to_binary(HTML0),
+    ?assertEqual(1, length(binary:matches(HTML, ~"<!--az:"))),
+    ?assertNotEqual(nomatch, binary:match(HTML, ~"-->XV<!--/az-->")),
+    ?assertNotEqual(nomatch, binary:match(HTML, ~"<script>BOOT</script>")).
+
+%% A raw-text element BETWEEN two normal elements: both neighbours get markers
+%% (two marked slots), the script in the middle is markerless, and the az indices
+%% stay contiguous (the script consumes none).
+raw_text_between_normal_siblings_markers(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_rt_between). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:html({'div', [], ["
+        "        {'span', [], [arizona_template:get(a, Bindings)]}, "
+        "        {'script', [], [arizona_template:get(boot, Bindings)]}, "
+        "        {'p', [], [arizona_template:get(b, Bindings)]}"
+        "    ]}). "
+    ),
+    {HTML0, _Snap} = arizona_render:render(
+        Mod:render(#{a => <<"AV">>, boot => <<"BOOT">>, b => <<"BV">>})
+    ),
+    HTML = iolist_to_binary(HTML0),
+    %% Exactly two marked slots (span + p), none for the middle script.
+    ?assertEqual(2, length(binary:matches(HTML, ~"<!--az:"))),
+    ?assertNotEqual(nomatch, binary:match(HTML, ~"<script>BOOT</script>")),
+    ?assertNotEqual(nomatch, binary:match(HTML, ~"-->AV<!--/az-->")),
+    ?assertNotEqual(nomatch, binary:match(HTML, ~"-->BV<!--/az-->")).
+
+%% Az-numbering integrity: a raw-text slot and a normal diffable slot coexist. The
+%% normal span still diffs correctly (emits an op when its binding changes) despite
+%% the script consuming no az index; the script never emits an op. Covers diff/2
+%% (child-view) and the production deps-aware diff/4.
+raw_text_mixed_az_numbering_diffs(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_rt_mixed). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:html({'div', [], ["
+        "        {'script', [], [arizona_template:get(boot, Bindings)]}, "
+        "        {'span', [], [arizona_template:get(count, Bindings)]}"
+        "    ]}). "
+    ),
+    T1 = Mod:render(#{boot => <<"a">>, count => <<"1">>}),
+    {_HTML, Snap0} = arizona_render:render(T1),
+    %% diff/2: changing the span binding emits an op; changing only the script does not.
+    {OpsCount, _} = arizona_diff:diff(Mod:render(#{boot => <<"a">>, count => <<"2">>}), Snap0),
+    ?assertNotEqual([], OpsCount),
+    {OpsBoot, _} = arizona_diff:diff(Mod:render(#{boot => <<"b">>, count => <<"1">>}), Snap0),
+    ?assertEqual([], OpsBoot),
+    %% diff/4 (production): same, keyed by the dirty binding set.
+    {_Ops0, DepsSnap, _V0} = arizona_diff:diff(T1, Snap0, #{}),
+    {OpsCount4, _, _} = arizona_diff:diff(
+        Mod:render(#{boot => <<"a">>, count => <<"2">>}), DepsSnap, #{}, #{count => true}
+    ),
+    ?assertNotEqual([], OpsCount4),
+    {OpsBoot4, _, _} = arizona_diff:diff(
+        Mod:render(#{boot => <<"b">>, count => <<"1">>}), DepsSnap, #{}, #{boot => true}
+    ),
+    ?assertEqual([], OpsBoot4).
+
+%% Two dynamic content slots in one raw-text element: both render verbatim, both
+%% markerless (the whole element's content is raw text).
+raw_text_two_content_slots(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_rt_two). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:html({'script', [], ["
+        "        arizona_template:get(a, Bindings), arizona_template:get(b, Bindings)"
+        "    ]}). "
+    ),
+    {HTML0, _Snap} = arizona_render:render(Mod:render(#{a => <<"AA">>, b => <<"BB">>})),
+    HTML = iolist_to_binary(HTML0),
+    ?assertEqual(nomatch, binary:match(HTML, ~"<!--az:")),
+    ?assertEqual(<<"<script>AABB</script>">>, HTML).
+
+%% Static text around a dynamic slot inside a raw-text element survives in order,
+%% markerless -- the computed value is spliced between the literal script bytes.
+raw_text_static_text_around_slot(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_rt_static). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:html({'script', [], ["
+        "        <<\"var x=\">>, arizona_template:get(url, Bindings), <<\"; init();\">>"
+        "    ]}). "
+    ),
+    {HTML0, _Snap} = arizona_render:render(Mod:render(#{url => <<"\"/u\"">>})),
+    HTML = iolist_to_binary(HTML0),
+    ?assertEqual(nomatch, binary:match(HTML, ~"<!--az:")),
+    ?assertEqual(<<"<script>var x=\"/u\"; init();</script>">>, HTML).
+
+%% A control-flow value (case) in a raw-text slot flows through
+%% expand_block_element_tails: the selected branch renders verbatim and markerless,
+%% and diffing is a no-op even when the scrutinee binding changes (render-once).
+raw_text_conditional_value_markerless(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_rt_cond). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:html({'script', [], ["
+        "        case arizona_template:get(env, Bindings) of "
+        "            prod -> <<\"prod()\">>; "
+        "            _ -> <<\"dev()\">> "
+        "        end"
+        "    ]}). "
+    ),
+    T1 = Mod:render(#{env => prod}),
+    {HTML0, Snap0} = arizona_render:render(T1),
+    HTML = iolist_to_binary(HTML0),
+    ?assertEqual(nomatch, binary:match(HTML, ~"<!--az:")),
+    ?assertEqual(<<"<script>prod()</script>">>, HTML),
+    %% Render-once: switching the scrutinee emits no op (no marker to patch).
+    {Ops, _} = arizona_diff:diff(Mod:render(#{env => dev}), Snap0),
+    ?assertEqual([], Ops).
+
+%% A raw-text element with BOTH a dynamic attribute and dynamic content: the
+%% attribute stays diffable (the element keeps its az and the attr emits an op when
+%% changed), but the content is markerless and never emits an op when changed.
+raw_text_attr_diffs_content_render_once(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_rt_attr_content). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:html({'script', "
+        "        [{src, arizona_template:get(src, Bindings)}], "
+        "        [arizona_template:get(body, Bindings)]}). "
+    ),
+    T1 = Mod:render(#{src => <<"/a.js">>, body => <<"A">>}),
+    {HTML0, Snap0} = arizona_render:render(T1),
+    HTML = iolist_to_binary(HTML0),
+    ?assertNotEqual(nomatch, binary:match(HTML, ~" az=\"")),
+    ?assertNotEqual(nomatch, binary:match(HTML, ~"src=\"/a.js\"")),
+    %% The body is markerless content even though the element has an az for the attr.
+    ?assertEqual(nomatch, binary:match(HTML, ~"<!--az:")),
+    %% Changing the attribute emits a patch; changing only the content does not.
+    {OpsSrc, _} = arizona_diff:diff(Mod:render(#{src => <<"/b.js">>, body => <<"A">>}), Snap0),
+    ?assertNotEqual([], OpsSrc),
+    {OpsBody, _} = arizona_diff:diff(Mod:render(#{src => <<"/a.js">>, body => <<"B">>}), Snap0),
+    ?assertEqual([], OpsBody).
+
+%% Escapable (<title>) and raw (<script>) raw-text elements adjacent under <head>,
+%% followed by a normal element: both kinds restore context, so the trailing
+%% element still gets markers while both raw-text slots stay markerless.
+raw_text_escapable_adjacent_to_raw(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_rt_head). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:html({'head', [], ["
+        "        {'title', [], [arizona_template:get(t, Bindings)]}, "
+        "        {'script', [], [arizona_template:get(boot, Bindings)]}, "
+        "        {'meta', [{name, arizona_template:get(m, Bindings)}]}"
+        "    ]}). "
+    ),
+    {HTML0, _Snap} = arizona_render:render(
+        Mod:render(#{t => <<"Hi">>, boot => <<"go()">>, m => <<"v">>})
+    ),
+    HTML = iolist_to_binary(HTML0),
+    %% Neither raw-text slot is marked.
+    ?assertEqual(nomatch, binary:match(HTML, ~"<!--az:")),
+    ?assertNotEqual(nomatch, binary:match(HTML, ~"<title>Hi</title>")),
+    ?assertNotEqual(nomatch, binary:match(HTML, ~"<script>go()</script>")),
+    %% The trailing <meta> still carries its az (its dynamic attr is diffable).
+    ?assertNotEqual(nomatch, binary:match(HTML, ~"<meta az=")).
+
+%% The raw-text rule is HTML-only: a `script`-tagged element on the native backend
+%% is unaffected (raw_text_kind is `none`), so its content keeps a normal addressed
+%% dynamic (a binary az), not the markerless `undefined`.
+native_script_tag_unaffected(Config) when is_list(Config) ->
+    Mod = compile_module(
+        "-module(pt_rt_native). "
+        "-export([render/1]). "
+        "render(Bindings) -> "
+        "    arizona_template:native({'script', [], [arizona_template:get(x, Bindings)]}). "
+    ),
+    T = Mod:render(#{x => <<"NV">>}),
+    ?assertMatch([{Az, _Fun, _Loc}] when is_binary(Az), maps:get(d, T)).
 
 %% A bare element tuple as a `case` branch result is compiled into a nested
 %% template (no ?html wrap needed): the block renders structurally, a value


### PR DESCRIPTION
# Description

Dynamic content slots inside raw-text elements (`script`, `style`, `textarea`, `title`) were wrapped in `<!--az:X-->...<!--/az-->` diff markers, which the browser treats as literal content there, corrupting module scripts (a `SyntaxError`), JSON-LD, CSS, and titles. Such slots now render markerless and render-once: `script`/`style` emit the value verbatim (no HTML-escaping, since the browser decodes no references there), `textarea`/`title` scalars stay HTML-escaped, dynamic attributes remain fully diffable, and the diff engine skips the slot's `undefined` az so it never emits a patch. Raw-text detection is a new `arizona_renderer:raw_text_kind/1` backend callback (HTML-only; native/terminal return `none`).

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona/blob/main/CONTRIBUTING.md)
