### PR TITLE
Resolve `{env, ...}` references in application config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,24 @@ So "persistent live chrome across navigation" (a sidebar with a live badge, a me
 
 A view transition wraps **any** DOM change in `document.startViewTransition` (not tied to navigation). Request one per-trigger (no global switch) with `arizona_js:transition(Cmd[, Opts])` -- wraps the command (or list) whose change should animate, like `on_key/2` -- or the `az_transition` attribute on any triggering element (bare = cross-fade, `{az_transition, ~"slide back"}` = space-separated `types`). A sync effect animates in place; `navigate`/`push_event` animate the resulting server diff. Guarded by feature-detect + `prefers-reduced-motion`; back/forward replays via history state. Real `<a href>` navigations transition through user CSS (`@view-transition { navigation: auto }`). All styling is user-owned CSS. See [.claude/rules/js.md](.claude/rules/js.md).
 
+## Configuration -- env-var references (`arizona_config`)
+
+Any `arizona` app-env value (sys.config) may be declared as an environment-variable reference instead of a literal, resolved at startup by `arizona_config`. Two forms: `{env, "VAR"}` -- **required**, returns `$VAR` as a binary and crashes (`env_not_set`) if unset; `{env, "VAR", Default}` -- **optional**, coerces `$VAR` to the type of `Default` and falls back to `Default` when unset. Env vars are strings, so coercion is driven by the default's type: integer (`list_to_integer`), float, boolean (`"true"`/`"false"`, case-insensitive), binary, atom (`list_to_existing_atom`), or list (a comma-split into trimmed binaries, the `csrf_origins` shape). The required form has no default and yields a binary (suits `secret_key`).
+
+```erlang
+{arizona, [
+    {secret_key, {env, "SECRET_KEY"}},
+    {session_secure, {env, "SESSION_SECURE", false}},
+    {server, #{
+        scheme => {env, "SCHEME", http},
+        transport_opts => [{port, {env, "PORT", 8080}}],
+        routes => [ ... ]
+    }}
+]}.
+```
+
+References resolve **anywhere** in the config surface: the scalar keys (`secret_key`, `check_origin`, `csrf_origins`, `session_max_age`, `session_max_bytes`, `session_secure`, `flash_secure`, `session_store_sweep_ms`, ...) go through `arizona_config:get_env/1,2` at their read sites; the nested `server` map (`port`, `scheme`, `tls` cert paths, `proto_opts` tunables) is resolved once in `arizona_roadrunner_server:start/2`. `resolve/1` recurses into maps, lists, and 2-tuples (proplist pairs) only, so route tuples (`{live, Path, Handler, Opts}` -- all >=3-tuples) pass through untouched: an operator-supplied `{env, _, _}` term sitting inside a route's `bindings`/`state` is never rewritten.
+
 ## CSRF / Origin checking
 
 CSRF defense is an **Origin check**, not a token: `arizona_origin:check(Origin, Host)` rejects a request whose `Origin` header is neither same-origin (its authority equals the `Host`) nor in an allowlist. A missing `Origin` (native `?native` clients, CLI tools, top-level GET navigations) is allowed.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,6 +55,7 @@
 | `src/arizona_mcp_session_registry.erl`    | ETS registry mapping `Mcp-Session-Id` to a session pid; sweeps dead pids on lookup                                                                                                        |
 | `src/arizona_mcp_sup.erl`                 | `simple_one_for_one` supervisor owning the session processes (so a session outlives its connection) and the registry table                                                                |
 | `src/arizona_error_page.erl`              | Dev-mode error page renderer -- pretty-prints compile and runtime errors                                                                                                                  |
+| `src/arizona_config.erl`                  | App-env reader with env-var resolution -- `get_env/1,2` (drop-in for `application:get_env`) + `resolve/1`; expands `{env, "VAR"}` / `{env, "VAR", Default}` refs, coerced by default type |
 | `src/arizona_app.erl`                     | Application callback -- starts `arizona_sup` and, when the `server` env is set, launches the roadrunner listener                                                                          |
 | `src/arizona_watcher.erl`                 | File watcher gen_server -- subscribes to `fs` events, debounces, calls callback, broadcasts via `arizona_pubsub`                                                                          |
 | `src/arizona_reloader.erl`                | Dev-mode hot reloader -- recompiles changed `.erl` files, broadcasts reload messages on the `arizona_reloader` pubsub topic                                                               |
@@ -1264,6 +1265,49 @@ roadrunner's callbacks and Arizona's shared pipeline:
 
 The `arizona_req` behaviour is the boundary between the server and the engine: handlers and the
 shared pipeline only ever see an `arizona_req:request()`, never roadrunner's native request type.
+
+## Configuration -- `arizona_config`
+
+Every `arizona` app-env value may be a literal or an environment-variable reference resolved at
+startup. `arizona_config` centralizes both the read and the resolution:
+
+- `get_env/1` / `get_env/2` -- drop-in replacements for `application:get_env(arizona, Key[,
+  Default])` that pass the stored value through `resolve/1`. The scattered scalar reads
+  (`arizona_origin`, `arizona_session`, `arizona_flash`, `arizona_crypto`, `arizona_sup`,
+  `arizona_req`, `arizona_session_store_ets`) call these.
+- `resolve/1` -- expands references in an arbitrary term. Called once at the top of
+  `arizona_roadrunner_server:start/2` to resolve the whole `server` opts map, so nested `port` /
+  `scheme` / `tls` / `proto_opts` references work and every direct caller (the test server, CT
+  suites) benefits without change.
+
+Reference forms:
+
+- `{env, "VAR"}` -- **required**. Returns `$VAR` as a binary; raises `env_not_set` (with a
+  `format_error/2` message) when unset. For a secret with no sensible default.
+- `{env, "VAR", Default}` -- **optional**. Coerces `$VAR` to the type of `Default`, or returns
+  `Default` when unset.
+
+Coercion is by the default's Erlang type (env vars are always strings): integer, float, boolean
+(`"true"`/`"false"`, case-insensitive), binary, atom (`list_to_existing_atom/1`), or list (a
+comma-split into trimmed binaries -- the `csrf_origins` / `secret_key_previous` shape). The
+required form yields a binary.
+
+`resolve/1` recurses into **maps, lists, and 2-tuples only**:
+
+```erlang
+resolve({env, Var}) -> ...;                 %% required
+resolve({env, Var, Default}) -> ...;        %% optional, coerced
+resolve(Map) when is_map(Map) -> #{K => resolve(V) || K := V <- Map};
+resolve(List) when is_list(List) -> [resolve(E) || E <- List];
+resolve({A, B}) -> {resolve(A), resolve(B)};
+resolve(Other) -> Other.
+```
+
+Limiting tuple recursion to 2-tuples (proplist pairs like `{port, ...}`, `{certfile, ...}`) is
+the safety property: route tuples (`{live, Path, Handler, Opts}` and friends -- all >=3-tuples)
+fall to the `Other` clause and pass through untouched, so an operator-supplied literal `{env, _,
+_}` sitting inside a route's `bindings`/`state` is never rewritten. Resolution is idempotent, so
+resolving in `start/2` is safe even if a caller already resolved.
 
 ## MCP server
 

--- a/rebar.config
+++ b/rebar.config
@@ -164,6 +164,7 @@
         {"test/support/arizona_update_effect_parent.erl", [unnecessary_function_arguments]},
         {"include/arizona_effect.hrl", [single_use_hrl_attrs]},
         {"include/arizona_common.hrl", [unused_macros, single_use_hrl_attrs]},
+        {"src/arizona_config.erl", [unnecessary_function_arguments]},
         {"src/arizona_crypto.erl", [unnecessary_function_arguments]},
         {"src/arizona_session.erl", [unnecessary_function_arguments]},
         {"src/arizona_template.erl", [unnecessary_function_arguments]},

--- a/src/arizona_config.erl
+++ b/src/arizona_config.erl
@@ -1,0 +1,238 @@
+-module(arizona_config).
+-moduledoc """
+Reads the `arizona` application environment, resolving environment-variable
+references declared in config.
+
+Any config value may be written as an env-var reference instead of a literal:
+
+- `{env, "VAR"}` -- **required**: reads `$VAR` and returns it as a binary;
+  raises `env_not_set` if the variable is unset. Suits a secret with no
+  sensible default (e.g. `{secret_key, {env, "SECRET_KEY"}}`).
+- `{env, "VAR", Default}` -- **optional**: reads `$VAR`, coercing it to the
+  type of `Default`; falls back to `Default` when the variable is unset.
+
+References resolve **anywhere** in the config surface, including nested inside
+the `server` map:
+
+```erlang
+{arizona, [
+    {secret_key, {env, "SECRET_KEY"}},
+    {session_secure, {env, "SESSION_SECURE", false}},
+    {server, #{
+        scheme => {env, "SCHEME", http},
+        transport_opts => [{port, {env, "PORT", 8080}}],
+        routes => [ ... ]
+    }}
+]}.
+```
+
+## Type coercion
+
+Environment variables are always strings; the resolver coerces the raw string
+to match the `Default`'s type (the required form has no default, so it yields a
+binary):
+
+| `Default` type | Coercion |
+|----------------|----------|
+| integer        | `list_to_integer/1` |
+| float          | `list_to_float/1` |
+| boolean        | `"true"`/`"false"` (case-insensitive) |
+| binary         | `list_to_binary/1` |
+| atom (non-boolean) | `list_to_existing_atom/1` |
+| list (`[]` or of binaries) | comma-split, each element trimmed `list_to_binary/1` |
+| string (char list, e.g. a cert path) | the raw string, unchanged |
+| (required, no default) | `list_to_binary/1` |
+
+A set-but-**empty** variable (`PORT=`) is treated as **unset**: the optional form
+falls back to `Default`, the required form raises `env_not_set`. A non-empty value
+that fails to coerce (`PORT=abc` for an integer default) raises `env_invalid_value`,
+rendered by `format_error/2` into an actionable boot message.
+
+## Resolution scope
+
+`resolve/1` recurses into maps, lists, and 2-tuples (proplist pairs like
+`{port, ...}` / `{certfile, ...}`), so nested references resolve. It does **not**
+descend into tuples of three or more elements: route tuples (`{live, Path,
+Handler, Opts}` and friends) pass through untouched, so an operator-supplied
+`{env, _, _}` term sitting inside a route's `bindings`/`state` is never rewritten.
+""".
+
+%% --------------------------------------------------------------------
+%% API function exports
+%% --------------------------------------------------------------------
+
+-export([get_env/1]).
+-export([get_env/2]).
+-export([resolve/1]).
+
+%% --------------------------------------------------------------------
+%% Ignore xref warnings
+%% --------------------------------------------------------------------
+
+-ignore_xref([format_error/2]).
+
+%% --------------------------------------------------------------------
+%% Error formatting exports
+%% --------------------------------------------------------------------
+
+-export([format_error/2]).
+
+%% --------------------------------------------------------------------
+%% API Functions
+%% --------------------------------------------------------------------
+
+-doc """
+Like `application:get_env(arizona, Key)`, but resolves any `{env, ...}`
+references in the stored value. Returns `undefined` when `Key` is unset.
+""".
+-spec get_env(Key) -> {ok, Value} | undefined when
+    Key :: atom(),
+    Value :: term().
+get_env(Key) ->
+    case application:get_env(arizona, Key) of
+        {ok, Value} -> {ok, resolve(Value)};
+        undefined -> undefined
+    end.
+
+-doc """
+Like `application:get_env(arizona, Key, Default)`, but resolves any `{env, ...}`
+references in the stored value. `Default` is returned (unresolved) when `Key` is
+unset.
+""".
+-spec get_env(Key, Default) -> Value when
+    Key :: atom(),
+    Default :: term(),
+    Value :: term().
+get_env(Key, Default) ->
+    resolve(application:get_env(arizona, Key, Default)).
+
+-doc """
+Resolves `{env, "VAR"}` / `{env, "VAR", Default}` references in `Term`, recursing
+through maps, lists, and 2-tuples. Non-reference values are returned unchanged.
+""".
+-spec resolve(Term) -> term() when
+    Term :: term().
+resolve({env, Var}) when is_list(Var) ->
+    resolve_env(Var, required);
+resolve({env, Var, Default}) when is_list(Var) ->
+    resolve_env(Var, {default, Default});
+resolve(Map) when is_map(Map) ->
+    #{K => resolve(V) || K := V <- Map};
+resolve(List) when is_list(List) ->
+    [resolve(E) || E <- List];
+resolve({A, B}) ->
+    {resolve(A), resolve(B)};
+resolve(Other) ->
+    Other.
+
+%% --------------------------------------------------------------------
+%% Error formatting
+%% --------------------------------------------------------------------
+
+-doc """
+Formats `arizona_config` runtime errors into a human-readable message. Picked up
+by `erl_error:format_exception/3` via the `error_info` annotation at the raise site.
+""".
+-spec format_error(Reason, Stacktrace) -> ErrorInfo when
+    Reason :: term(),
+    Stacktrace :: [tuple()],
+    ErrorInfo :: #{general := iolist()}.
+format_error({env_not_set, Var}, _ST) ->
+    #{
+        general =>
+            io_lib:format(
+                "required environment variable ~ts is not set; either export it or "
+                "declare a default with `{env, ~tp, Default}`",
+                [Var, Var]
+            )
+    };
+format_error({env_invalid_value, Var, Value, Type}, _ST) ->
+    #{
+        general =>
+            io_lib:format(
+                "environment variable ~ts=~tp is not a valid ~ts",
+                [Var, Value, type_label(Type)]
+            )
+    }.
+
+%% --------------------------------------------------------------------
+%% Internal functions
+%% --------------------------------------------------------------------
+
+%% `os:getenv` returns `false` (unset) or a string. An empty string is treated as
+%% unset too, so a bare `PORT=` in an env file falls back to the default and a
+%% required var with no value raises `env_not_set` (rather than a silent empty
+%% binary that only fails later).
+resolve_env(Var, Spec) ->
+    case os:getenv(Var) of
+        false -> unset(Var, Spec);
+        "" -> unset(Var, Spec);
+        Value -> coerce(Var, Value, Spec)
+    end.
+
+unset(Var, required) ->
+    erlang:error({env_not_set, Var}, [Var], [{error_info, #{module => ?MODULE}}]);
+unset(_Var, {default, Default}) ->
+    Default.
+
+%% The required form carries no default, so the raw string is the value (binary).
+coerce(_Var, Value, required) ->
+    list_to_binary(Value);
+%% Coerce to the type of the default. A malformed value (e.g. `PORT=abc` for an
+%% integer default) raises a `format_error`-rendered `env_invalid_value` at boot
+%% rather than a cryptic `badarg` from deep in the conversion.
+coerce(Var, Value, {default, Default}) ->
+    Type = default_type(Default),
+    try
+        convert(Type, Value)
+    catch
+        error:_ -> invalid(Var, Value, Type)
+    end.
+
+%% The coercion target inferred from the default's type. `is_boolean` is checked
+%% before `is_atom` because booleans are atoms. A char-list (string) default (e.g. a
+%% tls cert path) keeps the raw string; an empty list or a list of binaries (e.g.
+%% `csrf_origins`, `secret_key_previous`) comma-splits into trimmed binaries. `[]` is
+%% ambiguous (an empty list and an empty string are the same term) and resolves to
+%% the list case, the documented empty default.
+default_type(Default) when is_integer(Default) -> integer;
+default_type(Default) when is_float(Default) -> float;
+default_type(Default) when is_boolean(Default) -> boolean;
+default_type(Default) when is_binary(Default) -> binary;
+default_type(Default) when is_atom(Default) -> atom;
+default_type([]) -> binary_list;
+default_type([H | _]) when is_binary(H) -> binary_list;
+default_type([H | _]) when is_integer(H) -> string.
+
+%% Only integer/float/boolean/atom can fail to convert (and are re-raised as
+%% `env_invalid_value`); binary/binary_list/string always succeed.
+convert(integer, Value) -> list_to_integer(Value);
+convert(float, Value) -> list_to_float(Value);
+convert(boolean, Value) -> to_boolean(Value);
+convert(binary, Value) -> list_to_binary(Value);
+convert(atom, Value) -> list_to_existing_atom(Value);
+convert(binary_list, Value) -> comma_split(Value);
+convert(string, Value) -> Value.
+
+invalid(Var, Value, Type) ->
+    erlang:error(
+        {env_invalid_value, Var, Value, Type}, [Var], [{error_info, #{module => ?MODULE}}]
+    ).
+
+type_label(integer) -> "integer";
+type_label(float) -> "float";
+type_label(boolean) -> "boolean (expected \"true\" or \"false\")";
+type_label(atom) -> "atom (it must already be a known atom)";
+type_label(binary) -> "binary string";
+type_label(binary_list) -> "comma-separated list";
+type_label(string) -> "string".
+
+comma_split(Value) ->
+    Parts = [string:trim(S) || S <- string:split(Value, ",", all)],
+    [list_to_binary(P) || P <- Parts, P =/= ""].
+
+to_boolean(Value) ->
+    case string:lowercase(Value) of
+        "true" -> true;
+        "false" -> false
+    end.

--- a/src/arizona_crypto.erl
+++ b/src/arizona_crypto.erl
@@ -150,7 +150,7 @@ env, erroring if it is unset or empty.
 """.
 -spec secret() -> binary().
 secret() ->
-    case application:get_env(arizona, secret_key) of
+    case arizona_config:get_env(secret_key) of
         {ok, Secret} when is_binary(Secret), Secret =/= <<>> ->
             Secret;
         _ ->
@@ -227,7 +227,7 @@ aead_key(Key) ->
 %% new `secret_key`: existing values keep verifying under the old key for the grace
 %% window -- no forced re-issue, no wire-format change.
 candidate_keys() ->
-    [secret() | application:get_env(arizona, secret_key_previous, [])].
+    [secret() | arizona_config:get_env(secret_key_previous, [])].
 
 %% The clock is injected so the expiry boundary is deterministically testable.
 do_verify(Signed, Now) ->

--- a/src/arizona_flash.erl
+++ b/src/arizona_flash.erl
@@ -146,5 +146,5 @@ cookie_opts(MaxAge) ->
         same_site => lax,
         path => ~"/",
         max_age => MaxAge,
-        secure => application:get_env(arizona, flash_secure, false)
+        secure => arizona_config:get_env(flash_secure, false)
     }.

--- a/src/arizona_origin.erl
+++ b/src/arizona_origin.erl
@@ -36,7 +36,7 @@ origin is trusted (same-origin, allowlisted, missing, or checking disabled) and
     Origin :: binary() | undefined,
     Host :: binary() | undefined.
 check(Origin, Host) ->
-    case application:get_env(arizona, check_origin, true) of
+    case arizona_config:get_env(check_origin, true) of
         false ->
             warn_disabled(),
             ok;
@@ -83,4 +83,4 @@ same_origin(Origin, Host) ->
     end.
 
 allowlisted(Origin) ->
-    lists:member(Origin, application:get_env(arizona, csrf_origins, [])).
+    lists:member(Origin, arizona_config:get_env(csrf_origins, [])).

--- a/src/arizona_req.erl
+++ b/src/arizona_req.erl
@@ -722,7 +722,7 @@ read_session_value(Value, Req) ->
 %% The configured server-side session store module, or `undefined` for the default
 %% cookie store (the session map encrypted into the cookie).
 session_store() ->
-    application:get_env(arizona, session_store, undefined).
+    arizona_config:get_env(session_store, undefined).
 
 %% Returns the pending session (session_out), seeded from the incoming session on
 %% first write, plus the (possibly cookie-read) request. Idempotent: once written,

--- a/src/arizona_roadrunner_server.erl
+++ b/src/arizona_roadrunner_server.erl
@@ -31,6 +31,10 @@ routes take effect without restarting the listener.
   Set to `false` if you have an upstream proxy doing compression
   already.
 
+Any option value (`port`, `scheme`, `tls` cert paths, `proto_opts` tunables)
+may be an env-var reference resolved at startup -- `{env, "PORT", 8080}` or the
+required `{env, "PORT"}`. See `m:arizona_config`.
+
 ## Enabling HTTP/2
 
 Roadrunner ships with HTTP/2 support (RFC 9113, h2spec-compliant).
@@ -84,7 +88,12 @@ routes from `Opts`.
 -spec start(Name, Opts) -> {ok, pid()} | {error, term()} when
     Name :: atom(),
     Opts :: map().
-start(Name, #{routes := Routes} = Opts) ->
+start(Name, #{routes := _} = Opts0) ->
+    %% Resolve `{env, ...}` references (port, tls paths, proto_opts, ...) before
+    %% reading any option. `resolve/1` leaves the route tuples untouched, so
+    %% `Routes` is unchanged; it is idempotent, so a caller that already resolved
+    %% loses nothing.
+    #{routes := Routes} = Opts = arizona_config:resolve(Opts0),
     BuildOpts = #{compress => maps:get(compress, Opts, true)},
     Port = port_from_opts(Opts),
     UserProtoOpts = maps:get(proto_opts, Opts, #{}),

--- a/src/arizona_session.erl
+++ b/src/arizona_session.erl
@@ -183,7 +183,7 @@ this value, so browser and server expiry agree.
 """.
 -spec max_age() -> non_neg_integer().
 max_age() ->
-    application:get_env(arizona, session_max_age, ?DEFAULT_MAX_AGE).
+    arizona_config:get_env(session_max_age, ?DEFAULT_MAX_AGE).
 
 %% --- Store mode: the cookie carries a signed opaque id, the data lives in a store ---
 
@@ -237,7 +237,7 @@ format_error({session_too_large, Size, Limit}, _ST) ->
 
 %% Maximum encoded-cookie size in bytes (default 4096, the ~4KB browser cap).
 max_bytes() ->
-    application:get_env(arizona, session_max_bytes, ?DEFAULT_MAX_BYTES).
+    arizona_config:get_env(session_max_bytes, ?DEFAULT_MAX_BYTES).
 
 cookie_opts(MaxAge) ->
     #{
@@ -245,5 +245,5 @@ cookie_opts(MaxAge) ->
         same_site => lax,
         path => ~"/",
         max_age => MaxAge,
-        secure => application:get_env(arizona, session_secure, false)
+        secure => arizona_config:get_env(session_secure, false)
     }.

--- a/src/arizona_session_store_ets.erl
+++ b/src/arizona_session_store_ets.erl
@@ -147,4 +147,4 @@ schedule_sweep(State) ->
     State.
 
 sweep_ms() ->
-    application:get_env(arizona, session_store_sweep_ms, ?DEFAULT_SWEEP_MS).
+    arizona_config:get_env(session_store_sweep_ms, ?DEFAULT_SWEEP_MS).

--- a/src/arizona_sup.erl
+++ b/src/arizona_sup.erl
@@ -66,7 +66,7 @@ start_link() ->
     SupFlags :: supervisor:sup_flags(),
     ChildSpec :: supervisor:child_spec().
 init(#{}) ->
-    Reloader = application:get_env(arizona, reloader, #{}),
+    Reloader = arizona_config:get_env(reloader, #{}),
     Children =
         [pubsub_spec(), mcp_sup_spec()] ++ store_specs() ++ watcher_specs(Reloader),
     {ok, {#{strategy => one_for_one}, Children}}.
@@ -96,7 +96,7 @@ mcp_sup_spec() ->
 %% it if the backend declares a `child_spec/0` (the ETS store owns its table; a backend
 %% that runs its own process can omit the callback).
 store_specs() ->
-    case application:get_env(arizona, session_store, undefined) of
+    case arizona_config:get_env(session_store, undefined) of
         undefined ->
             [];
         Mod ->

--- a/test/arizona_config_SUITE.erl
+++ b/test/arizona_config_SUITE.erl
@@ -1,0 +1,280 @@
+-module(arizona_config_SUITE).
+-include_lib("stdlib/include/assert.hrl").
+
+-export([all/0]).
+-export([groups/0]).
+
+-export([resolve_integer/1]).
+-export([resolve_float/1]).
+-export([resolve_boolean/1]).
+-export([resolve_binary/1]).
+-export([resolve_atom/1]).
+-export([resolve_list_comma_split/1]).
+-export([resolve_string_default_kept/1]).
+-export([resolve_required_returns_binary/1]).
+-export([resolve_required_missing_crashes/1]).
+-export([resolve_default_when_unset/1]).
+-export([resolve_empty_uses_default/1]).
+-export([resolve_empty_required_crashes/1]).
+-export([resolve_invalid_integer_crashes/1]).
+-export([resolve_invalid_boolean_crashes/1]).
+-export([resolve_invalid_atom_crashes/1]).
+-export([invalid_value_error_is_formatted/1]).
+-export([resolve_scalar_passthrough/1]).
+-export([resolve_nested_server_map/1]).
+-export([resolve_tls_paths/1]).
+-export([resolve_leaves_routes_untouched/1]).
+-export([get_env_2_resolves/1]).
+-export([get_env_1_resolves/1]).
+-export([get_env_1_undefined/1]).
+
+all() ->
+    [{group, config}].
+
+groups() ->
+    %% Sequential: os env vars are VM-global, so cases must not run concurrently.
+    [
+        {config, [], [
+            resolve_integer,
+            resolve_float,
+            resolve_boolean,
+            resolve_binary,
+            resolve_atom,
+            resolve_list_comma_split,
+            resolve_string_default_kept,
+            resolve_required_returns_binary,
+            resolve_required_missing_crashes,
+            resolve_default_when_unset,
+            resolve_empty_uses_default,
+            resolve_empty_required_crashes,
+            resolve_invalid_integer_crashes,
+            resolve_invalid_boolean_crashes,
+            resolve_invalid_atom_crashes,
+            invalid_value_error_is_formatted,
+            resolve_scalar_passthrough,
+            resolve_nested_server_map,
+            resolve_tls_paths,
+            resolve_leaves_routes_untouched,
+            get_env_2_resolves,
+            get_env_1_resolves,
+            get_env_1_undefined
+        ]}
+    ].
+
+%% --------------------------------------------------------------------
+%% resolve/1 -- coercion by default type
+%% --------------------------------------------------------------------
+
+resolve_integer(Config) when is_list(Config) ->
+    with_env("AZ_CFG_INT", "9001", fun() ->
+        ?assertEqual(9001, arizona_config:resolve({env, "AZ_CFG_INT", 8080}))
+    end).
+
+resolve_float(Config) when is_list(Config) ->
+    with_env("AZ_CFG_FLOAT", "2.5", fun() ->
+        ?assertEqual(2.5, arizona_config:resolve({env, "AZ_CFG_FLOAT", 1.0}))
+    end).
+
+resolve_boolean(Config) when is_list(Config) ->
+    %% Case-insensitive, and the default's own boolean value is irrelevant to parsing.
+    with_env("AZ_CFG_BOOL", "TRUE", fun() ->
+        ?assertEqual(true, arizona_config:resolve({env, "AZ_CFG_BOOL", false}))
+    end),
+    with_env("AZ_CFG_BOOL", "false", fun() ->
+        ?assertEqual(false, arizona_config:resolve({env, "AZ_CFG_BOOL", true}))
+    end).
+
+resolve_binary(Config) when is_list(Config) ->
+    with_env("AZ_CFG_BIN", "hello", fun() ->
+        ?assertEqual(~"hello", arizona_config:resolve({env, "AZ_CFG_BIN", ~"default"}))
+    end).
+
+resolve_atom(Config) when is_list(Config) ->
+    %% `http`/`https` are interned by referencing them here, so list_to_existing_atom works.
+    _ = https,
+    with_env("AZ_CFG_ATOM", "https", fun() ->
+        ?assertEqual(https, arizona_config:resolve({env, "AZ_CFG_ATOM", http}))
+    end).
+
+resolve_list_comma_split(Config) when is_list(Config) ->
+    %% An empty-list default coerces a comma string into trimmed binaries (csrf_origins shape).
+    with_env("AZ_CFG_LIST", "https://a.example, https://b.example ,", fun() ->
+        ?assertEqual(
+            [~"https://a.example", ~"https://b.example"],
+            arizona_config:resolve({env, "AZ_CFG_LIST", []})
+        )
+    end).
+
+resolve_string_default_kept(Config) when is_list(Config) ->
+    %% A char-list (string) default -- e.g. a tls cert path -- keeps the raw string
+    %% rather than comma-splitting into binaries.
+    with_env("AZ_CFG_PATH", "/etc/ssl/app.pem", fun() ->
+        ?assertEqual(
+            "/etc/ssl/app.pem", arizona_config:resolve({env, "AZ_CFG_PATH", "priv/cert.pem"})
+        )
+    end).
+
+resolve_required_returns_binary(Config) when is_list(Config) ->
+    with_env("AZ_CFG_REQ", "s3cr3t", fun() ->
+        ?assertEqual(~"s3cr3t", arizona_config:resolve({env, "AZ_CFG_REQ"}))
+    end).
+
+resolve_required_missing_crashes(Config) when is_list(Config) ->
+    without_env("AZ_CFG_MISSING", fun() ->
+        ?assertError(
+            {env_not_set, "AZ_CFG_MISSING"},
+            arizona_config:resolve({env, "AZ_CFG_MISSING"})
+        )
+    end).
+
+resolve_default_when_unset(Config) when is_list(Config) ->
+    without_env("AZ_CFG_UNSET", fun() ->
+        ?assertEqual(8080, arizona_config:resolve({env, "AZ_CFG_UNSET", 8080}))
+    end).
+
+%% --------------------------------------------------------------------
+%% resolve/1 -- empty and invalid values
+%% --------------------------------------------------------------------
+
+resolve_empty_uses_default(Config) when is_list(Config) ->
+    %% A set-but-empty var (`PORT=`) is treated as unset: the optional form falls
+    %% back to its default rather than trying (and failing) to coerce "".
+    with_env("AZ_CFG_EMPTY", "", fun() ->
+        ?assertEqual(8080, arizona_config:resolve({env, "AZ_CFG_EMPTY", 8080})),
+        ?assertEqual([], arizona_config:resolve({env, "AZ_CFG_EMPTY", []}))
+    end).
+
+resolve_empty_required_crashes(Config) when is_list(Config) ->
+    %% Empty is unset, so the required form raises `env_not_set` rather than <<>>.
+    with_env("AZ_CFG_EMPTY_REQ", "", fun() ->
+        ?assertError(
+            {env_not_set, "AZ_CFG_EMPTY_REQ"},
+            arizona_config:resolve({env, "AZ_CFG_EMPTY_REQ"})
+        )
+    end).
+
+resolve_invalid_integer_crashes(Config) when is_list(Config) ->
+    with_env("AZ_CFG_BADINT", "abc", fun() ->
+        ?assertError(
+            {env_invalid_value, "AZ_CFG_BADINT", "abc", integer},
+            arizona_config:resolve({env, "AZ_CFG_BADINT", 8080})
+        )
+    end).
+
+resolve_invalid_boolean_crashes(Config) when is_list(Config) ->
+    with_env("AZ_CFG_BADBOOL", "yes", fun() ->
+        ?assertError(
+            {env_invalid_value, "AZ_CFG_BADBOOL", "yes", boolean},
+            arizona_config:resolve({env, "AZ_CFG_BADBOOL", false})
+        )
+    end).
+
+resolve_invalid_atom_crashes(Config) when is_list(Config) ->
+    %% An atom default coerces via list_to_existing_atom; a value that is not an
+    %% already-known atom raises env_invalid_value rather than a raw badarg. The env
+    %% string is never written as an atom literal here, so it stays non-existing.
+    with_env("AZ_CFG_BADATOM", "az_cfg_definitely_not_an_atom_42", fun() ->
+        ?assertError(
+            {env_invalid_value, "AZ_CFG_BADATOM", "az_cfg_definitely_not_an_atom_42", atom},
+            arizona_config:resolve({env, "AZ_CFG_BADATOM", http})
+        )
+    end).
+
+invalid_value_error_is_formatted(Config) when is_list(Config) ->
+    #{general := General} = arizona_config:format_error(
+        {env_invalid_value, "PORT", "abc", integer}, []
+    ),
+    Msg = unicode:characters_to_binary(General),
+    ?assertMatch({_, _}, binary:match(Msg, ~"PORT")),
+    ?assertMatch({_, _}, binary:match(Msg, ~"not a valid integer")).
+
+%% --------------------------------------------------------------------
+%% resolve/1 -- structure recursion
+%% --------------------------------------------------------------------
+
+resolve_scalar_passthrough(Config) when is_list(Config) ->
+    ?assertEqual(true, arizona_config:resolve(true)),
+    ?assertEqual(42, arizona_config:resolve(42)),
+    ?assertEqual(~"x", arizona_config:resolve(~"x")),
+    ?assertEqual([1, 2, 3], arizona_config:resolve([1, 2, 3])),
+    ?assertEqual(#{a => 1}, arizona_config:resolve(#{a => 1})).
+
+resolve_nested_server_map(Config) when is_list(Config) ->
+    with_env("AZ_CFG_PORT", "9090", fun() ->
+        Server = #{
+            scheme => http,
+            transport_opts => [{port, {env, "AZ_CFG_PORT", 8080}}],
+            proto_opts => #{max_clients => {env, "AZ_CFG_MAXC", 200}}
+        },
+        Resolved = arizona_config:resolve(Server),
+        ?assertEqual([{port, 9090}], maps:get(transport_opts, Resolved)),
+        %% Unset nested env falls back to its default inside a map.
+        ?assertEqual(#{max_clients => 200}, maps:get(proto_opts, Resolved))
+    end).
+
+resolve_tls_paths(Config) when is_list(Config) ->
+    with_env("AZ_CFG_CERT", "/etc/ssl/app.pem", fun() ->
+        Tls = [{certfile, {env, "AZ_CFG_CERT", ~"priv/cert.pem"}}, {keyfile, ~"priv/key.pem"}],
+        ?assertEqual(
+            [{certfile, ~"/etc/ssl/app.pem"}, {keyfile, ~"priv/key.pem"}],
+            arizona_config:resolve(Tls)
+        )
+    end).
+
+resolve_leaves_routes_untouched(Config) when is_list(Config) ->
+    %% A literal {env, _, _} sitting inside a route's opts (a >=3-tuple) must NOT be
+    %% rewritten -- resolve only descends into maps, lists, and 2-tuples.
+    Routes = [
+        {live, ~"/", my_page, #{state => {env, "SHOULD_NOT_RESOLVE", 1}}},
+        {ws, ~"/ws", #{}}
+    ],
+    Server = #{transport_opts => [{port, {env, "AZ_CFG_RT_PORT", 4040}}], routes => Routes},
+    Resolved = arizona_config:resolve(Server),
+    ?assertEqual(Routes, maps:get(routes, Resolved)),
+    ?assertEqual([{port, 4040}], maps:get(transport_opts, Resolved)).
+
+%% --------------------------------------------------------------------
+%% get_env/1,2 -- application env + resolution
+%% --------------------------------------------------------------------
+
+get_env_2_resolves(Config) when is_list(Config) ->
+    with_env("AZ_CFG_GE2", "7777", fun() ->
+        with_app_env(some_test_key, {env, "AZ_CFG_GE2", 8080}, fun() ->
+            ?assertEqual(7777, arizona_config:get_env(some_test_key, 0))
+        end)
+    end).
+
+get_env_1_resolves(Config) when is_list(Config) ->
+    with_env("AZ_CFG_GE1", "abc", fun() ->
+        with_app_env(some_test_key, {env, "AZ_CFG_GE1"}, fun() ->
+            ?assertEqual({ok, ~"abc"}, arizona_config:get_env(some_test_key))
+        end)
+    end).
+
+get_env_1_undefined(Config) when is_list(Config) ->
+    application:unset_env(arizona, nonexistent_test_key),
+    ?assertEqual(undefined, arizona_config:get_env(nonexistent_test_key)).
+
+%% --------------------------------------------------------------------
+%% Helpers
+%% --------------------------------------------------------------------
+
+with_env(Var, Value, Fun) ->
+    true = os:putenv(Var, Value),
+    try
+        Fun()
+    after
+        os:unsetenv(Var)
+    end.
+
+without_env(Var, Fun) ->
+    os:unsetenv(Var),
+    Fun().
+
+with_app_env(Key, Value, Fun) ->
+    ok = application:set_env(arizona, Key, Value),
+    try
+        Fun()
+    after
+        application:unset_env(arizona, Key)
+    end.

--- a/test/support/arizona_test_server.erl
+++ b/test/support/arizona_test_server.erl
@@ -1,5 +1,5 @@
 -module(arizona_test_server).
--export([start/0, stop/0, port/0, routes/0]).
+-export([start/0, stop/0, routes/0]).
 
 start() ->
     %% The session fixtures (arizona_session_view/controller) encrypt the az_session
@@ -7,7 +7,7 @@ start() ->
     %% set plain cookies and don't read it.
     ok = application:set_env(arizona, secret_key, <<"e2e-test-secret-key-0123456789ab">>),
     {ok, _} = arizona_roadrunner_server:start(http, #{
-        transport_opts => [{port, port()}],
+        transport_opts => [{port, {env, "PORT", 4040}}],
         routes => routes()
     }),
     %% Set the server app env *after* the listener is up (arizona_app has already
@@ -161,9 +161,3 @@ routes() ->
 
 stop() ->
     arizona_roadrunner_server:stop(http).
-
-port() ->
-    case os:getenv("PORT") of
-        false -> 4040;
-        Val -> list_to_integer(Val)
-    end.


### PR DESCRIPTION
Any `arizona` application-env value can now be declared as an environment-variable reference: `{env, "VAR"}` (required; returns the raw value as a binary and errors if unset) or `{env, "VAR", Default}` (optional; coerced to the type of `Default`, else the default). References resolve anywhere in the config surface, including nested in the `server` map, so `transport_opts => [{port, {env, "PORT", 8080}}]` works, while route tuples are left untouched.

A new `arizona_config` module centralizes the read (`get_env/1,2`, drop-in for `application:get_env`) and resolution (`resolve/1`); the scalar security/session keys and the server map route through it. An empty variable is treated as unset (falls back to the default), and a value that fails to coerce raises a clear boot error via `format_error/2`.
